### PR TITLE
feat(Operators): allow operator template literals to use computed

### DIFF
--- a/packages/cerebral/src/operators/helpers/populatePath.js
+++ b/packages/cerebral/src/operators/helpers/populatePath.js
@@ -1,7 +1,10 @@
 export default function populatePath (context, strings, values) {
   return strings.reduce((currentPath, string, idx) => {
     const valueTemplate = values[idx]
-    const value = valueTemplate ? valueTemplate(context).toValue() : ''
-    return currentPath + string + value
+    if (valueTemplate && valueTemplate.getValue) {
+      return currentPath + string + context.state.compute(valueTemplate)
+    }
+
+    return currentPath + string + (valueTemplate ? valueTemplate(context).toValue() : '')
   }, '')
 }

--- a/packages/cerebral/src/operators/string.test.js
+++ b/packages/cerebral/src/operators/string.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import Controller from '../Controller'
 import assert from 'assert'
+import {Computed} from '../'
 import {input, string} from './'
 
 describe('operator.string', () => {
@@ -10,6 +11,24 @@ describe('operator.string', () => {
         test: [
           (context) => {
             assert.deepEqual(string`foo.${input`ref`}`(context).toValue(), 'foo.bar')
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')({ref: 'bar'})
+  })
+  it('should allow computed in template literal', () => {
+    const computed = Computed({
+      foo: 'foo'
+    }, (props) => props.foo)
+    const controller = new Controller({
+      state: {
+        foo: 'bar'
+      },
+      signals: {
+        test: [
+          (context) => {
+            assert.deepEqual(string`foo.${computed}`(context).toValue(), 'foo.bar')
           }
         ]
       }


### PR DESCRIPTION
Now we can use computed in template literals:

```js
showSomething(string`You got ${totalUserScore} points!`)
```