### PR TITLE
feat(Views): give option to expose the signals prop from c1

### DIFF
--- a/packages/cerebral/src/react/react.test.js
+++ b/packages/cerebral/src/react/react.test.js
@@ -123,6 +123,38 @@ describe('React', () => {
         </Container>
       ))
     })
+    it('should expose signals prop with an option', () => {
+      const controller = Controller({
+        options: {signalsProp: true},
+        state: {
+          foo: 'bar'
+        },
+        signals: {
+          someSignal: []
+        },
+        modules: {
+          moduleA: {
+            signals: {
+              someOtherSignal: []
+            }
+          }
+        }
+      })
+      const TestComponent = connect({
+        foo: 'foo'
+      }, (props) => {
+        assert.ok(props.signals.someSignal)
+        assert.ok(props.signals.moduleA.someOtherSignal)
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent />
+        </Container>
+      ))
+    })
     it('should rerender on state update', () => {
       const controller = Controller({
         state: {

--- a/packages/cerebral/src/viewFactories/Container.js
+++ b/packages/cerebral/src/viewFactories/Container.js
@@ -45,6 +45,7 @@ export default (View) => {
     */
     createDummyController (state = {}) {
       return {
+        options: {},
         on () {},
         getState (path) {
           return ensurePath(path).reduce((currentState, pathKey) => {


### PR DESCRIPTION
After discussions with @schotime we decided to just add an option for exposing the `signals` prop. Going all in with a generic extension API is just too much now. We can refactor this later if we decide to do something like that. But for now it is enough with this option.