### PR TITLE
feat(DependencyStore): introduce strict render as option

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -16,8 +16,9 @@ import {dependencyStore as computedDependencyStore} from './Computed'
   based on top level providers and providers defined in modules
 */
 class Controller extends EventEmitter {
-  constructor ({state = {}, routes = {}, signals = {}, providers = [], modules = {}, router, devtools = null}) {
+  constructor ({state = {}, routes = {}, signals = {}, providers = [], modules = {}, router, devtools = null, strictRender = false}) {
     super()
+    this.strictRender = strictRender
     this.flush = this.flush.bind(this)
     this.devtools = devtools
     this.model = new Model({}, this.devtools)
@@ -67,7 +68,7 @@ class Controller extends EventEmitter {
   */
   flush () {
     const changes = this.model.flush()
-    const computedsAboutToBecomeDirty = computedDependencyStore.getUniqueEntities(changes)
+    const computedsAboutToBecomeDirty = this.strictRender ? computedDependencyStore.getStrictUniqueEntities(changes) : computedDependencyStore.getUniqueEntities(changes)
 
     computedsAboutToBecomeDirty.forEach((computed) => {
       computed.flag()

--- a/packages/cerebral/src/viewFactories/Container.js
+++ b/packages/cerebral/src/viewFactories/Container.js
@@ -86,7 +86,16 @@ export default (View) => {
       for all components to update
     */
     onCerebralUpdate (changes, force) {
-      const componentsToRender = force ? this.dependencyStore.getAllUniqueEntities() : this.dependencyStore.getUniqueEntities(changes)
+      let componentsToRender = []
+
+      if (force) {
+        componentsToRender = this.dependencyStore.getAllUniqueEntities()
+      } else if (this.props.controller.strictRender) {
+        componentsToRender = this.dependencyStore.getStrictUniqueEntities(changes)
+      } else {
+        componentsToRender = this.dependencyStore.getUniqueEntities(changes)
+      }
+
       const start = Date.now()
       componentsToRender.forEach((component) => {
         if (this.hasDevtools()) {

--- a/packages/cerebral/tests/DependencyStore.js
+++ b/packages/cerebral/tests/DependencyStore.js
@@ -27,68 +27,6 @@ describe('DependencyStore', () => {
     depsStore.addEntity(component, {'bar': 'bar'})
     assert.deepEqual(depsStore.map, {foo: [], bar: [component]})
   })
-  it('should return components matching normal deps', () => {
-    const depsStore = new DependencyStore()
-    const component = {}
-    depsStore.addEntity(component, {'foo': 'foo'})
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: true
-    }), [component])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: true}
-    }), [])
-  })
-  it('should return components matching immediate deps', () => {
-    const depsStore = new DependencyStore()
-    const component = {}
-    depsStore.addEntity(component, {'foo': 'foo.*'})
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: true
-    }), [component])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: true}
-    }), [component])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: {mip: true}}
-    }), [])
-  })
-  it('should return components matching nested deps', () => {
-    const depsStore = new DependencyStore()
-    const component = {}
-    depsStore.addEntity(component, {'foo': 'foo.**'})
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: true
-    }), [component])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: true}
-    }), [component])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: {mip: true}}
-    }), [component])
-  })
-  it('should return components matching deep deps', () => {
-    const depsStore = new DependencyStore()
-    const component = {}
-    depsStore.addEntity(component, {'foo': 'foo.bar.baz'})
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: true
-    }), [])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: true}
-    }), [])
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: {bar: {baz: true}}
-    }), [component])
-  })
-  it('should return unique components', () => {
-    const depsStore = new DependencyStore()
-    const component = {}
-    depsStore.addEntity(component, {'foo': 'foo', 'bar': 'bar'})
-    assert.deepEqual(depsStore.getUniqueEntities({
-      foo: true,
-      bar: true
-    }), [component])
-  })
   it('should return all unique components', () => {
     const depsStore = new DependencyStore()
     const componentA = {}
@@ -96,5 +34,98 @@ describe('DependencyStore', () => {
     depsStore.addEntity(componentA, {'foo': 'foo', 'bar': 'bar'})
     depsStore.addEntity(componentB, {'foo': 'foo'})
     assert.deepEqual(depsStore.getAllUniqueEntities(), [componentA, componentB])
+  })
+  describe('strict', () => {
+    it('should STRICTLY return components matching normal deps', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo'})
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: true
+      }), [component])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: true}
+      }), [])
+    })
+    it('should STRICTLY return components matching immediate deps', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo.*'})
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: true
+      }), [component])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: true}
+      }), [component])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: {mip: true}}
+      }), [])
+    })
+    it('should STRICTLY return components matching nested deps', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo.**'})
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: true
+      }), [component])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: true}
+      }), [component])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: {mip: true}}
+      }), [component])
+    })
+    it('should STRICTLY return components matching deep deps', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo.bar.baz'})
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: true
+      }), [])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: true}
+      }), [])
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: {bar: {baz: true}}
+      }), [component])
+    })
+    it('should STRICTLY return unique components', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo', 'bar': 'bar'})
+      assert.deepEqual(depsStore.getStrictUniqueEntities({
+        foo: true,
+        bar: true
+      }), [component])
+    })
+  })
+  describe('non strict', () => {
+    it('should return components where changemap matches dependency path', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo'})
+      assert.deepEqual(depsStore.getUniqueEntities({
+        foo: {bar: true}
+      }), [component])
+    })
+    it('should return components where dependency path matches change map', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo.bar.baz'})
+      assert.deepEqual(depsStore.getUniqueEntities({
+        foo: {
+          bar: true
+        }
+      }), [component])
+    })
+    it('should return unique components', () => {
+      const depsStore = new DependencyStore()
+      const component = {}
+      depsStore.addEntity(component, {'foo': 'foo', 'bar': 'bar'})
+      assert.deepEqual(depsStore.getUniqueEntities({
+        foo: true,
+        bar: true
+      }), [component])
+    })
   })
 })

--- a/packages/cerebral/tests/computed.js
+++ b/packages/cerebral/tests/computed.js
@@ -154,6 +154,7 @@ describe('Computed', () => {
     })
     it('should handle strict path updates', () => {
       const controller = Controller({
+        strictRender: true,
         state: {
           foo: {
             bar: 'woop'


### PR DESCRIPTION
- Added new option:

```js
Controller({
  strictRender: true // False by default
})
```

- Dependency store now has two ways to extract components/computed to render/cachebust based on the change map