### PR TITLE
chore(function-tree): add direct entry points to function-tree

### DIFF
--- a/packages/cerebral/src/operators/debounce.js
+++ b/packages/cerebral/src/operators/debounce.js
@@ -1,3 +1,1 @@
-import debounce from 'function-tree/lib/factories/debounce'
-
-export default debounce
+export {debounce as default} from 'function-tree/factories'

--- a/packages/cerebral/src/providers/index.js
+++ b/packages/cerebral/src/providers/index.js
@@ -1,3 +1,3 @@
 // This providers exposed to 'cerebral/providers' entry point
 
-export {default as ContextProvider} from 'function-tree/lib/providers/Context'
+export {ContextProvider} from 'function-tree/providers'

--- a/packages/function-tree-demos/src/mobx/run.js
+++ b/packages/function-tree-demos/src/mobx/run.js
@@ -1,6 +1,5 @@
 import FunctionTree from 'function-tree'
-import DebuggerProvider from 'function-tree/lib/providers/Debugger'
-import ContextProvider from 'function-tree/lib/providers/Context'
+import {ContextProvider, DebuggerProvider} from 'function-tree/providers'
 import axios from 'axios'
 import store from './store'
 

--- a/packages/function-tree-demos/src/node/runTask.js
+++ b/packages/function-tree-demos/src/node/runTask.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const FunctionTree = require('function-tree')
-const NodeDebuggerProvider = require('function-tree/lib/providers/NodeDebugger')
-const ContextProvider = require('function-tree/lib/providers/Context')
+const NodeDebuggerProvider = require('function-tree/providers').NodeDebuggerProvider
+const ContextProvider = require('function-tree/providers').ContextProvider
 const request = require('request')
 const fs = require('fs')
 

--- a/packages/function-tree-demos/src/redux/run.js
+++ b/packages/function-tree-demos/src/redux/run.js
@@ -1,7 +1,5 @@
 import FunctionTree from 'function-tree'
-import DebuggerProvider from 'function-tree/lib/providers/Debugger'
-import ReduxProvider from 'function-tree/lib/providers/Redux'
-import ContextProvider from 'function-tree/lib/providers/Context'
+import {ContextProvider, DebuggerProvider, ReduxProvider} from 'function-tree/providers'
 import axios from 'axios'
 import store from './store'
 

--- a/packages/function-tree-firebase-demo/src/runTask.js
+++ b/packages/function-tree-firebase-demo/src/runTask.js
@@ -1,5 +1,5 @@
 const FunctionTree = require('function-tree').default
-const NodeDebuggerProvider = require('function-tree/lib/providers/NodeDebugger')
+const NodeDebuggerProvider = require('function-tree/providers').NodeDebuggerProvider
 const FirebaseProvider = require('./providers/Firebase')
 const DashboardProvider = require('./providers/Dashboard')
 

--- a/packages/function-tree/README.md
+++ b/packages/function-tree/README.md
@@ -53,7 +53,7 @@ When you want to test the whole function tree execution you can do:
 
 ```js
 const FunctionTree = require('function-tree')
-const ContextProvider = require('function-tree/providers/Context')
+const ContextProvider = require('function-tree/providers').ContextProvider
 const appMounted = require('../src/events/appMounted')
 
 const window = {app: {}}
@@ -91,7 +91,7 @@ export default execute;
 
 ```js
 import FunctionTree from 'function-tree'
-import ContextProvider from 'function-tree/providers/Context'
+import {ContextProvider} from 'function-tree/providers'
 import request from 'request'
 
 const execute = new FunctionTree([
@@ -378,7 +378,7 @@ Will extend the context. If the debugger is active the methods on the attached o
 
 ```js
 import FunctionTree from 'function-tree'
-import ContextProvider from 'function-tree/providers/Context'
+import {ContextProvider} from 'function-tree/providers'
 import request from 'request'
 
 function funcA(context) {
@@ -403,8 +403,7 @@ Download the [Chrome Extension](https://chrome.google.com/webstore/detail/functi
 
 ```js
 import FunctionTree from 'function-tree'
-import DebuggerProvider from 'function-tree/providers/Debugger'
-import ContextProvider from 'function-tree/providers/Context'
+import {ContextProvider, DebuggerProvider} from 'function-tree/providers'
 import request from 'request'
 
 const execute = new FunctionTree([

--- a/packages/function-tree/factories.js
+++ b/packages/function-tree/factories.js
@@ -1,0 +1,1 @@
+exports.debounce = require('./lib/factories/debounce').default

--- a/packages/function-tree/providers.js
+++ b/packages/function-tree/providers.js
@@ -1,0 +1,7 @@
+exports.ContextProvider = require('./lib/providers/Context').default
+exports.DebuggerProvider = require('./lib/providers/Debugger').default
+exports.ExecutionProvider = require('./lib/providers/Execution').default
+exports.InputProvider = require('./lib/providers/Input').default
+exports.NodeDebuggerProvider = require('./lib/providers/NodeDebugger').default
+exports.PathProvider = require('./lib/providers/Path').default
+exports.ReduxProvider = require('./lib/providers/Redux').default

--- a/packages/function-tree/src/providers/Path.js
+++ b/packages/function-tree/src/providers/Path.js
@@ -6,7 +6,7 @@ function createNext (next, path) {
   }
 }
 
-export default () => {
+export default function PathProvider () {
   return (context, functionDetails, payload, next) => {
     if (functionDetails.outputs) {
       context.path = Object.keys(functionDetails.outputs).reduce((output, outputPath) => {


### PR DESCRIPTION
New syntax: import {ContextProvider} from 'function-tree/providers'

ISSUES CLOSED: #348 

Not sure how to test the function-tree-demos... Any hint ?