### PR TITLE
fix(computed): force computed to return value in actions

### DIFF
--- a/providers/stateProvider.js
+++ b/providers/stateProvider.js
@@ -43,7 +43,7 @@ module.exports = function (context, execution, controller) {
     }
 
     state.computed = function (computed) {
-      return computed.get(model.accessors.get([]))
+      return computed.get(model.accessors.get([]), true)
     }
 
     return state

--- a/src/Computed.js
+++ b/src/Computed.js
@@ -41,8 +41,8 @@ function Computed (paths, cb) {
       getDepsMap: function () {
         return deps
       },
-      get: function (passedState) {
-        if (Computed.cache[cacheKey]) {
+      get: function (passedState, force) {
+        if (!force && Computed.cache[cacheKey]) {
           return Computed.cache[cacheKey]
         }
 


### PR DESCRIPTION
Due to computed now being "view driven", meaning it updates on "flush event" it needs to force recomputing its value when used in actions using: `state.computed`. The bottleneck of computed is not in signal, it is in rendering, so this is perfectly okay :)