### PR TITLE
test(Views): restore accidently deleted tests

### DIFF
--- a/packages/cerebral/.babelrc
+++ b/packages/cerebral/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015", "react"]
 }

--- a/packages/cerebral/tests/react.js
+++ b/packages/cerebral/tests/react.js
@@ -1,0 +1,403 @@
+/* eslint-env mocha */
+'use strict'
+
+const jsdom = require('jsdom')
+
+global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
+global.window = document.defaultView
+global.navigator = {userAgent: 'node.js'}
+
+const React = require('react')
+const TestUtils = require('react-addons-test-utils')
+const assert = require('assert')
+const Controller = require('../src/Controller').default
+const Container = require('../src/react/container').default
+const connect = require('../src/react/connect').default
+
+describe('React', () => {
+  describe('container', () => {
+    it('should be able to wrap app with container', () => {
+      class TestComponent extends React.Component {
+        render () {
+          return (
+            <div />
+          )
+        }
+      }
+      const tree = TestUtils.renderIntoDocument((
+        <Container>
+          <TestComponent />
+        </Container>
+      ))
+
+      assert.ok(TestUtils.findRenderedComponentWithType(tree, TestComponent))
+    })
+    it('should be able to expose state', () => {
+      const state = {
+        foo: 'bar'
+      }
+      const TestComponent = connect({
+        foo: 'foo'
+      }, (props) => {
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      const tree = TestUtils.renderIntoDocument((
+        <Container state={state}>
+          <TestComponent />
+        </Container>
+      ))
+
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+    })
+    it('should be able to expose controller', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        }
+      })
+      const TestComponent = connect({
+        foo: 'foo'
+      }, (props) => {
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+    })
+  })
+  describe('connect', () => {
+    it('should be able to extract state', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        }
+      })
+      const TestComponent = connect({
+        foo: 'foo'
+      }, (props) => {
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+    })
+    it('should be able to extract signals', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        },
+        signals: {
+          someSignal: []
+        }
+      })
+      const TestComponent = connect({
+        foo: 'foo'
+      }, {
+        signal: 'someSignal'
+      }, (props) => {
+        assert.ok(typeof props.signal === 'function')
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+    })
+    it('should rerender on state update', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo', 'bar2')]
+        }
+      })
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          return (
+            <div>{this.props.foo}</div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar2')
+    })
+    it('should only rerender affected components', () => {
+      let renderCount = 0
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo', 'bar2')]
+        }
+      })
+      class TestComponentClass2 extends React.Component {
+        render () {
+          renderCount++
+          return (
+            <div />
+          )
+        }
+      }
+      const TestComponent2 = connect({}, TestComponentClass2)
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          renderCount++
+          return (
+            <div><TestComponent2 /></div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(renderCount, 3)
+    })
+    it('should be able to dynamically define state dependencies', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar',
+          foo2: 'bar2'
+        }
+      })
+      class TestComponentClass2 extends React.Component {
+        render () {
+          return (
+            <div>{this.props.foo}</div>
+          )
+        }
+      }
+      const TestComponent2 = connect((props) => {
+        return {
+          foo: props.path
+        }
+      }, TestComponentClass2)
+      class TestComponentClass extends React.Component {
+        constructor (props) {
+          super(props)
+          this.state = {path: 'foo'}
+        }
+        changePath () {
+          this.setState({
+            path: 'foo2'
+          })
+        }
+        render () {
+          return (
+            <span><TestComponent2 path={this.state.path} /></span>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.changePath()
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar2')
+    })
+    it('should not update when parent path changes', () => {
+      let renderCount = 0
+      const controller = Controller({
+        state: {
+          foo: {
+            bar: 'baz'
+          }
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo', 'bar2')]
+        }
+      })
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          renderCount++
+          return (
+            <div>{this.props.foo}</div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo.bar'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(renderCount, 1)
+    })
+    it('should not update when child path changes', () => {
+      let renderCount = 0
+      const controller = Controller({
+        state: {
+          foo: {
+            bar: 'baz'
+          }
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
+        }
+      })
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          renderCount++
+          return (
+            <div>{this.props.foo.bar}</div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(renderCount, 1)
+    })
+    it('should update when immediate child interest defined', () => {
+      let renderCount = 0
+      const controller = Controller({
+        state: {
+          foo: {
+            bar: 'baz'
+          }
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
+        }
+      })
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          renderCount++
+          return (
+            <div>{this.props.foo.bar}</div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo.*'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(renderCount, 2)
+    })
+    it('should update when nested children interest defined', () => {
+      let renderCount = 0
+      const controller = Controller({
+        state: {
+          foo: {
+            bar: {
+              baz: 'value'
+            }
+          }
+        },
+        signals: {
+          methodCalled: [({state}) => state.set('foo.bar.baz', 'value2')]
+        }
+      })
+      class TestComponentClass extends React.Component {
+        callSignal () {
+          this.props.methodCalled()
+        }
+        render () {
+          renderCount++
+          return (
+            <div>{this.props.foo.bar.baz}</div>
+          )
+        }
+      }
+      const TestComponent = connect({
+        foo: 'foo.**'
+      }, {
+        methodCalled: 'methodCalled'
+      }, TestComponentClass)
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'value')
+      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+      component.callSignal()
+      assert.equal(renderCount, 2)
+    })
+  })
+})

