### PR TITLE
fix(Model): fix unset to flush the path changes up to the removed key

### DIFF
--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -205,6 +205,7 @@ class Model {
     })
   }
   unset (path) {
+    this.changedPaths.push(path.slice())
     const key = path.pop()
 
     this.updateIn(path, (obj) => {

--- a/packages/cerebral/src/Model.test.js
+++ b/packages/cerebral/src/Model.test.js
@@ -114,6 +114,15 @@ describe('Model', () => {
       model.unset(['foo'])
       assert.deepEqual(model.get(), {})
     })
+    it('should flush unset paths', () => {
+      const model = new Model({
+        foo: {
+          bar: 'value'
+        }
+      })
+      model.unset(['foo', 'bar'])
+      assert.deepEqual(model.flush(), {foo: {bar: true}})
+    })
   })
   describe('CONCAT', () => {
     it('should be able to concat array', () => {


### PR DESCRIPTION
```js
model.unset(['foo', 'bar'])
```

Should notify changes like

```js
{foo: {bar: true}}
```

not

```js
{foo: true}
```