### PR TITLE
Cerebral2: getSignals

### DIFF
--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -88,6 +88,8 @@ export default (View) => {
 
             return currentProps
           }, propsToPass)
+        } else {
+          propsToPass.signals = controller.getSignals()
         }
 
         return propsToPass

--- a/packages/cerebral/tests/Controller.js
+++ b/packages/cerebral/tests/Controller.js
@@ -143,4 +143,30 @@ describe('Controller', () => {
     const controller = new Controller({})
     assert.equal(controller.getState('foo.bar'), undefined)
   })
+  it('should expose method to get all signals', () => {
+    const controller = new Controller({
+      signals: {
+        foo: []
+      },
+      modules: {
+        moduleA: {
+          signals: {
+            fooNested: []
+          },
+          modules: {
+            moduleB: {
+              signals: {
+                fooNestedNested: []
+              }
+            }
+          }
+        }
+      }
+    })
+    assert.doesNotThrow(() => {
+      controller.getSignals().foo()
+      controller.getSignals().moduleA.fooNested()
+      controller.getSignals().moduleA.moduleB.fooNestedNested()
+    })
+  })
 })


### PR DESCRIPTION
A way to have all the signals placed on props in by using connect as was available in Cerebral 1.
We can discuss if there is a way we can optionally turn this on, but here is the implementation.
This is extremely useful to have when using TypeScript.
