### PR TITLE
Add coverage reports on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+
+coverage:
+  round: down
+  status:
+    project:
+      default:
+        enabled: yes
+        target: 0%
+    patch:
+      default:
+        enabled: yes
+        target: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,4 @@ coverage:
       default:
         enabled: yes
         target: 0%
+  comment: off


### PR DESCRIPTION
Right now we just say "passed" at any percentage of coverage, but we can change this to "auto" to make sure coverage increases or stays the same to accept the commit