### PR TITLE
fix(function-tree): should give unique index for every function in tree

### DIFF
--- a/packages/function-tree/src/FunctionTree.test.js
+++ b/packages/function-tree/src/FunctionTree.test.js
@@ -167,4 +167,26 @@ describe('FunctionTree', () => {
     })
     execute(tree)
   })
+  it('should provide unique index to functions, even though the same', () => {
+    function actionA () {}
+    let count = 0
+    const execute = FunctionTree([
+      function (context, functionDetails) {
+        if (count === 0) {
+          assert.equal(functionDetails.functionIndex, 0)
+        } else {
+          assert.equal(functionDetails.functionIndex, 1)
+        }
+
+        count++
+
+        return context
+      }
+    ])
+    const tree = [
+      actionA,
+      actionA
+    ]
+    execute(tree)
+  })
 })

--- a/packages/function-tree/src/staticTree.js
+++ b/packages/function-tree/src/staticTree.js
@@ -30,7 +30,7 @@ function traverse (functions, item, isChain) {
     const outputs = isChain
     const funcDetails = {
       name: func.displayName || getFunctionName(func),
-      functionIndex: functions.indexOf(func) === -1 ? (functions.push(func) - 1) : functions.indexOf(func),
+      functionIndex: functions.push(func) - 1,
       function: func
     }
     if (outputs) {


### PR DESCRIPTION
It should be possible to identify if the first function is running, this is used by the devtools. When the same function is used multiple times it risks getting index 0, which breaks devtools. This fix makes every function index unique, even though it is the same function.