### PR TITLE
Fix devtools null errors when in production

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -16,7 +16,7 @@ import {dependencyStore as computedDependencyStore} from './Computed'
   based on top level providers and providers defined in modules
 */
 class Controller extends EventEmitter {
-  constructor ({state = {}, routes = {}, signals = {}, providers = [], modules = {}, router, devtools}) {
+  constructor ({state = {}, routes = {}, signals = {}, providers = [], modules = {}, router, devtools = null}) {
     super()
     this.flush = this.flush.bind(this)
     this.devtools = devtools

--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -1,9 +1,14 @@
 import {isObject, isSerializable, throwError} from './utils'
 
 class Model {
-  constructor (initialState = {}, devtools = {}) {
-    this.preventExternalMutations = devtools.preventExternalMutations
-    this.enforceSerializable = Boolean(devtools.enforceSerializable)
+  constructor (initialState = {}, devtools = null) {
+    if (devtools) {
+      this.preventExternalMutations = devtools.preventExternalMutations
+      this.enforceSerializable = Boolean(devtools.enforceSerializable)
+    } else {
+      this.preventExternalMutations = false
+      this.enforceSerializable = false
+    }
     this.state = (
       this.preventExternalMutations
         ? this.freezeObject(initialState)


### PR DESCRIPTION
When `NODE_ENV==='production'` I got errors because devtools is null:

```js
const controller = Controller({
  devtools: process.env.NODE_ENV === 'production' ? null : Devtools(),
...
```

With this change now this will not generate errors because `Model`'s constructor checks if `devtools` is `null` and do not try to get `preventExternalMutations` and `enforceSerializable` from a `null` parameter.