### PR TITLE
feat(asyncActions): warn about async actions

### DIFF
--- a/src/staticTree.js
+++ b/src/staticTree.js
@@ -43,6 +43,9 @@ var traverse = function (item, parentItem, path, actions, isSync) {
       outputs: null,
       actionIndex: actions.indexOf(item) === -1 ? actions.push(item) - 1 : actions.indexOf(item)
     }
+    if (utils.isDeveloping() && !item.async && !isSync) {
+      console.warn('Cerebral - The action "' + action.name + '" will be run ASYNC even though you have not stated it as such. Please be explicit about actions running async')
+    }
     nextItem = parentItem[parentItem.indexOf(item) + 1]
     if (!Array.isArray(nextItem) && typeof nextItem === 'object') {
       parentItem.splice(parentItem.indexOf(nextItem), 1)

--- a/tests/staticTree.js
+++ b/tests/staticTree.js
@@ -38,10 +38,11 @@ suite['should use display name of action if available'] = function (test) {
 }
 
 suite['should bring along arrays and indicate async'] = function (test) {
+  function async1 () {}
+  async1.async = true
+
   var signal = [
-    [
-      function async1 () {}
-    ]
+    async1
   ]
   var tree = staticTree(signal).branches
   test.equals(tree.length, 1)
@@ -52,14 +53,15 @@ suite['should bring along arrays and indicate async'] = function (test) {
 }
 
 suite['should keep paths'] = function (test) {
+  function async1 () {}
+  async1.async = true
+
   var signal = [
-    [
-      function async1 () {}, {
-        success: [
-          function sync1 () {}
-        ]
-      }
-    ]
+    async1, {
+      success: [
+        function sync1 () {}
+      ]
+    }
   ]
   var tree = staticTree(signal).branches
   test.equals(tree[0].length, 1)
@@ -71,17 +73,18 @@ suite['should keep paths'] = function (test) {
 }
 
 suite['should handle deeply nested structures'] = function (test) {
+  function async1 () {}
+  async1.async = true
+  function async2 () {}
+  async2.async = true
+
   var signal = [
-    [
-      function async1 () {}, {
-        success: [
-          function sync1 () {},
-          [
-            function async2 () {}
-          ]
-        ]
-      }
-    ]
+    async1, {
+      success: [
+        function sync1 () {},
+        async2
+      ]
+    }
   ]
   var tree = staticTree(signal).branches
   test.equals(tree[0][0].outputs.success[1][0].name, 'async2')


### PR DESCRIPTION
I think the best approach is to warn about actions running async which has not explicitly been set to running async. This way we handle the case where actions run async without you knowing about it. Which is the most important thing. The timeout is more of a feature which we could implement later if necessary.