### PR TITLE
perf(computed): check cached value as soon as possible.

### DIFF
--- a/src/Computed.js
+++ b/src/Computed.js
@@ -86,12 +86,10 @@ export class Computed {
 class ComputedFactory {
   constructor (paths, func) {
     if (
-      !paths ||
-      (
-        !isObject(paths) &&
-        typeof paths !== 'function'
+      !(
+        isObject(paths) ||
+        typeof paths === 'function'
       ) ||
-      !func ||
       typeof func !== 'function'
     ) {
       throwError('You are not passing the correct arguments to the computed factory')

--- a/src/Computed.js
+++ b/src/Computed.js
@@ -110,14 +110,14 @@ class ComputedFactory {
     any optional props. It checks the cache or creates a new computed
   */
   create (props = {}) {
-    const paths = typeof this.paths === 'function' ? this.paths(props) : this.paths
-    const depsMap = this.getDepsMap(paths)
-
     for (let x = 0; x < this.cache.length; x++) {
       if (!propsDiffer(props, this.cache[x].props)) {
         return this.cache[x]
       }
     }
+
+    const paths = typeof this.paths === 'function' ? this.paths(props) : this.paths
+    const depsMap = this.getDepsMap(paths)
 
     const computedInstance = new Computed(props, paths, this.func, depsMap, this)
     this.cache.push(computedInstance)


### PR DESCRIPTION
The check in computed factory should happen before resolving paths or depsMap.