### PR TITLE
feat(cerebral-router): add routes config as option to router

### DIFF
--- a/packages/cerebral-router/src/index.js
+++ b/packages/cerebral-router/src/index.js
@@ -33,12 +33,12 @@ export function goTo (url) {
 export default function Router (options = {}) {
   options.mapper = urlMapper({query: options.query})
 
-  return (passedRoutesConfig, controller) => {
+  return (controller) => {
     if (!options.mapper || typeof options.mapper.map !== 'function') {
       throw new Error('Cerebral router - mapper option must be provided.')
     }
 
-    const routesConfig = flattenConfig(passedRoutesConfig)
+    const routesConfig = flattenConfig(options.routes)
 
     if (!options.baseUrl && options.onlyHash) {
       // autodetect baseUrl

--- a/packages/cerebral-router/src/utils.js
+++ b/packages/cerebral-router/src/utils.js
@@ -1,4 +1,6 @@
-import {isObject} from 'cerebral/lib/utils'
+function isObject (obj) {
+  return typeof obj === 'object' && !Array.isArray(obj) && obj !== null
+}
 
 export function flattenConfig (config, prev = '') {
   return Object.keys(config).reduce((flattened, key) => {

--- a/packages/cerebral-router/tests/matching.js
+++ b/packages/cerebral-router/tests/matching.js
@@ -19,11 +19,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/': 'home'
+          }
         }),
-        routes: {
-          '/': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -54,11 +54,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/foo': 'home'
+          }
         }),
-        routes: {
-          '/foo': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -89,11 +89,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/foo/bar/baz/42': 'home'
+          }
         }),
-        routes: {
-          '/foo/bar/baz/42': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -125,11 +125,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/foo/:param': 'home'
+          }
         }),
-        routes: {
-          '/foo/:param': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -160,11 +160,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/foo/:param/:param2': 'home'
+          }
         }),
-        routes: {
-          '/foo/:param/:param2': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -202,11 +202,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/foo/:param([\\w+-?]+)-test/:param2(%3A\\d+)': 'home'
+          }
         }),
