### PR TITLE
fix(signalPayload): show warning when passing invalid payload to singal

### DIFF
--- a/providers/inputProvider.js
+++ b/providers/inputProvider.js
@@ -8,16 +8,24 @@ module.exports = function (context, execution) {
     execution.payload,
     action.options.defaultInput ? action.options.defaultInput : {}
   ]
-  context.input = utils.merge.apply(null, inputs)
 
-  if (utils.isDeveloping() && action.options.input) {
-    try {
-      JSON.stringify(context.input)
-    } catch (e) {
-      console.log('Not serializable', context.input)
-      throw new Error('Cerebral - Could not serialize input to signal. Please check signal ' + signal.name)
-    }
+  if (
+    utils.isDeveloping() &&
+    execution.payload &&
+    (
+      typeof execution.payload !== 'object' ||
+      (
+        typeof execution.payload === 'object' &&
+        execution.payload !== null &&
+        !Array.isArray(execution.payload) &&
+        execution.payload.constructor.name !== 'Object'
+      )
+    )
+  ) {
+    console.warn('Cerebral - You passed an invalid signal payload to signal "' + signal.name + '", it has to be a plain object or nothing. This is the payload: ', execution.payload)
   }
+
+  context.input = utils.merge.apply(null, inputs)
 
   return context
 }


### PR DESCRIPTION
It has been quite common to pass in events and other bad data to signals. Typically events, because an inline use of signals on `onClick` etc passes in the event object. This code gives a warning during development when that happens :)