### PR TITLE
feat(Devtools): dependencyStore usage refactored

### DIFF
--- a/packages/cerebral-todomvc/src/controller.js
+++ b/packages/cerebral-todomvc/src/controller.js
@@ -6,7 +6,7 @@ import App from './modules/app'
 import Recorder from './modules/recorder'
 
 const controller = Controller({
-  strictRender: true,
+  options: {strictRender: true},
   devtools: Devtools(),
   router: Router({
     onlyHash: true,

--- a/packages/cerebral/src/Computed.test.js
+++ b/packages/cerebral/src/Computed.test.js
@@ -146,7 +146,7 @@ describe('Computed', () => {
     })
     it('should handle strict path updates', () => {
       const controller = Controller({
-        strictRender: true,
+        options: {strictRender: true},
         state: {
           foo: {
             bar: 'woop'

--- a/packages/cerebral/src/operators/merge.js
+++ b/packages/cerebral/src/operators/merge.js
@@ -11,7 +11,11 @@ export default function (targetTemplate, valueTemplate) {
       throw new Error('Cerebral operator.merge: You have to use a state template tag as first argument')
     }
 
-    context.state.merge(target.path, value)
+    context.state.merge(target.path, Object.keys(value).reduce((currentValue, key) => {
+      currentValue[key] = typeof value[key] === 'function' ? value[key](context).toValue() : value[key]
+
+      return currentValue
+    }, {}))
   }
 
   merge.displayName = 'operator.merge'

--- a/packages/cerebral/src/react/react.test.js
+++ b/packages/cerebral/src/react/react.test.js
@@ -307,7 +307,7 @@ describe('React', () => {
       it('should not update when parent path changes', () => {
         let renderCount = 0
         const controller = Controller({
-          strictRender: true,
+          options: {strictRender: true},
           state: {
             foo: {
               bar: 'baz'
@@ -346,7 +346,7 @@ describe('React', () => {
       it('should not update when child path changes', () => {
         let renderCount = 0
         const controller = Controller({
-          strictRender: true,
+          options: {strictRender: true},
           state: {
             foo: {
               bar: 'baz'
@@ -385,7 +385,7 @@ describe('React', () => {
       it('should update when immediate child interest defined', () => {
         let renderCount = 0
         const controller = Controller({
-          strictRender: true,
+          options: {strictRender: true},
           state: {
             foo: {
               bar: 'baz'
@@ -424,7 +424,7 @@ describe('React', () => {
       it('should update when nested children interest defined', () => {
         let renderCount = 0
         const controller = Controller({
-          strictRender: true,
+          options: {strictRender: true},
           state: {
             foo: {
               bar: {
@@ -464,8 +464,8 @@ describe('React', () => {
       })
       it('should throw error with devtools when replacing path, causing render not to happen', () => {
         const controller = Controller({
-          strictRender: true,
-          devtools: {init () {}, send () {}},
+          options: {strictRender: true},
+          devtools: {init () {}, send () {}, updateComponentsMap () {}},
           state: {
             foo: {
               bar: 'baz'

--- a/packages/cerebral/src/utils.js
+++ b/packages/cerebral/src/utils.js
@@ -90,3 +90,18 @@ export function verifyStrictRender (changes, dependencyMap) {
     currentPathKey.length = 0
   }
 }
+
+export function debounce (func, wait) {
+  let timeout
+
+  return function (...args) {
+    const context = this
+    const later = () => {
+      timeout = null
+      func.apply(context, args)
+    }
+
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+  }
+}

--- a/packages/cerebral/src/viewFactories/Container.js
+++ b/packages/cerebral/src/viewFactories/Container.js
@@ -1,18 +1,24 @@
-/* global CustomEvent */
-import DependencyStore from '../DependencyStore'
-import {ensurePath, verifyStrictRender} from '../utils'
+import {ensurePath} from '../utils'
 
 export default (View) => {
   class Container extends View.Component {
     constructor (props) {
       super(props)
-      this.dependencyStore = new DependencyStore()
-      this.debuggerComponentsMap = {}
-      this.debuggerComponentDetailsId = 1
-      this.registerComponent = this.registerComponent.bind(this)
-      this.unregisterComponent = this.unregisterComponent.bind(this)
-      this.updateComponent = this.updateComponent.bind(this)
-      this.onCerebralUpdate = this.onCerebralUpdate.bind(this)
+      this.registerComponent = (
+        props.controller
+        ? this.registerComponent.bind(this)
+        : () => {}
+      )
+      this.unregisterComponent = (
+        props.controller
+        ? this.unregisterComponent.bind(this)
+        : () => {}
+      )
+      this.updateComponent = (
+        props.controller
+        ? this.updateComponent.bind(this)
+        : () => {}
+      )
     }
     getChildContext () {
       const controller = (
@@ -30,28 +36,6 @@ export default (View) => {
     }
     hasDevtools () {
       return Boolean(this.props.controller && this.props.controller.devtools)
-    }
-    /*
-      The container will listen to "flush" events from the controller
-      and send an event to debugger about initial registered components
-    */
-    componentDidMount () {
-      this.props.controller && this.props.controller.on('flush', this.onCerebralUpdate)
-
-      if (this.hasDevtools() && this.props.controller.devtools.verifyStrictRender) {
-        const event = new CustomEvent('cerebral2.client.message', {
-          detail: JSON.stringify({
-            type: 'components',
-            data: {
-              map: this.debuggerComponentsMap,
-              render: {
-                components: []
-              }
-            }
-          })
-        })
-        window.dispatchEvent(event)
-      }
     }
     /*
       When testing and running on the server there is no need to
@@ -72,120 +56,25 @@ export default (View) => {
         }
       }
     }
-    /*
-      The container will listen to "flush" events from the controller
-      and send an event to debugger about initial registered components
-    */
-    extractComponentName (component) {
-      return component.constructor.displayName.replace('CerebralWrapping_', '')
-    }
-    /*
-      On "flush" event use changes to extract affected components
-      from dependency store and render them. If debugger is attached
-      the current components map is passed with a timeout due to waiting
-      for all components to update
-    */
-    onCerebralUpdate (changes, force) {
-      let componentsToRender = []
-
-      if (force) {
-        componentsToRender = this.dependencyStore.getAllUniqueEntities()
-      } else if (this.props.controller.strictRender) {
-        componentsToRender = this.dependencyStore.getStrictUniqueEntities(changes)
-        if (this.hasDevtools()) {
-          verifyStrictRender(changes, this.dependencyStore.map)
-        }
-      } else {
-        componentsToRender = this.dependencyStore.getUniqueEntities(changes)
-      }
-
-      const start = Date.now()
-      componentsToRender.forEach((component) => {
-        if (this.hasDevtools()) {
-          this.updateDebuggerComponentsMap(component)
-        }
-        component._update(force)
-      })
-      const end = Date.now()
-
-      if (this.hasDevtools() && componentsToRender.length) {
-        setTimeout(() => {
-          const event = new CustomEvent('cerebral2.client.message', {
-            detail: JSON.stringify({
-              type: 'components',
-              data: {
-                map: this.debuggerComponentsMap,
-                render: {
-                  start: start,
-                  duration: end - start,
-                  changes: changes,
-                  components: componentsToRender.map(this.extractComponentName)
-                }
-              }
-            })
-          })
-          window.dispatchEvent(event)
-        }, 50)
-      }
-    }
     registerComponent (component, depsMap) {
-      this.dependencyStore.addEntity(component, depsMap)
+      this.props.controller.componentDependencyStore.addEntity(component, depsMap)
       if (this.hasDevtools()) {
-        this.updateDebuggerComponentsMap(component, depsMap)
+        this.props.controller.devtools.updateComponentsMap(component, depsMap)
       }
     }
     unregisterComponent (component, depsMap) {
-      this.dependencyStore.removeEntity(component, depsMap)
+      this.props.controller.componentDependencyStore.removeEntity(component, depsMap)
       if (this.hasDevtools()) {
-        this.updateDebuggerComponentsMap(component, null, depsMap)
+        this.props.controller.devtools.updateComponentsMap(component, null, depsMap)
       }
     }
     updateComponent (component, prevDepsMap, depsMap) {
-      this.dependencyStore.removeEntity(component, prevDepsMap)
-      this.dependencyStore.addEntity(component, depsMap)
+      this.props.controller.componentDependencyStore.removeEntity(component, prevDepsMap)
+      this.props.controller.componentDependencyStore.addEntity(component, depsMap)
       if (this.hasDevtools()) {
-        this.updateDebuggerComponentsMap(component, depsMap, prevDepsMap)
+        this.props.controller.devtools.updateComponentsMap(component, depsMap, prevDepsMap)
       }
       component._update()
-    }
-    /*
-      Updates the map the represents what active state paths and
-      components are in your app. Used by the debugger
-    */
-    updateDebuggerComponentsMap (component, nextDeps, prevDeps) {
-      const componentDetails = {
-        name: this.extractComponentName(component),
-        renderCount: component.renderCount ? component.renderCount + 1 : 1,
-        id: component.componentDetailsId || this.debuggerComponentDetailsId++
-      }
-      component.componentDetailsId = componentDetails.id
-      component.renderCount = componentDetails.renderCount
-
-      if (prevDeps) {
-        for (const depsKey in prevDeps) {
-          const debuggerComponents = this.debuggerComponentsMap[prevDeps[depsKey]]
-
-          for (let x = 0; x < debuggerComponents.length; x++) {
-            if (debuggerComponents[x].id === component.componentDetailsId) {
-              debuggerComponents.splice(x, 1)
-              if (debuggerComponents.length === 0) {
-                delete this.debuggerComponentsMap[prevDeps[depsKey]]
-              }
-              break
-            }
-          }
-        }
-      }
-
-      if (nextDeps) {
-        for (const depsKey in nextDeps) {
-          this.debuggerComponentsMap[nextDeps[depsKey]] = (
-            this.debuggerComponentsMap[nextDeps[depsKey]]
-              ? this.debuggerComponentsMap[nextDeps[depsKey]].concat(componentDetails)
-              : [componentDetails]
-          )
-        }
-      }
     }
     render () {
       return this.props.children


### PR DESCRIPTION
- components dependency store now in controller (allows multiple Container)
- Debugger logic for components moved into devtools
- Only verifyStrict on components as computeds are attached to components, no need for double check
- Fixed issue with merge, missing functionality (allowing template tags on merged prop values)
- Added `options` to controller for `strictRender`, more options coming

fixes #391 