### PR TITLE
fix(errors): don't throw exceptions when listeners attached to signalError

### DIFF
--- a/src/CreateSignalFactory.js
+++ b/src/CreateSignalFactory.js
@@ -173,9 +173,12 @@ module.exports = function (controller, model, services, compute, modules) {
                       message: e.message,
                       stack: actionFunc.toString()
                     }
-                    controller.emit('signalError', {action: action, signal: signal})
+                    var hadListeners = controller.emit('signalError', {action: action, signal: signal})
                     controller.emit('change', {signal: signal})
-                    throw e
+
+                    if (!hadListeners) {
+                      throw e
+                    }
                   }
                 } else {
                   actionFunc(actionArg)
@@ -204,8 +207,10 @@ module.exports = function (controller, model, services, compute, modules) {
                 })
                 .catch(function (error) {
                   // We just throw any unhandled errors
-                  controller.emit('error', error)
-                  throw error
+                  var hadListeners = controller.emit('error', error)
+                  if (!hadListeners) {
+                    throw error
+                  }
                 })
             }
           } else {
@@ -257,9 +262,12 @@ module.exports = function (controller, model, services, compute, modules) {
                     message: e.message,
                     stack: e.stack
                   }
-                  controller.emit('signalError', {action: action, signal: signal})
+                  var hadListeners = controller.emit('signalError', {action: action, signal: signal})
                   controller.emit('change', {signal: signal})
-                  throw e
+
+                  if (!hadListeners) {
+                    throw e
+                  }
                 }
               } else {
                 actionFunc(actionArg)

--- a/tests/signals.js
+++ b/tests/signals.js
@@ -902,13 +902,50 @@ suite['should attach error when failed action execution'] = function (test) {
     'test': signal
   })
 
-  test.throws(function () {
+  ctrl.on('signalError', function (args) {
+    test.equal(args.action.error.name, 'TypeError')
+    test.done()
+  })
+  ctrl.getSignals().test.sync()
+}
+
+suite['should not throw error when listener attached to signalError'] = function (test) {
+  var ctrl = Controller(Model())
+  var testObject = {}
+  var signal = [
+    function () { testObject.unknown.property }
+  ]
+
+  ctrl.signals({
+    'test': signal
+  })
+
+  test.doesNotThrow(function () {
     ctrl.on('signalError', function (args) {
       test.equal(args.action.error.name, 'TypeError')
       test.done()
     })
     ctrl.getSignals().test.sync()
   })
+}
+
+suite['should throw error when no listener attached to signalError'] = function (test) {
+  var ctrl = Controller(Model())
+  var testObject = {}
+  var signal = [
+    function () { testObject.unknown.property }
+  ]
+
+  ctrl.signals({
+    'test': signal
+  })
+
+  try {
+    ctrl.getSignals().test.sync()
+  } catch (e) {
+    test.equal(e.name, 'TypeError')
+    test.done()
+  }
 }
 
 suite['should wrap and track use of services'] = function (test) {


### PR DESCRIPTION
Straight forward.

See docs for the boolean: https://nodejs.org/api/events.html#events_emitter_emit_event_arg1_arg2