### PR TITLE
fix(function-tree): pass final resulting payload to end event

### DIFF
--- a/packages/function-tree/src/FunctionTree.test.js
+++ b/packages/function-tree/src/FunctionTree.test.js
@@ -103,6 +103,19 @@ describe('FunctionTree', () => {
       foo: 'bar'
     })
   })
+
+  it('should pass final payload on end event', () => {
+    const execute = FunctionTree()
+    execute.once('end', (execution, payload) => {
+      assert.deepEqual(payload, {foo: 'bar', bar: 'foo'})
+    })
+    execute([
+      () => {
+        return {bar: 'foo'}
+      }
+    ], {foo: 'bar'})
+  })
+
   it('should be able to reuse existing tree', (done) => {
     function actionA ({path}) {
       assert.ok(true)

--- a/packages/function-tree/src/index.js
+++ b/packages/function-tree/src/index.js
@@ -211,9 +211,9 @@ class FunctionTree extends EventEmitter {
     })
 
     this.emit('start', execution, payload)
-    executeTree(execution.staticTree, execution.runFunction, payload, () => {
-      this.emit('end', execution, payload)
-      cb && cb(null, execution, payload)
+    executeTree(execution.staticTree, execution.runFunction, payload, (finalPayload) => {
+      this.emit('end', execution, finalPayload)
+      cb && cb(null, execution, finalPayload)
     })
   }
 }


### PR DESCRIPTION
Pass the resulting payload to the end event - before the initial payload was passed instead.