### PR TITLE
fix(computed): by default send object as props to computed

### DIFF
--- a/src/Computed.js
+++ b/src/Computed.js
@@ -43,6 +43,7 @@ function Computed (paths, cb) {
     ) {
       throw new Error('Cerebral - A computed is passed props that is not an object')
     }
+    props = props || {}
     var deps = typeof paths === 'function' ? paths(props) : paths
     var cacheKey = JSON.stringify(deps) + (props ? JSON.stringify(props) : '') + cb.toString().replace(/\s/g, '')
     traverseDepsMap(deps, cacheKey)

--- a/tests/computed.js
+++ b/tests/computed.js
@@ -27,7 +27,7 @@ suite['should add cached result to registry'] = function (test) {
   var computedCb = function (state) {
     return state.foo
   }
-  var cacheKey = JSON.stringify(stateDeps) + computedCb.toString().replace(/\s/g, '')
+  var cacheKey = JSON.stringify(stateDeps) + '{}' + computedCb.toString().replace(/\s/g, '')
   var computed = Computed(stateDeps, computedCb)
   computed().get({
     foo: 'bar'
@@ -45,7 +45,7 @@ suite['should add cache key to path'] = function (test) {
     return state.foo
   }
 
-  var cacheKey = JSON.stringify(stateDeps) + computedCb.toString().replace(/\s/g, '')
+  var cacheKey = JSON.stringify(stateDeps) + '{}' + computedCb.toString().replace(/\s/g, '')
   var computed = Computed(stateDeps, computedCb)
   computed()
   test.ok(Computed.registry['foo'].indexOf(cacheKey) >= 0)


### PR DESCRIPTION
Fixes issue where not passing in props to computed gives "undefined" as the props. Should be empty object.