### PR TITLE
fix(computed): make callback part of cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,58 +10,7 @@ A state controller with its own debugger
 [![js-standard-style][standard-image]][standard-url]
 [![Discord][discord-image]][discord-url]
 
-
 <img src="images/logo.png" width="300" align="center">
-
-## Testing new version
-
-Add
-
-- `https://github.com/cerebral/cerebral.git#state-tree`
-- `https://github.com/cerebral/cerebral-view-react.git#state-tree`
-
-in `package.json` and install deps.
-
-Everything should actually just work with a couple of minor tweaks:
-
-### Instantiate
-```js
-import { Controller } from 'cerebral';
-import Model from 'cerebral-model-immutable';
-
-const controller = Controller(Model({}));
-```
-
-### Computed
-```js
-// Old
-function (get) {
-  var someState = get('some.state')
-}
-
-// New
-import { Computed } from 'cerebral';
-
-Computed({
-  someState: 'some.state'
-}, state => {
-  state.someState
-})
-```
-
-Computed are more explicit now.
-
-### connect
-
-```js
-import { connect } from 'cerebral-view-react';
-
-connect({
-  foo: 'some.state'
-}, Component)
-```
-
-Okay, happy testing! :)
 
 ## Please head over to our website
 [http://www.cerebraljs.com/](http://www.cerebraljs.com/). You will find all the information you need there.

--- a/src/Computed.js
+++ b/src/Computed.js
@@ -13,7 +13,7 @@ function getByPath (path, state) {
 function Computed (paths, cb) {
   return function (props) {
     var deps = typeof paths === 'function' ? paths(props) : paths
-    var cacheKey = JSON.stringify(deps) + (props ? JSON.stringify(props) : '')
+    var cacheKey = JSON.stringify(deps) + (props ? JSON.stringify(props) : '') + cb.toString().replace(/\s/g, '')
     Object.keys(deps).forEach(function (key) {
       if (!Computed.registry[deps[key]]) {
         Computed.registry[deps[key]] = [cacheKey]

--- a/tests/computed.js
+++ b/tests/computed.js
@@ -24,10 +24,11 @@ suite['should add cached result to registry'] = function (test) {
   var stateDeps = {
     foo: 'foo'
   }
-  var cacheKey = JSON.stringify(stateDeps)
-  var computed = Computed(stateDeps, function (state) {
+  var computedCb = function (state) {
     return state.foo
-  })
+  }
+  var cacheKey = JSON.stringify(stateDeps) + computedCb.toString().replace(/\s/g, '')
+  var computed = Computed(stateDeps, computedCb)
   computed().get({
     foo: 'bar'
   })
@@ -40,10 +41,12 @@ suite['should add cache key to path'] = function (test) {
   var stateDeps = {
     foo: 'foo'
   }
-  var cacheKey = JSON.stringify(stateDeps)
-  var computed = Computed(stateDeps, function (state) {
+  var computedCb = function (state) {
     return state.foo
-  })
+  }
+
+  var cacheKey = JSON.stringify(stateDeps) + computedCb.toString().replace(/\s/g, '')
+  var computed = Computed(stateDeps, computedCb)
   computed()
   test.ok(Computed.registry['foo'].indexOf(cacheKey) >= 0)
   test.done()


### PR DESCRIPTION
We actually got into a situation where two computeds has the exact same state dependencies, but just runs them differently. So we need to put the actual function string representation into the computed cache key as well :)