### PR TITLE
fix: flush on functionEnd, needed because state changes in path-chain…

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -51,6 +51,7 @@ class Controller extends EventEmitter {
 
     this.runTree = new FunctionTree(allProviders)
     this.runTree.on('asyncFunction', () => this.flush())
+    this.runTree.on('functionEnd', () => this.flush())
     this.runTree.on('end', () => this.flush())
 
     if (this.devtools) {


### PR DESCRIPTION
… did not work

eg.
```
...
GetData,
        {
          success: [
            set(state`data`, input`result`),
...
```
-> Component depending on state.data did not rerender