### PR TITLE
fix(DependencyStore): fix deep path resolution

### DIFF
--- a/packages/cerebral/src/DependencyStore.js
+++ b/packages/cerebral/src/DependencyStore.js
@@ -80,7 +80,7 @@ class DependencyStore {
       }
 
       if (changesMap[key] !== true) {
-        currentEntities = currentEntities.concat(this.getUniqueEntities(changesMap[key], key))
+        currentEntities = currentEntities.concat(this.getUniqueEntities(changesMap[key], pathKey))
       }
     }
 

--- a/packages/cerebral/tests/DependencyStore.js
+++ b/packages/cerebral/tests/DependencyStore.js
@@ -66,6 +66,20 @@ describe('DependencyStore', () => {
       foo: {bar: {mip: true}}
     }), [component])
   })
+  it('should return components matching deep deps', () => {
+    const depsStore = new DependencyStore()
+    const component = {}
+    depsStore.addEntity(component, {'foo': 'foo.bar.baz'})
+    assert.deepEqual(depsStore.getUniqueEntities({
+      foo: true
+    }), [])
+    assert.deepEqual(depsStore.getUniqueEntities({
+      foo: {bar: true}
+    }), [])
+    assert.deepEqual(depsStore.getUniqueEntities({
+      foo: {bar: {baz: true}}
+    }), [component])
+  })
   it('should return unique components', () => {
     const depsStore = new DependencyStore()
     const component = {}


### PR DESCRIPTION
When using deep paths such as 'foo.bar.baz', the resolution breaks after second depth level.

Added a test and a fix.