--- a/packages/cerebral/tests/react.js
+++ b/packages/cerebral/tests/react.js
@@ -245,159 +245,245 @@ describe('React', () => {
       component.changePath()
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar2')
     })
-    it('should not update when parent path changes', () => {
-      let renderCount = 0
-      const controller = Controller({
-        state: {
-          foo: {
-            bar: 'baz'
-          }
-        },
-        signals: {
-          methodCalled: [({state}) => state.set('foo', 'bar2')]
-        }
-      })
-      class TestComponentClass extends React.Component {
-        callSignal () {
-          this.props.methodCalled()
-        }
-        render () {
-          renderCount++
-          return (
-            <div>{this.props.foo}</div>
-          )
-        }
-      }
-      const TestComponent = connect({
-        foo: 'foo.bar'
-      }, {
-        methodCalled: 'methodCalled'
-      }, TestComponentClass)
-      const tree = TestUtils.renderIntoDocument((
-        <Container controller={controller}>
-          <TestComponent />
-        </Container>
-      ))
-      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
-      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
-      component.callSignal()
-      assert.equal(renderCount, 1)
-    })
-    it('should not update when child path changes', () => {
-      let renderCount = 0
-      const controller = Controller({
-        state: {
-          foo: {
-            bar: 'baz'
-          }
-        },
-        signals: {
-          methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
-        }
-      })
-      class TestComponentClass extends React.Component {
-        callSignal () {
-          this.props.methodCalled()
-        }
-        render () {
-          renderCount++
-          return (
-            <div>{this.props.foo.bar}</div>
-          )
-        }
-      }
-      const TestComponent = connect({
-        foo: 'foo'
-      }, {
-        methodCalled: 'methodCalled'
-      }, TestComponentClass)
-      const tree = TestUtils.renderIntoDocument((
-        <Container controller={controller}>
-          <TestComponent />
-        </Container>
-      ))
-      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
-      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
-      component.callSignal()
-      assert.equal(renderCount, 1)
-    })
-    it('should update when immediate child interest defined', () => {
-      let renderCount = 0
-      const controller = Controller({
-        state: {
-          foo: {
-            bar: 'baz'
-          }
-        },
-        signals: {
-          methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
-        }
-      })
-      class TestComponentClass extends React.Component {
-        callSignal () {
-          this.props.methodCalled()
-        }
-        render () {
-          renderCount++
-          return (
-            <div>{this.props.foo.bar}</div>
-          )
-        }
-      }
-      const TestComponent = connect({
-        foo: 'foo.*'
-      }, {
-        methodCalled: 'methodCalled'
-      }, TestComponentClass)
-      const tree = TestUtils.renderIntoDocument((
-        <Container controller={controller}>
-          <TestComponent />
-        </Container>
-      ))
-      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
-      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
-      component.callSignal()
-      assert.equal(renderCount, 2)
-    })
-    it('should update when nested children interest defined', () => {
-      let renderCount = 0
-      const controller = Controller({
-        state: {
-          foo: {
-            bar: {
-              baz: 'value'
+    describe('STRICT render update', () => {
+      it('should not update when parent path changes', () => {
+        let renderCount = 0
+        const controller = Controller({
+          strictRender: true,
+          state: {
+            foo: {
+              bar: 'baz'
             }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo', 'bar2')]
           }
-        },
-        signals: {
-          methodCalled: [({state}) => state.set('foo.bar.baz', 'value2')]
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo}</div>
+            )
+          }
         }
+        const TestComponent = connect({
+          foo: 'foo.bar'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(renderCount, 1)
       })
-      class TestComponentClass extends React.Component {
-        callSignal () {
-          this.props.methodCalled()
+      it('should not update when child path changes', () => {
+        let renderCount = 0
+        const controller = Controller({
+          strictRender: true,
+          state: {
+            foo: {
+              bar: 'baz'
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo.bar}</div>
+            )
+          }
         }
-        render () {
-          renderCount++
-          return (
-            <div>{this.props.foo.bar.baz}</div>
-          )
+        const TestComponent = connect({
+          foo: 'foo'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(renderCount, 1)
+      })
+      it('should update when immediate child interest defined', () => {
+        let renderCount = 0
+        const controller = Controller({
+          strictRender: true,
+          state: {
+            foo: {
+              bar: 'baz'
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo.bar}</div>
+            )
+          }
         }
-      }
-      const TestComponent = connect({
-        foo: 'foo.**'
-      }, {
-        methodCalled: 'methodCalled'
-      }, TestComponentClass)
-      const tree = TestUtils.renderIntoDocument((
-        <Container controller={controller}>
-          <TestComponent />
-        </Container>
-      ))
-      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'value')
-      const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
-      component.callSignal()
-      assert.equal(renderCount, 2)
+        const TestComponent = connect({
+          foo: 'foo.*'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(renderCount, 2)
+      })
+      it('should update when nested children interest defined', () => {
+        let renderCount = 0
+        const controller = Controller({
+          strictRender: true,
+          state: {
+            foo: {
+              bar: {
+                baz: 'value'
+              }
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo.bar.baz', 'value2')]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo.bar.baz}</div>
+            )
+          }
+        }
+        const TestComponent = connect({
+          foo: 'foo.**'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'value')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(renderCount, 2)
+      })
+    })
+    describe('DEFAULT render update', () => {
+      it('should update when parent path changes', () => {
+        let renderCount = 0
+        const controller = Controller({
+          state: {
+            foo: {
+              bar: 'baz'
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo', {bar: 'baz2'})]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo}</div>
+            )
+          }
+        }
+        const TestComponent = connect({
+          foo: 'foo.bar'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz2')
+        assert.equal(renderCount, 2)
+      })
+      it('should update when child path changes', () => {
+        let renderCount = 0
+        const controller = Controller({
+          state: {
+            foo: {
+              bar: 'baz'
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo.bar', 'baz2')]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            renderCount++
+            return (
+              <div>{this.props.foo.bar}</div>
+            )
+          }
+        }
+        const TestComponent = connect({
+          foo: 'foo'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        component.callSignal()
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz2')
+        assert.equal(renderCount, 2)
+      })
     })
   })
 })


### PR DESCRIPTION
restored view tests but it fails now.
I think it is because of new strictRender.
@christianalfoni please push fix with another commit to this branch