### PR TITLE
Register signals to a global hook for the cerebral debugger

### DIFF
--- a/src/CreateRegisterModules.js
+++ b/src/CreateRegisterModules.js
@@ -4,13 +4,25 @@ module.exports = function (controller, model, allModules) {
 
   var initialState = {};
 
+  var registerDevToolsSignals = function(moduleName, signals) {
+    if (window.__CEREBRAL_DEVTOOLS_GLOBAL_HOOK__) {
+      for (var signal in signals) {
+        window.__CEREBRAL_DEVTOOLS_GLOBAL_HOOK__.signals[
+          moduleName + '.' + signal
+        ] = signals[signal];
+      }
+    }
+  };
+
   var registerSignals = function (moduleName, signals) {
     var scopedSignals = Object.keys(signals).reduce(function (scopedSignals, key) {
       scopedSignals[moduleName + '.' + key] = signals[key];
       return scopedSignals;
     }, {});
 
-    return controller.signals(scopedSignals, {
+    registerDevToolsSignals(moduleName, signals);
+
+    controller.signals(scopedSignals, {
       modulePath: moduleName.split('.')
     });
   };
@@ -20,6 +32,9 @@ module.exports = function (controller, model, allModules) {
       scopedSignals[moduleName + '.' + key] = signals[key];
       return scopedSignals;
     }, {});
+
+    registerDevToolsSignals(moduleName, signals);
+
     return controller.signalsSync(scopedSignals, {
       modulePath: moduleName.split('.')
     });


### PR DESCRIPTION
This is reliant on this pull request: https://github.com/cerebral/cerebral-chrome-extension/pull/15

This will register all signals to a global hook (if found). This allows the debugger to inspect actions (show them in the source tab)