### PR TITLE
feat(Computed): simplify use of computed without props

### DIFF
--- a/packages/cerebral-demo/src/components/UpperTitle/index.js
+++ b/packages/cerebral-demo/src/components/UpperTitle/index.js
@@ -3,7 +3,7 @@ import {connect} from 'cerebral/react'
 import upperCaseTitleComputed from '../../computeds/upperCaseTitle'
 
 export default connect({
-  title: upperCaseTitleComputed()
+  title: upperCaseTitleComputed
 },
   function UpperTitle (props) {
     return (

--- a/packages/cerebral-todomvc/src/components/App/index.js
+++ b/packages/cerebral-todomvc/src/components/App/index.js
@@ -8,7 +8,7 @@ import visibleTodosRefs from '../../computed/visibleTodosRefs'
 export default connect({
   todos: 'app.todos',
   isSaving: 'app.isSaving',
-  visibleTodosRefs: visibleTodosRefs()
+  visibleTodosRefs: visibleTodosRefs
 },
   function App (props) {
     return (

--- a/packages/cerebral-todomvc/src/components/Footer/index.js
+++ b/packages/cerebral-todomvc/src/components/Footer/index.js
@@ -5,7 +5,7 @@ import cn from 'classnames'
 
 export default connect({
   filter: 'app.filter',
-  counts: counts()
+  counts: counts
 }, {
   filterClicked: 'app.filterClicked',
   clearCompletedClicked: 'app.clearCompletedClicked'

--- a/packages/cerebral-todomvc/src/components/List/index.js
+++ b/packages/cerebral-todomvc/src/components/List/index.js
@@ -6,8 +6,8 @@ import isAllChecked from '../../computed/isAllChecked'
 import visibleTodosRefs from '../../computed/visibleTodosRefs'
 
 export default connect({
-  isAllChecked: isAllChecked(),
-  todoRefs: visibleTodosRefs()
+  isAllChecked: isAllChecked,
+  todoRefs: visibleTodosRefs
 }, {
   toggleAllChanged: 'app.toggleAllChanged'
 },

--- a/packages/cerebral-todomvc/src/computed/isAllChecked.js
+++ b/packages/cerebral-todomvc/src/computed/isAllChecked.js
@@ -2,7 +2,7 @@ import {Computed} from 'cerebral'
 import visibleTodosRefs from './visibleTodosRefs'
 
 export default Computed({
-  visibleTodosRefs: visibleTodosRefs(),
+  visibleTodosRefs: visibleTodosRefs,
   todos: 'app.todos.**'
 }, props => {
   return props.visibleTodosRefs.filter((ref) => {

--- a/packages/cerebral-todomvc/src/modules/app/actions/toggleAllChecked.js
+++ b/packages/cerebral-todomvc/src/modules/app/actions/toggleAllChecked.js
@@ -2,8 +2,8 @@ import isAllChecked from '../../../computed/isAllChecked'
 import visibleTodosRefs from '../../../computed/visibleTodosRefs'
 
 function toggleAllChecked ({state}) {
-  const isCompleted = !state.compute(isAllChecked())
-  const currentTodosKeys = state.compute(visibleTodosRefs())
+  const isCompleted = !state.compute(isAllChecked)
+  const currentTodosKeys = state.compute(visibleTodosRefs)
 
   currentTodosKeys.forEach((ref) => {
     state.set(`app.todos.${ref}.completed`, isCompleted)

--- a/packages/cerebral/README.md
+++ b/packages/cerebral/README.md
@@ -81,7 +81,7 @@ In component:
 import someComputed from './someComputed'
 
 export default connect({
-  myComputed: someComputed()
+  myComputed: someComputed
 })
 ```
 

--- a/packages/cerebral/src/Model.test.js
+++ b/packages/cerebral/src/Model.test.js
@@ -126,13 +126,12 @@ describe('Model', () => {
   })
   describe('COMPUTE', () => {
     it('should compute value from Computed', () => {
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const model = new Model({
         user: {
           firstName: 'John',
@@ -142,13 +141,12 @@ describe('Model', () => {
       assert.deepEqual(model.compute(fullName), 'John Difool')
     })
     it('should force recompute value from Computed', () => {
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const model = new Model({
         user: {
           firstName: 'John',

--- a/packages/cerebral/src/providers/providers.test.js
+++ b/packages/cerebral/src/providers/providers.test.js
@@ -139,13 +139,12 @@ describe('providers', () => {
       assert.deepEqual(controller.getState(), {foo: ['foo', 'bar']})
     })
     it('should be able to COMPUTE state', () => {
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const controller = new Controller({
         state: {
           user: {
@@ -160,13 +159,12 @@ describe('providers', () => {
       controller.getSignal('test')()
     })
     it('should clear COMPUTE cache on signal flush', () => {
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const controller = new Controller({
         state: {
           user: {
@@ -188,13 +186,12 @@ describe('providers', () => {
       controller.getSignal('test')()
     })
     it('should allow forcing recompute on COMPUTE state', () => {
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const controller = new Controller({
         state: {
           user: {
@@ -221,13 +218,12 @@ describe('providers', () => {
         init () {},
         send () {}
       }
-      const fullNameFactory = Computed({
+      const fullName = Computed({
         firstName: 'user.firstName',
         lastName: 'user.lastName'
       }, ({firstName, lastName}) => {
         return `${firstName} ${lastName}`
       })
-      const fullName = fullNameFactory()
       const controller = new Controller({
         state: {
           user: {

--- a/packages/cerebral/src/react/react.test.js
+++ b/packages/cerebral/src/react/react.test.js
@@ -255,7 +255,7 @@ describe('React', () => {
           methodCalled: [({state}) => state.set('foo', 'bar2')]
         }
       })
-      const computedFactory = Computed({
+      const computed = Computed({
         foo: 'foo'
       }, ({foo}) => {
         return `${foo} computed`
@@ -271,7 +271,7 @@ describe('React', () => {
         }
       }
       const TestComponent = connect({
-        foo: computedFactory()
+        foo: computed
       }, {
         methodCalled: 'methodCalled'
       }, TestComponentClass)


### PR DESCRIPTION
```js
connect({
  foo: someComputed,
  foo2: someComputed.props({foo: 'bar'})
})
```

```js
function someAction({state}) {
  state.compute(someComputed)
  state.compute(someComputed.props({foo: 'bar'})
}
```

BREAKING CHANGE:

Use "myComputed" instead of "myComputed()"