### PR TITLE
Add name property to modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ var Controller = function (Model, services) {
         }
       });
       controller.modules[moduleName] = {
+        name: moduleName,
         signals: signals[moduleName],
         services: module.services
       };


### PR DESCRIPTION
Seems like it might be useful to add `name` to each `cerebral.modules` incase they are passed around individually.