### PR TITLE
feat(Operators): add input to set and document operator tags

### DIFF
--- a/packages/cerebral/src/operators/set.js
+++ b/packages/cerebral/src/operators/set.js
@@ -7,11 +7,17 @@ export default function (target, value) {
     const targetTemplate = target(context)
     const setValue = typeof value === 'function' ? value(context).value : value
 
-    if (targetTemplate.target !== 'state') {
-      throw new Error('Cerebral operator.set: You have to use a state template tag as first argument')
+    if (targetTemplate.target !== 'state' && targetTemplate.target !== 'input') {
+      throw new Error('Cerebral operator.set: You have to use a state or input operator tag as first argument')
     }
 
-    context.state.set(targetTemplate.path, setValue)
+    if (targetTemplate.target === 'state') {
+      context.state.set(targetTemplate.path, setValue)
+    } else {
+      return {
+        [targetTemplate.path]: setValue
+      }
+    }
   }
 
   set.displayName = 'operator.set'

--- a/packages/cerebral/src/operators/set.test.js
+++ b/packages/cerebral/src/operators/set.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import Controller from '../Controller'
 import assert from 'assert'
-import {input, set, state} from './'
+import {input, string, set, state} from './'
 
 describe('operator.set', () => {
   it('should set value to model', () => {
@@ -17,6 +17,19 @@ describe('operator.set', () => {
     })
     controller.getSignal('test')()
     assert.deepEqual(controller.getState(), {foo: 'bar2'})
+  })
+  it('should set value to input', () => {
+    const controller = new Controller({
+      signals: {
+        test: [
+          set(input`foo`, 'bar'),
+          ({input}) => {
+            assert.equal(input.foo, 'bar')
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
   })
   it('should set non string value to model', () => {
     const controller = new Controller({
@@ -69,7 +82,7 @@ describe('operator.set', () => {
       },
       signals: {
         test: [
-          set(input`foo`, 'bar')
+          set(string`foo`, 'bar')
         ]
       }
     })

--- a/packages/docs/content/api/05_operators.en.md
+++ b/packages/docs/content/api/05_operators.en.md
@@ -3,48 +3,31 @@ title: Operators
 ---
 
 ## Operators
-Operators are function factories that returns an action. These allows you to do common things like updating state and control the flow.
+You can call operators to create actions for you. These actions will help you change state and control the flow of execution.
 
-### Template tags
-When using operators you typically use a lot of template tags. These template tags are plain JavaScript which is used to target and extract data. The tree template tags available are:
+### Operator tags
+When using operators you want to express dynamic behavior. For example changing some state based on the input. Operator tags helps you express this. There are three operator tags available, **state**, **input** and **string**.
 
-```js
-import {set, state, input} from 'cerebral/operators'
+There are two parts to operator tags. A target, and a template. The target tells the operator what to use the template for. And the template resolves to a string, for whatever purpose. Usually it is a path to the state tree, or some value on an input, but it could be anything.
 
-// Example with state
-[
-  set(state`foo`, 'bar')
-]
-
-// Example with state and input
-[
-  set(state`foo`, input`foo`)
-]
-```
-
-The template tags can be inlined, allowing you to do things like:
+For example:
 
 ```js
-import {set, state, input} from 'cerebral/operators'
-
-[
-  set(state`users.${input`userId`}.isAwesome`, true)
-]
+state`foo.bar`
 ```
 
-It is also possible to use computed inline with template tags. For example:
+State is the target and "foo.bar" is the template. What this target and template is used for is decided by the operator.
+
+Operator tags can also inline other operator tags. For example:
 
 ```js
-import {set, state, input} from 'cerebral/operators'
-import someComputed from '../computeds/someComputed'
-
-[
-  set(state`foo.${someComputed}`, true)
-]
+state`users.${input`userId`}`
 ```
+
+There is nothing magic about this, it is pure JavaScript and super helpful expressing your business logic.
 
 ### State operators
-The methods available on **state** inside actions is also available as operators to make simple state changes. All these operators supports using **input** as value, where available.
+The methods for changing state within actions is also available as operators. All state operators supports using both **state** and **input** operator tags as values.
 
 ```js
 import {
@@ -65,6 +48,9 @@ import {
 export default [
   // Set some state
   set(state`foo.bar`, true)
+
+  // Set some input
+  set(input`foo`, true)
 
   // Unset key from object
   unset(state`users.user0`),
@@ -172,14 +158,14 @@ function showNotificationFactory(message, ms) {
 Wherever this **showNofication** factory is used, in whatever signal, it will cancel out any other. This makes sure that notifications are always shown at the set time, no matter what existing notification is already there.
 
 ### Custom operators
-You can easily create your own operators and use the template tags. Here showing the implementation of **set**
+You can easily create your own operators and use the operator tags. Here showing the implementation of **set**
 
 ```js
 function setFactory(target, value) {
   function set(context) {
-    // Returns an object with type of template tag, the path
+    // Returns an object with type of operator tag, the path
     // it resolves to and any value it resolves to. So given
-    // state {foo: 'bar'}, the template tag: state`foo` resolves
+    // state {foo: 'bar'}, the operator tag: state`foo` resolves
     // to {target: 'state', path: 'foo', value: 'bar'}
     const targetTemplate = target(context)
 
@@ -188,9 +174,9 @@ function setFactory(target, value) {
       throw new Error('You have to target state when merging')
     }
 
-    // Since we allow both using a template tag or a hardcoded value
-    // we check if it is a function, which means it is a template tag.
-    // Then we either grab the value from the template tag or the value
+    // Since we allow both using an operator tag or a hardcoded value
+    // we check if it is a function, which means it is an operator tag.
+    // Then we either grab the value from the operator tag or the value
     // passed in
     const setValue = typeof value === 'function' ? value(context).value : value
 
@@ -201,7 +187,7 @@ function setFactory(target, value) {
 }
 ```
 
-Custom operators often wants to extract paths, though not necessarily related to state or input. That is why we have template tag **string**:
+Custom operators often wants to extract paths, though not necessarily related to state or input. That is why we have operator tag **string**.
 
 ```js
 import {string} from 'cerebral/operators'


### PR DESCRIPTION
Okay, I played around with different syntax. But I think we should rather explain better how "operator tags" work... cause now the syntax is very familiar and it makes sense. Keeping the `string` operator for short.