### PR TITLE
Feature(modules): make signals optional and support sync signals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,12 @@ var Controller = function (Model, services) {
           controller.signal(signalName, module.signals[key]);
         }
       });
+      Object.keys(module.syncSignals || {}).forEach(function (key) {
+        if (Array.isArray(module.syncSignals[key])) {
+          var signalName = moduleName + '.' + key;
+          controller.signalSync(signalName, module.syncSignals[key]);
+        }
+      });
       controller.modules[moduleName] = {
         signals: signals[moduleName],
         services: module.services

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ var Controller = function (Model, services) {
   controller.extends = function (modules) {
     Object.keys(modules).forEach(function (moduleName) {
       var module = modules[moduleName];
-      Object.keys(module.signals).forEach(function (key) {
+      Object.keys(module.signals || {}).forEach(function (key) {
         if (Array.isArray(module.signals[key])) {
           var signalName = moduleName + '.' + key;
           controller.signal(signalName, module.signals[key]);


### PR DESCRIPTION
1. Adds support for modules without signals.
2. Adds support for registering sync signals. A module should be able to require that a signal is sync (same justification behind `controller.signalSync()`.

Modules now look like:

```js
export default {
   init({controller, name, signals}) {
     return ...
   },
  signals: {},
  syncSignals: {},
  services: {}
}
```

Not sure I'm sold on `syncSignals`. Maybe `signalsSync` to stay consistent with `signalSync()`?