### PR TITLE
fix(tutorial): make sure source folder is not hidden

### DIFF
--- a/packages/tutorial/.gitignore
+++ b/packages/tutorial/.gitignore
@@ -1,2 +1,1 @@
 /public/index.html
-/src


### PR DESCRIPTION
When `src` is part of  `gitignore` it might be hidden by IDEs, it should not do that, very confusing. The SRC folder is built up with chapter 01 when starting up anyways.