### PR TITLE
feat(Devtools): show warning on big components

### DIFF
--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -15,7 +15,11 @@ class Devtools {
     preventExternalMutations: true,
     enforceSerializable: true,
     verifyStrictRender: true,
-    preventInputPropReplacement: false
+    preventInputPropReplacement: false,
+    bigComponentsWarning: {
+      state: 5,
+      signals: 5
+    }
   }) {
     this.VERSION = VERSION
     this.debuggerComponentsMap = {}
@@ -25,6 +29,7 @@ class Devtools {
     this.enforceSerializable = Boolean(options.enforceSerializable)
     this.verifyStrictRender = Boolean(options.verifyStrictRender)
     this.preventInputPropReplacement = Boolean(options.preventInputPropReplacement)
+    this.bigComponentsWarning = options.bigComponentsWarning
     this.backlog = []
     this.mutations = []
     this.latestExecutionId = null

--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -83,9 +83,24 @@ export default (View) => {
           return currentProps
         }, {}))
 
+        if (
+          this.context.cerebral.controller.devtools &&
+          this.context.cerebral.controller.devtools.bigComponentsWarning &&
+          Object.keys(propsToPass).length >= this.context.cerebral.controller.devtools.bigComponentsWarning.state
+        ) {
+          console.warn(`Component named ${Component.displayName || Component.name} has a lot of state dependencies, consider refactoring. Adjust this option in devtools`)
+        }
+
         if (this.signals) {
           const extractedSignals = typeof signals === 'function' ? signals(propsToPass) : signals
 
+          if (
+            this.context.cerebral.controller.devtools &&
+            this.context.cerebral.controller.devtools.bigComponentsWarning &&
+            Object.keys(extractedSignals).length >= this.context.cerebral.controller.devtools.bigComponentsWarning.signals
+          ) {
+            console.warn(`Component named ${Component.displayName || Component.name} has a lot of signals, consider refactoring. Adjust this option in devtools`)
+          }
           propsToPass = Object.keys(extractedSignals).reduce((currentProps, key) => {
             currentProps[key] = controller.getSignal(extractedSignals[key])
 

--- a/packages/docs/content/getting-real/03_devtools.en.md
+++ b/packages/docs/content/getting-real/03_devtools.en.md
@@ -39,8 +39,11 @@ const controller = Controller({
     enforceSerializable: true,
     // Warnings when strict render path usage is wrong
     verifyStrictRender: true,
-    //Throw error when overwriting existing input property
-    preventInputPropReplacement: false
+    // Throw error when overwriting existing input property
+    preventInputPropReplacement: false,
+    // Shows a warning when you have components with number of state dependencies
+    // or signals above the set number
+    bigComponentsWarning: {state: 5, signals: 5}
   })
 })
 ```


### PR DESCRIPTION
When refactoring we came up with the idea to show a warning if you have more than a set number of state dependencies or signals... helping out splitting up components.