### PR TITLE
feat(Views): add ability to inject props to component

### DIFF
--- a/packages/cerebral/src/inferno/connect.js
+++ b/packages/cerebral/src/inferno/connect.js
@@ -1,19 +1,23 @@
 import HOC from './hoc'
 
-export default function connect (paths, passedSignals, passedComponent) {
+export default function connect (paths, passedSignals, injectedProps, passedComponent) {
   let component = passedComponent
   let signals = passedSignals
+  let props = injectedProps
 
-  if (arguments.length === 2) {
+  if (arguments.length === 3) {
+    component = props
+    props = null
+  } else if (arguments.length === 2) {
     component = signals
     signals = null
   }
 
   if (!component) {
     return function (decoratedComponent) {
-      return process.env.NODE_ENV === 'test' ? decoratedComponent : HOC(paths, signals, decoratedComponent)
+      return process.env.NODE_ENV === 'test' ? decoratedComponent : HOC(paths, signals, props, decoratedComponent)
     }
   }
 
-  return process.env.NODE_ENV === 'test' ? component : HOC(paths, signals, component)
+  return process.env.NODE_ENV === 'test' ? component : HOC(paths, signals, props, component)
 }

--- a/packages/cerebral/src/react/connect.js
+++ b/packages/cerebral/src/react/connect.js
@@ -1,19 +1,23 @@
 import HOC from './hoc'
 
-export default function connect (paths, passedSignals, passedComponent) {
+export default function connect (paths, passedSignals, injectedProps, passedComponent) {
   let component = passedComponent
   let signals = passedSignals
+  let props = injectedProps
 
-  if (arguments.length === 2) {
+  if (arguments.length === 3) {
+    component = props
+    props = null
+  } else if (arguments.length === 2) {
     component = signals
     signals = null
   }
 
   if (!component) {
     return function (decoratedComponent) {
-      return process.env.NODE_ENV === 'test' ? decoratedComponent : HOC(paths, signals, decoratedComponent)
+      return process.env.NODE_ENV === 'test' ? decoratedComponent : HOC(paths, signals, props, decoratedComponent)
     }
   }
 
-  return process.env.NODE_ENV === 'test' ? component : HOC(paths, signals, component)
+  return process.env.NODE_ENV === 'test' ? component : HOC(paths, signals, props, component)
 }

--- a/packages/cerebral/src/react/react.test.js
+++ b/packages/cerebral/src/react/react.test.js
@@ -284,6 +284,23 @@ describe('React', () => {
       component.callSignal()
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar2 computed')
     })
+    it('should be able to inject props', () => {
+      const controller = Controller({})
+      const TestComponent = connect({}, {}, {
+        foo: 'bar'
+      }, (props) => {
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+    })
     describe('STRICT render update', () => {
       it('should not update when parent path changes', () => {
         let renderCount = 0

--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -2,12 +2,13 @@ import {Computed} from './../Computed'
 import {cleanPath, propsDiffer} from './../utils'
 
 export default (View) => {
-  return function HOC (paths, signals, Component) {
+  return function HOC (paths, signals, injectedProps, Component) {
     class CerebralComponent extends View.Component {
       constructor (props) {
         super(props)
         this.evaluatedPaths = this.getStatePaths(props)
         this.signals = signals
+        this.injectedProps = injectedProps
         this.Component = Component
         this.depsMap = this.getDepsMap()
       }
@@ -86,6 +87,14 @@ export default (View) => {
 
           propsToPass = Object.keys(extractedSignals).reduce((currentProps, key) => {
             currentProps[key] = controller.getSignal(extractedSignals[key])
+
+            return currentProps
+          }, propsToPass)
+        }
+
+        if (this.injectedProps) {
+          propsToPass = Object.keys(this.injectedProps).reduce((currentProps, key) => {
+            currentProps[key] = this.injectedProps[key]
 
             return currentProps
           }, propsToPass)


### PR DESCRIPTION
Added new signature:

```js
connect({/*paths*/}, {/*signals*/}, {/*props*/}, () => {})
```

Allows you to add arbitrary props passed into component.