### PR TITLE
feat(Devtools): throw error in strict mode when replacing paths

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -1,7 +1,7 @@
 import FunctionTree from 'function-tree'
 import Module from './Module'
 import Model from './Model'
-import {ensurePath, isDeveloping, throwError, isSerializable} from './utils'
+import {ensurePath, isDeveloping, throwError, isSerializable, verifyStrictRender} from './utils'
 import VerifyInputProvider from './providers/VerifyInput'
 import StateProvider from './providers/State'
 import DebuggerProvider from './providers/Debugger'
@@ -75,6 +75,9 @@ class Controller extends EventEmitter {
       computedsAboutToBecomeDirty = computedDependencyStore.getAllUniqueEntities()
     } else if (this.strictRender) {
       computedsAboutToBecomeDirty = computedDependencyStore.getStrictUniqueEntities(changes)
+      if (Boolean(this.devtools) && this.devtools.verifyStrictRender) {
+        verifyStrictRender(changes, computedDependencyStore.map)
+      }
     } else {
       computedsAboutToBecomeDirty = computedDependencyStore.getUniqueEntities(changes)
     }

--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -165,14 +165,10 @@ class Model {
   merge (path, value) {
     this.checkValue(value, path)
 
-    // We want to show changes to added keys, as this is pretty
-    // much like setting multiple keys. More predictable
-    Object.keys(value).forEach((key) => {
-      this.changedPaths.push(path.concat(key))
-    })
-    this.updateIn(path, (obj) => {
-      return Object.assign(obj, value)
-    })
+    // We want this to behave like setting multiple keys
+    for (let prop in value) {
+      this.set(path.concat(prop), value[prop])
+    }
   }
   pop (path) {
     this.updateIn(path, (array) => {

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -7,11 +7,12 @@ const VERSION = 'v1'
   - Stores data related to time travel, if activated
 */
 class Devtools {
-  constructor (options = {storeMutations: true, preventExternalMutations: true, enforceSerializable: true}) {
+  constructor (options = {storeMutations: true, preventExternalMutations: true, enforceSerializable: true, verifyStrictRender: true}) {
     this.VERSION = VERSION
     this.storeMutations = options.storeMutations
     this.preventExternalMutations = options.preventExternalMutations
     this.enforceSerializable = options.enforceSerializable
+    this.strictPathReplaceError = options.verifyStrictRender
     this.backlog = []
     this.mutations = []
     this.latestExecutionId = null

--- a/packages/cerebral/src/react/react.test.js
+++ b/packages/cerebral/src/react/react.test.js
@@ -6,6 +6,8 @@ const jsdom = require('jsdom')
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
 global.window = document.defaultView
 global.navigator = {userAgent: 'node.js'}
+global.CustomEvent = global.window.CustomEvent = () => {}
+global.window.dispatchEvent = () => {}
 
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
@@ -442,6 +444,45 @@ describe('React', () => {
         const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
         component.callSignal()
         assert.equal(renderCount, 2)
+      })
+      it('should throw error with devtools when replacing path, causing render not to happen', () => {
+        const controller = Controller({
+          strictRender: true,
+          devtools: {init () {}, send () {}},
+          state: {
+            foo: {
+              bar: 'baz'
+            }
+          },
+          signals: {
+            methodCalled: [({state}) => state.set('foo', 'bar')]
+          }
+        })
+        class TestComponentClass extends React.Component {
+          callSignal () {
+            this.props.methodCalled()
+          }
+          render () {
+            return (
+              <div>{this.props.foo}</div>
+            )
+          }
+        }
+        const TestComponent = connect({
+          foo: 'foo.bar'
+        }, {
+          methodCalled: 'methodCalled'
+        }, TestComponentClass)
+        const tree = TestUtils.renderIntoDocument((
+          <Container controller={controller}>
+            <TestComponent />
+          </Container>
+        ))
+        assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
+        const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
+        assert.throws(() => {
+          component.callSignal()
+        })
       })
     })
     describe('DEFAULT render update', () => {

--- a/packages/cerebral/src/utils.js
+++ b/packages/cerebral/src/utils.js
@@ -72,3 +72,21 @@ export function isDebuggerEnv () {
     )
   )
 }
+
+export function verifyStrictRender (changes, dependencyMap) {
+  let currentPathKey = []
+  for (let path in dependencyMap) {
+    const pathArray = cleanPath(path).split('.')
+    let currentChangeKey = pathArray.shift()
+    let currentChangePath = changes
+    currentPathKey.push(currentChangeKey)
+    while (currentChangePath) {
+      if (currentChangePath[currentChangeKey] === true && pathArray.length !== 0) {
+        throwError(`You are in strict mode and path "${path}" is being replaced by "${currentPathKey.join('.')}". Change "${path}" to "${currentPathKey.join('.')}" or do not replace the path`)
+      }
+      currentPathKey.push(currentChangeKey)
+      currentChangePath = currentChangePath[pathArray.shift()]
+    }
+    currentPathKey.length = 0
+  }
+}

--- a/packages/cerebral/src/viewFactories/Container.js
+++ b/packages/cerebral/src/viewFactories/Container.js
@@ -1,6 +1,6 @@
 /* global CustomEvent */
 import DependencyStore from '../DependencyStore'
-import {ensurePath} from '../utils'
+import {ensurePath, verifyStrictRender} from '../utils'
 
 export default (View) => {
   class Container extends View.Component {
@@ -38,7 +38,7 @@ export default (View) => {
     componentDidMount () {
       this.props.controller && this.props.controller.on('flush', this.onCerebralUpdate)
 
-      if (this.hasDevtools()) {
+      if (this.hasDevtools() && this.props.controller.devtools.verifyStrictRender) {
         const event = new CustomEvent('cerebral2.client.message', {
           detail: JSON.stringify({
             type: 'components',
@@ -92,6 +92,9 @@ export default (View) => {
         componentsToRender = this.dependencyStore.getAllUniqueEntities()
       } else if (this.props.controller.strictRender) {
         componentsToRender = this.dependencyStore.getStrictUniqueEntities(changes)
+        if (this.hasDevtools()) {
+          verifyStrictRender(changes, this.dependencyStore.map)
+        }
       } else {
         componentsToRender = this.dependencyStore.getUniqueEntities(changes)
       }


### PR DESCRIPTION
After quite a few discussions I have implemented an error when using strict mode and replacing paths, causing components/computed not to update.

It happens when:

```js
{
  foo: {
    bar: 'baz'
  }
}
```

You depend on path `foo.bar` and you do a `state.set('foo', {bar: 'baz2', wip: 'wop'})`. Whatever depends on `foo.bar` will not update because there was no change to that path. Now this throws an error encouraging you to depend on path `foo` instead, as it can be replaced.

Strict mode should not render children automatically because that is exactly what strict mode should not, it will break its most important optimization. We also investigated API extension like `foo.<.bar`... but this is taking it too far. It is better to adjust to strict modes special requirements to keep optimized UI. In our Ducky project we did not even meet the issue, so it is also considered an edge case.