### PR TITLE
feat(Operators): add string template tag

### DIFF
--- a/packages/cerebral/src/operators/index.js
+++ b/packages/cerebral/src/operators/index.js
@@ -5,6 +5,7 @@ export {default as wait} from './wait'
 
 export {default as state} from './state'
 export {default as input} from './input'
+export {default as string} from './string'
 
 export {default as concat} from './concat'
 export {default as merge} from './merge'

--- a/packages/cerebral/src/operators/state.test.js
+++ b/packages/cerebral/src/operators/state.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import Controller from '../Controller'
 import assert from 'assert'
-import {input, state} from './'
+import {state, string} from './'
 
 describe('operator.state', () => {
   it('should build path', () => {
@@ -11,8 +11,8 @@ describe('operator.state', () => {
       },
       signals: {
         test: [
-          () => {
-            assert.deepEqual(state`foo.${input`ref`}`({input: {ref: 'bar'}}).path, 'foo.bar')
+          (context) => {
+            assert.deepEqual(string`foo.${state`foo`}`(context).toValue(), 'foo.bar')
           }
         ]
       }

--- a/packages/cerebral/src/operators/string.js
+++ b/packages/cerebral/src/operators/string.js
@@ -1,0 +1,16 @@
+import populatePath from './helpers/populatePath'
+
+export default function string (strings, ...values) {
+  return (context) => {
+    const target = 'string'
+    const path = populatePath(context, strings, values)
+
+    return {
+      target,
+      path,
+      toValue () {
+        return path
+      }
+    }
+  }
+}

--- a/packages/cerebral/src/operators/string.test.js
+++ b/packages/cerebral/src/operators/string.test.js
@@ -3,17 +3,17 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {input, string} from './'
 
-describe('operator.input', () => {
-  it('should read value from input', () => {
+describe('operator.string', () => {
+  it('should build path', () => {
     const controller = new Controller({
       signals: {
         test: [
           (context) => {
-            assert.deepEqual(string`foo.${input`foo`}`(context).toValue(), 'foo.bar')
+            assert.deepEqual(string`foo.${input`ref`}`(context).toValue(), 'foo.bar')
           }
         ]
       }
     })
-    controller.getSignal('test')({foo: 'bar'})
+    controller.getSignal('test')({ref: 'bar'})
   })
 })


### PR DESCRIPTION
We need a tag template which just becomes a string. This will probably be the most useful tag template for app specific factories:

```js
showToast(string`Wow, awesome, ${state`user.name`}`)
```

Now you only need to check if argument is function and call it with `.toValue()` behind to extract and of these templates.

I am open to change the name, though `string` is generic and explicit.