### PR TITLE
feat(Providers): get computed value with state.compute(computed)

### DIFF
--- a/packages/cerebral/src/Computed.js
+++ b/packages/cerebral/src/Computed.js
@@ -1,5 +1,5 @@
 import DependencyStore from './DependencyStore'
-import {cleanPath, isObject, throwError, propsDiffer} from './utils'
+import {cleanPath, ensurePath, isObject, throwError, propsDiffer} from './utils'
 
 /*
   The dependency store used to store and extract what computeds
@@ -41,7 +41,7 @@ export class Computed {
     Produces a new value if the computed is dirty or returns existing
     value
   */
-  getValue (controller) {
+  getValue (model) {
     if (this.isDirty) {
       const computedProps = Object.assign(
         {},
@@ -49,8 +49,8 @@ export class Computed {
         Object.keys(this.paths).reduce((currentProps, depsMapKey) => {
           currentProps[depsMapKey] = (
             this.paths[depsMapKey] instanceof Computed
-              ? this.paths[depsMapKey].getValue(controller)
-              : controller.getState(cleanPath(this.paths[depsMapKey]))
+              ? this.paths[depsMapKey].getValue(model)
+              : model.get(ensurePath(cleanPath(this.paths[depsMapKey])))
           )
 
           return currentProps

--- a/packages/cerebral/src/Computed.test.js
+++ b/packages/cerebral/src/Computed.test.js
@@ -49,33 +49,33 @@ describe('Computed', () => {
       })
     })
     it('should return value', () => {
-      const controller = Controller({})
+      const model = Controller({}).model
       const computedFactory = Computed({}, () => {
         return 'foo'
       })
       const computed = computedFactory()
-      assert.equal(computed.getValue(controller), 'foo')
+      assert.equal(computed.getValue(model), 'foo')
     })
     it('should extract state', () => {
-      const controller = Controller({
+      const model = Controller({
         state: {
           foo: 'bar'
         }
-      })
+      }).model
       const computedFactory = Computed({
         foo: 'foo'
       }, ({foo}) => {
         return foo
       })
       const computed = computedFactory()
-      assert.equal(computed.getValue(controller), 'bar')
+      assert.equal(computed.getValue(model), 'bar')
     })
     it('should cache values', () => {
-      const controller = Controller({
+      const model = Controller({
         state: {
           foo: 'bar'
         }
-      })
+      }).model
       const computedFactory = Computed({
         foo: 'foo'
       }, ({foo}) => {
@@ -84,9 +84,9 @@ describe('Computed', () => {
         }
       })
       const computed = computedFactory()
-      const value = computed.getValue(controller)
+      const value = computed.getValue(model)
       assert.deepEqual(value, {foo: 'bar'})
-      assert.equal(computed.getValue(controller), value)
+      assert.equal(computed.getValue(model), value)
     })
     it('should bust cache when path updates', () => {
       const controller = Controller({
@@ -94,6 +94,7 @@ describe('Computed', () => {
           foo: 'bar'
         }
       })
+      const model = controller.model
       const computedFactory = Computed({
         foo: 'foo'
       }, ({foo}) => {
@@ -102,18 +103,18 @@ describe('Computed', () => {
         }
       })
       const computed = computedFactory()
-      assert.deepEqual(computed.getValue(controller), {foo: 'bar'})
-      assert.deepEqual(computed.getValue(controller), {foo: 'bar'})
-      controller.model.set(['foo'], 'bar2')
+      assert.deepEqual(computed.getValue(model), {foo: 'bar'})
+      assert.deepEqual(computed.getValue(model), {foo: 'bar'})
+      model.set(['foo'], 'bar2')
       controller.flush()
-      assert.deepEqual(computed.getValue(controller), {foo: 'bar2'})
+      assert.deepEqual(computed.getValue(model), {foo: 'bar2'})
     })
     it('should handle computed in computed', () => {
-      const controller = Controller({
+      const model = Controller({
         state: {
           foo: 'bar'
         }
-      })
+      }).model
       const computedFactoryA = Computed({
         foo: 'foo'
       }, ({foo}) => {
@@ -126,7 +127,7 @@ describe('Computed', () => {
         return foo + foo2
       })
       const computed = computedFactoryB()
-      assert.equal(computed.getValue(controller), 'barbar')
+      assert.equal(computed.getValue(model), 'barbar')
     })
     it('should bust cache when nested computed updates', () => {
       const controller = Controller({
@@ -135,6 +136,7 @@ describe('Computed', () => {
           bar: 'foo'
         }
       })
+      const model = controller.model
       const computedFactoryA = Computed({
         foo: 'foo'
       }, ({foo}) => {
@@ -147,10 +149,10 @@ describe('Computed', () => {
         return foo + bar
       })
       const computed = computedFactoryB()
-      assert.equal(computed.getValue(controller), 'barfoo')
-      controller.model.set(['foo'], 'bar2')
+      assert.equal(computed.getValue(model), 'barfoo')
+      model.set(['foo'], 'bar2')
       controller.flush()
-      assert.equal(computed.getValue(controller), 'bar2foo')
+      assert.equal(computed.getValue(model), 'bar2foo')
     })
     it('should handle strict path updates', () => {
       const controller = Controller({
@@ -161,6 +163,7 @@ describe('Computed', () => {
           }
         }
       })
+      const model = controller.model
       const computedFactoryA = Computed({
         foo: 'foo'
       }, ({foo}) => {
@@ -173,12 +176,12 @@ describe('Computed', () => {
       })
       const computedA = computedFactoryA()
       const computedB = computedFactoryB()
-      assert.equal(computedA.getValue(controller), 'woop')
-      assert.equal(computedB.getValue(controller), 'woop')
-      controller.model.set(['foo', 'bar'], 'woop2')
+      assert.equal(computedA.getValue(model), 'woop')
+      assert.equal(computedB.getValue(model), 'woop')
+      model.set(['foo', 'bar'], 'woop2')
       controller.flush()
-      assert.equal(computedA.getValue(controller), 'woop')
-      assert.equal(computedB.getValue(controller), 'woop2')
+      assert.equal(computedA.getValue(model), 'woop')
+      assert.equal(computedB.getValue(model), 'woop2')
     })
     it('should remove computed from dependency store', () => {
       const controller = Controller({
@@ -186,20 +189,21 @@ describe('Computed', () => {
           foo: 'bar'
         }
       })
+      const model = controller.model
       const computedFactory = Computed({
         foo: 'foo'
       }, ({foo}) => {
         return foo
       })
       const computed = computedFactory()
-      assert.equal(computed.getValue(controller), 'bar')
-      controller.model.set(['foo'], 'bar2')
+      assert.equal(computed.getValue(model), 'bar')
+      model.set(['foo'], 'bar2')
       controller.flush()
-      assert.equal(computed.getValue(controller), 'bar2')
+      assert.equal(computed.getValue(model), 'bar2')
       computed.remove()
-      controller.model.set(['foo'], 'bar3')
+      model.set(['foo'], 'bar3')
       controller.flush()
-      assert.equal(computed.getValue(controller), 'bar2')
+      assert.equal(computed.getValue(model), 'bar2')
     })
   })
 })

--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -219,6 +219,12 @@ class Model {
       return array.concat(value)
     })
   }
+  compute (computed, forceRecompute = false) {
+    if (forceRecompute) {
+      computed.flag()
+    }
+    return computed.getValue(this)
+  }
 }
 
 export default Model

--- a/packages/cerebral/src/Model.test.js
+++ b/packages/cerebral/src/Model.test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import Model from './Model'
+import Computed from './Computed'
 import assert from 'assert'
 
 describe('Model', () => {
@@ -121,6 +122,43 @@ describe('Model', () => {
       })
       model.concat(['foo'], ['bar'])
       assert.deepEqual(model.get(), {foo: ['foo', 'bar']})
+    })
+  })
+  describe('COMPUTE', () => {
+    it('should compute value from Computed', () => {
+      const fullNameFactory = Computed({
+        firstName: 'user.firstName',
+        lastName: 'user.lastName'
+      }, ({firstName, lastName}) => {
+        return `${firstName} ${lastName}`
+      })
+      const fullName = fullNameFactory()
+      const model = new Model({
+        user: {
+          firstName: 'John',
+          lastName: 'Difool'
+        }
+      })
+      assert.deepEqual(model.compute(fullName), 'John Difool')
+    })
+    it('should force recompute value from Computed', () => {
+      const fullNameFactory = Computed({
+        firstName: 'user.firstName',
+        lastName: 'user.lastName'
+      }, ({firstName, lastName}) => {
+        return `${firstName} ${lastName}`
+      })
+      const fullName = fullNameFactory()
+      const model = new Model({
+        user: {
+          firstName: 'John',
+          lastName: 'Difool'
+        }
+      })
+      model.compute(fullName)
+      model.set(['user', 'firstName'], 'Animah')
+      assert.deepEqual(model.compute(fullName), 'John Difool')
+      assert.deepEqual(model.compute(fullName, true), 'Animah Difool')
     })
   })
   describe('Prevent mutations', () => {

--- a/packages/cerebral/src/providers/State.js
+++ b/packages/cerebral/src/providers/State.js
@@ -11,10 +11,13 @@ function StateProviderFactory (model) {
     'unshift',
     'splice',
     'unset',
-    'concat'
+    'concat',
+    'compute'
   ]
   const stateContext = methods.reduce((currentStateContext, methodKey) => {
-    if (typeof model[methodKey] === 'function') {
+    if (methodKey === 'compute') {
+      currentStateContext.compute = (...args) => model.compute(...args)
+    } else if (typeof model[methodKey] === 'function') {
       currentStateContext[methodKey] = (...args) => {
         const path = ensurePath(args.shift())
 
@@ -30,7 +33,7 @@ function StateProviderFactory (model) {
 
     if (context.debugger) {
       context.state = methods.reduce((currentState, methodKey) => {
-        if (methodKey === 'get') {
+        if (methodKey === 'get' || methodKey === 'compute') {
           currentState[methodKey] = stateContext[methodKey]
         } else {
           const originFunc = stateContext[methodKey]


### PR DESCRIPTION
BREAKING CHANGE:

computed.getValue now takes model as argument instead of controller

ISSUES CLOSED: #354

API is `state.compute(computed, forceRecompute = false)` (using a verb like 'get', 'set', 'concat', etc).