-        routes: {
-          '/foo/:param([\\w+-?]+)-test/:param2(%3A\\d+)': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -246,11 +246,11 @@ describe('Router - matching', () => {
       let count = 0
       const controller = Controller({
         router: Router({
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/*': 'home'
+          }
         }),
-        routes: {
-          '/*': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -277,11 +277,11 @@ describe('Router - matching', () => {
       const controller = Controller({
         router: Router({
           baseUrl: '/base',
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/': 'home'
+          }
         }),
-        routes: {
-          '/': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -315,11 +315,11 @@ describe('Router - matching', () => {
       const controller = Controller({
         router: Router({
           onlyHash: true,
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/': 'home'
+          }
         }),
-        routes: {
-          '/': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -355,11 +355,11 @@ describe('Router - matching', () => {
         router: Router({
           onlyHash: true,
           baseUrl: '/base',
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/': 'home'
+          }
         }),
-        routes: {
-          '/': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }
@@ -395,11 +395,11 @@ describe('Router - matching', () => {
       const controller = Controller({
         router: Router({
           onlyHash: true,
-          preventAutostart: true
+          preventAutostart: true,
+          routes: {
+            '/': 'home'
+          }
         }),
-        routes: {
-          '/': 'home'
-        },
         signals: {
           'home': [() => { count++ }]
         }

--- a/packages/cerebral-router/tests/router.js
+++ b/packages/cerebral-router/tests/router.js
@@ -17,26 +17,45 @@ describe('Router', () => {
     addressbar.value = '/'
     addressbar.removeAllListeners('change')
   })
-  it('should expose base router and accept custom mapper', () => {
+  it('should be able to define routes as config', () => {
     let count = 0
     Controller({
-      router: Router(),
-      routes: {
-        '/': 'test'
-      },
+      router: Router({
+        routes: {
+          '/': 'test'
+        }
+      }),
       signals: {
         test: [() => { count++ }]
       }
     })
     assert.equal(count, 1)
   })
+  /*
+  it('should expose base router and accept custom mapper', () => {
+    let count = 0
+    Controller({
+      router: Router({
+        routes: {
+          '/': 'test'
+        }
+      }),
+      signals: {
+        test: [() => { count++ }]
+      }
+    })
+    assert.equal(count, 1)
+  })
+  */
   it('should not trigger if preventAutostart option was provided', () => {
     let count = 0
     Controller({
-      router: Router({preventAutostart: true}),
-      routes: {
-        '/': 'test'
-      },
+      router: Router({
+        preventAutostart: true,
+        routes: {
+          '/': 'test'
+        }
+      }),
       signals: {
         test: [() => { count++ }]
       }
@@ -46,16 +65,17 @@ describe('Router', () => {
   it('should support nested route definitions', () => {
     let count = 0
     Controller({
-      router: Router(),
-      routes: {
-        '/': 'foo',
-        '/bar': {
-          '/': 'bar',
-          '/baz': {
-            '/': 'baz'
+      router: Router({
+        routes: {
+          '/': 'foo',
+          '/bar': {
+            '/': 'bar',
+            '/baz': {
+              '/': 'baz'
+            }
           }
         }
-      },
+      }),
       signals: {
         foo: [() => { count++ }],
         bar: [() => { count++ }],
@@ -66,53 +86,26 @@ describe('Router', () => {
     triggerUrlChange('/bar/baz')
     assert.equal(count, 3)
   })
-  it('should support module routes', () => {
-    let count = 0
-    Controller({
-      router: Router(),
-      routes: {
-        '/': 'foo'
-      },
-      signals: {
-        foo: [() => { count++ }]
-      },
-      modules: {
-        bar: {
-          routes: {
-            '/': 'bar',
-            '/baz': {
-              '/': 'baz'
-            }
-          },
-          signals: {
-            bar: [() => { count++ }],
-            baz: [() => { count++ }]
-          }
-        }
-      }
-    })
-    triggerUrlChange('/bar')
-    triggerUrlChange('/bar/baz')
-    assert.equal(count, 3)
-  })
   it('should throw on missing signal', () => {
     assert.throws(() => {
       Controller({
-        router: Router(),
-        routes: {
-          '/': 'test'
-        }
+        router: Router({
+          routes: {
+            '/': 'test'
+          }
+        })
       })
     })
   })
   it('should throw on duplicate signal', () => {
     assert.throws(() => {
       Controller({
-        router: Router(),
-        routes: {
-          '/': 'test',
-          '/foo': 'test'
-        },
+        router: Router({
+          routes: {
+            '/': 'test',
+            '/foo': 'test'
+          }
+        }),
         signals: {
           test: []
         }
@@ -125,11 +118,11 @@ describe('Router', () => {
       router: Router({
         baseUrl: '/test',
         onlyHash: true,
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'test'
+        }
       }),
-      routes: {
-        '/': 'test'
-      },
       signals: {
         test: [
           function action ({router}) {
@@ -144,12 +137,12 @@ describe('Router', () => {
   it('should update addressbar for routable signal call', () => {
     const controller = Controller({
       router: Router({
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'home',
+          '/test': 'test'
+        }
       }),
-      routes: {
-        '/': 'home',
-        '/test': 'test'
-      },
       signals: {
         home: [],
         test: []
@@ -185,10 +178,11 @@ describe('Router', () => {
     addressbar.value = addressbar.origin + '/test'
     let count = 0
     const controller = Controller({
-      router: Router(),
-      routes: {
-        '/test': 'test'
-      },
+      router: Router({
+        routes: {
+          '/test': 'test'
+        }
+      }),
       signals: {
         test: [],
         foo: [() => { count++ }]
@@ -200,11 +194,12 @@ describe('Router', () => {
   })
   it('should allow redirect to url and trigger corresponded signal', (done) => {
     Controller({
-      router: Router(),
-      routes: {
-        '/': 'doRedirect',
-        '/existing/:string/:bool/:num': 'existing'
-      },
+      router: Router({
+        routes: {
+          '/': 'doRedirect',
+          '/existing/:string/:bool/:num': 'existing'
+        }
+      }),
       signals: {
         doRedirect: [({router}) => router.redirect('/existing/foo/%3Atrue/%3A42')],
         existing: [({input}) => {
@@ -220,12 +215,12 @@ describe('Router', () => {
   it('should replaceState on redirect by default', () => {
     Controller({
       router: Router({
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/foo': 'doRedirect',
+          '/existing': 'existing'
+        }
       }),
-      routes: {
-        '/foo': 'doRedirect',
-        '/existing': 'existing'
-      },
       signals: {
         doRedirect: [({router}) => router.redirect('/existing')],
         existing: [({input}) => {
@@ -240,12 +235,12 @@ describe('Router', () => {
   it('should expose goTo on context provider', (done) => {
     Controller({
       router: Router({
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/foo': 'doRedirect',
+          '/existing': 'existing'
+        }
       }),
-      routes: {
-        '/foo': 'doRedirect',
-        '/existing': 'existing'
-      },
       signals: {
         doRedirect: [({router}) => router.goTo('/existing')],
         existing: [() => {
@@ -260,12 +255,12 @@ describe('Router', () => {
   it('should allow redirect to signal', (done) => {
     const controller = Controller({
       router: Router({
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'home',
+          '/foo/:id': 'detail'
+        }
       }),
-      routes: {
-        '/': 'home',
-        '/foo/:id': 'detail'
-      },
       signals: {
         'home': [],
         'createClicked': [
@@ -289,11 +284,11 @@ describe('Router', () => {
   it('should warn if trying redirect to signal not bound to route', () => {
     const controller = Controller({
       router: Router({
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'home'
+        }
       }),
-      routes: {
-        '/': 'home'
-      },
       signals: {
         'home': [],
         'createClicked': [
@@ -313,11 +308,11 @@ describe('Router', () => {
     Controller({
       router: Router({
         baseUrl: '/base',
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'home'
+        }
       }),
-      routes: {
-        '/': 'home'
-      },
       signals: {
         'home': []
       }
@@ -334,11 +329,11 @@ describe('Router', () => {
       router: Router({
         baseUrl: '/base',
         allowEscape: true,
-        preventAutostart: true
+        preventAutostart: true,
+        routes: {
+          '/': 'home'
+        }
       }),
-      routes: {
-        '/': 'home'
-      },
       signals: {
         'home': []
       }

--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -16,7 +16,7 @@ import {dependencyStore as computedDependencyStore} from './Computed'
   based on top level providers and providers defined in modules
 */
 class Controller extends EventEmitter {
-  constructor ({state = {}, routes = {}, signals = {}, providers = [], modules = {}, router, devtools = null, strictRender = false}) {
+  constructor ({state = {}, signals = {}, providers = [], modules = {}, router, devtools = null, strictRender = false}) {
     super()
     this.strictRender = strictRender
     this.flush = this.flush.bind(this)
@@ -24,11 +24,10 @@ class Controller extends EventEmitter {
     this.model = new Model({}, this.devtools)
     this.module = new Module([], {
       state,
-      routes,
       signals,
       modules
     }, this)
-    this.router = router ? router(this.module.getRoutes(), this) : null
+    this.router = router ? router(this) : null
 
     const allProviders = (
       this.router ? [

--- a/packages/cerebral/src/Module.js
+++ b/packages/cerebral/src/Module.js
@@ -13,30 +13,8 @@ class Module {
     }
 
     this.signals = moduleDescription.signals || {}
-    this.routes = moduleDescription.routes || {}
     this.provider = moduleDescription.provider
     this.registerModules(moduleDescription.modules || {})
-  }
-  /*
-    Returns the routes defined on this module, but relative to
-    the module path. So "/foo" becomes "/moduleName/foo"
-  */
-  getRoutes () {
-    return Object.keys(this.modules).reduce((currentRoutes, moduleKey) => {
-      return Object.assign({}, currentRoutes, this.modules[moduleKey].getRoutes())
-    }, Object.keys(this.routes).reduce((currentInitialRoutes, routeKey) => {
-      if (typeof this.routes[routeKey] === 'string') {
-        currentInitialRoutes[(this.path.length ? `/${this.path.join('/') + routeKey}` : this.path.join('/') + routeKey)] = this.path.length ? `${this.path.join('.')}.${this.routes[routeKey]}` : this.routes[routeKey]
-      } else {
-        currentInitialRoutes[(this.path.length ? `/${this.path.join('/')}` : '') + routeKey] = Object.keys(this.routes[routeKey]).reduce((nestedRoutes, nestedKey) => {
-          nestedRoutes[nestedKey] = this.path.length ? `${this.path.join('.')}.${this.routes[routeKey][nestedKey]}` : this.routes[routeKey][nestedKey]
-
-          return nestedRoutes
-        }, {})
-      }
-
-      return currentInitialRoutes
-    }, {}))
   }
   registerModules (modules) {
     Object.keys(modules).forEach(moduleKey => {


### PR DESCRIPTION
I have added the routes config as an option to the router itself. I have kept the "routes by modules" to allow some more testing. Let us conclude after some discussion on it :)