### PR TITLE
Fix controller init

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -69,6 +69,7 @@ class Controller extends EventEmitter {
 
     if (this.router) this.router.init()
 
+    this.model.flush()
     this.emit('initialized')
   }
   /*

--- a/packages/cerebral/src/Controller.test.js
+++ b/packages/cerebral/src/Controller.test.js
@@ -163,4 +163,16 @@ describe('Controller', () => {
     })
     controller.getSignal('test')()
   })
+  it('should flush model after module initialization', () => {
+    const controller = new Controller({
+      modules: {
+        editor: {
+          state: {
+            this: 'that'
+          }
+        }
+      }
+    })
+    assert.deepEqual(controller.model.flush(), {})
+  })
 })

--- a/packages/cerebral/src/operators/equals.test.js
+++ b/packages/cerebral/src/operators/equals.test.js
@@ -3,7 +3,7 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {input, state, equals} from './'
 
-describe('operators.equals', () => {
+describe('operator.equals', () => {
   it('should go down path based on input', () => {
     let count = 0
     const controller = new Controller({

--- a/packages/cerebral/src/operators/unset.test.js
+++ b/packages/cerebral/src/operators/unset.test.js
@@ -3,7 +3,7 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {input, state, unset} from './'
 
-describe('operators.unset', () => {
+describe('operator.unset', () => {
   it('should unset value in model', () => {
     const controller = new Controller({
       state: {

--- a/packages/cerebral/src/operators/unshift.test.js
+++ b/packages/cerebral/src/operators/unshift.test.js
@@ -3,7 +3,7 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {input, state, unshift} from './'
 
-describe('operators.unshift', () => {
+describe('operator.unshift', () => {
   it('should unshift value in model', () => {
     const controller = new Controller({
       state: {

--- a/packages/cerebral/src/operators/wait.test.js
+++ b/packages/cerebral/src/operators/wait.test.js
@@ -3,7 +3,7 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {wait} from './'
 
-describe('operators.wait', () => {
+describe('operator.wait', () => {
   it('should hold execution for set time', (done) => {
     const start = Date.now()
     const controller = new Controller({

--- a/packages/cerebral/src/operators/when.test.js
+++ b/packages/cerebral/src/operators/when.test.js
@@ -3,7 +3,7 @@ import Controller from '../Controller'
 import assert from 'assert'
 import {input, state, when} from './'
 
-describe('operators.when', () => {
+describe('operator.when', () => {
   it('should check truthy value of input', () => {
     let count = 0
     const controller = new Controller({


### PR DESCRIPTION
Initial model state should be "no changes" or on first action run, the changes are checked and debugger may wrongly throw "you are changing 'foo' in strict mode". Problem is module initial state set.