### PR TITLE
refactor(forms): merge runValidation and validate

### DIFF
--- a/packages/cerebral-forms/src/factories/resetForm.js
+++ b/packages/cerebral-forms/src/factories/resetForm.js
@@ -2,17 +2,19 @@ import configureField from '../utils/configureField'
 
 function resetObject (form) {
   return Object.keys(form).reduce(function (newForm, key) {
-    if (Array.isArray(form[key])) {
-      newForm[key] = resetArray(form[key])
-    } else if ('value' in form[key]) {
-      const newField = Object.keys(form[key]).reduce((newField, fKey) => {
-        newField[fKey] = form[key][fKey]
-        return newField
-      }, {})
-      newField.value = newField.defaultValue
-      newForm[key] = configureField(form, newField)
-    } else {
-      newForm[key] = resetObject(form[key])
+    if (form[key] === Object(form[key])) {
+      if (Array.isArray(form[key])) {
+        newForm[key] = resetArray(form[key])
+      } else if ('value' in form[key]) {
+        const newField = Object.keys(form[key]).reduce((newField, fKey) => {
+          newField[fKey] = form[key][fKey]
+          return newField
+        }, {})
+        newField.value = newField.defaultValue
+        newForm[key] = configureField(form, newField)
+      } else {
+        newForm[key] = resetObject(form[key])
+      }
     }
 
     return newForm

--- a/packages/cerebral-forms/src/factories/validateField.js
+++ b/packages/cerebral-forms/src/factories/validateField.js
@@ -1,21 +1,4 @@
-import validate from '../utils/validate'
-import checkHasValue from '../utils/checkHasValue'
-
-function runValidation (fieldPath, field, form) {
-  const hasValue = checkHasValue(form, field.value, field.isValueRules)
-  const result = validate(form, field.value, field.validationRules)
-  const isValid = result.isValid && (
-    (field.isRequired && hasValue) ||
-    !field.isRequired
-  )
-
-  return {
-    isValid,
-    isPristine: false,
-    hasValue: checkHasValue(form, field.value, field.isValueRules),
-    errorMessage: result.isValid ? null : field.validationMessages[result.failedRuleIndex]
-  }
-}
+import runValidation from '../utils/runValidation'
 
 export default function validateFieldFactory (pathTemplate) {
   function validateField (context) {
@@ -24,7 +7,7 @@ export default function validateFieldFactory (pathTemplate) {
     const formPath = fieldPath.slice().splice(0, fieldPath.length - 1)
     const field = context.state.get(fieldPath)
     const form = context.state.get(formPath)
-    const validationResult = runValidation(fieldPath, field, form)
+    const validationResult = runValidation(field, form)
 
     context.state.merge(fieldPath, validationResult)
 
@@ -45,7 +28,7 @@ export default function validateFieldFactory (pathTemplate) {
         throw new Error(`The path ${stringPath} used with "dependsOn" on field ${fieldPath.join('.')} is not correct, please check it`)
       }
 
-      const dependentValidationResult = runValidation(dependentFieldPath, field, form)
+      const dependentValidationResult = runValidation(field, form)
       context.state.merge(dependentFieldPath, dependentValidationResult)
 
       if (currentValidationResult.isValid && !dependentValidationResult.isValid) {

--- a/packages/cerebral-forms/src/factories/validateForm.js
+++ b/packages/cerebral-forms/src/factories/validateForm.js
@@ -1,5 +1,4 @@
-import validate from '../utils/validate'
-import checkHasValue from '../utils/checkHasValue'
+import runValidation from '../utils/runValidation'
 
 export default function validateFormFactory (passedFormPathTemplate) {
   function validateForm (context) {
@@ -12,7 +11,7 @@ export default function validateFormFactory (passedFormPathTemplate) {
         if (Array.isArray(form[key])) {
           validateArray(path.concat(key), form[key])
         } else if ('value' in form[key]) {
-          doValidation(path.concat(key), form, key)
+          context.state.merge(path.concat(key), runValidation(form[key], form))
         } else {
           validateForm(path.concat(key), form[key])
         }
@@ -22,23 +21,6 @@ export default function validateFormFactory (passedFormPathTemplate) {
     function validateArray (path, formArray) {
       formArray.forEach((form, index) => {
         validateForm(path.concat(index), form)
-      })
-    }
-
-    function doValidation (path, form, key) {
-      const field = form[key]
-      const hasValue = checkHasValue(form, field.value, field.isValueRules)
-      const result = validate(form, field.value, field.validationRules)
-      const isValid = result.isValid && (
-        (field.isRequired && hasValue) ||
-        !field.isRequired
-      )
-
-      context.state.merge(path, {
-        isValid: isValid,
-        hasValue: hasValue,
-        errorMessage: isValid ? null : (field.validationMessages && field.validationMessages.length > 0 ? field.validationMessages[result.failedRuleIndex] : null),
-        isPristine: false
       })
     }
 

--- a/packages/cerebral-forms/src/factories/validateForm.js
+++ b/packages/cerebral-forms/src/factories/validateForm.js
@@ -8,12 +8,14 @@ export default function validateFormFactory (passedFormPathTemplate) {
 
     function validateForm (path, form) {
       Object.keys(form).forEach(function (key) {
-        if (Array.isArray(form[key])) {
-          validateArray(path.concat(key), form[key])
-        } else if ('value' in form[key]) {
-          context.state.merge(path.concat(key), runValidation(form[key], form))
-        } else {
-          validateForm(path.concat(key), form[key])
+        if (form[key] === Object(form[key])) {
+          if (Array.isArray(form[key])) {
+            validateArray(path.concat(key), form[key])
+          } else if ('value' in form[key]) {
+            context.state.merge(path.concat(key), runValidation(form[key], form))
+          } else {
+            validateForm(path.concat(key), form[key])
+          }
         }
       })
     }

--- a/packages/cerebral-forms/src/helpers/formToJSON.js
+++ b/packages/cerebral-forms/src/helpers/formToJSON.js
@@ -1,11 +1,15 @@
 function extractObject (object) {
   return Object.keys(object).reduce((newObject, key) => {
-    if (Array.isArray(object[key])) {
-      newObject[key] = extractArray(object[key])
-    } else if (object[key] && 'value' in object[key]) {
-      newObject[key] = object[key].value
-    } else if (object[key] && typeof object[key] === 'object') {
-      newObject[key] = extractObject(object[key])
+    if (object[key] && object[key] === Object(object[key])) {
+      if (Array.isArray(object[key])) {
+        newObject[key] = extractArray(object[key])
+      } else if ('value' in object[key]) {
+        newObject[key] = object[key].value
+      } else {
+        newObject[key] = extractObject(object[key])
+      }
+    } else if (object[key]) {
+      newObject[key] = object[key]
     }
 
     return newObject

--- a/packages/cerebral-forms/src/helpers/getFormFields.js
+++ b/packages/cerebral-forms/src/helpers/getFormFields.js
@@ -10,7 +10,7 @@ export default function getFormFields (object, currentPath = [], allFields = {})
       currentPath.pop()
 
       return allFields
-    } else if ('value' in object[key]) {
+    } else if (object[key] === Object(object[key]) && 'value' in object[key]) {
       allFields[currentPath.join('.')] = object[key]
       currentPath.pop()
 

--- a/packages/cerebral-forms/src/utils/configureField.js
+++ b/packages/cerebral-forms/src/utils/configureField.js
@@ -1,5 +1,4 @@
-import checkHasValue from './checkHasValue'
-import validate from './validate'
+import runValidation from './runValidation'
 
 export default function configureField (formData, field) {
   // If not an actual field but a global property or just a namespace
@@ -14,25 +13,22 @@ export default function configureField (formData, field) {
   const validationRules = field.validationRules || null
   const validationMessages = field.validationMessages || []
   const requiredMessage = field.requiredMessage || null
-  const hasValue = checkHasValue(formData, value, isValueRules)
-  const validationResult = validate(formData, value, validationRules)
 
   field.defaultValue = defaultValue
   field.validationRules = validationRules
   // Field is valid only when there is a value and the validation rule
   // says it is valid. If "isRequired" it will only be valid if it actually
   // has a value
-  field.isValid = ((hasValue && validationResult.isValid) || (!isRequired && !hasValue))
   field.validationMessages = validationMessages
   field.requiredMessage = requiredMessage
-  if (isRequired && !hasValue) {
-    field.errorMessage = requiredMessage
-  } else {
-    field.errorMessage = validationResult.isValid ? null : validationMessages[validationResult.failedRuleIndex]
-  }
   field.isValueRules = isValueRules
   field.isRequired = isRequired
-  field.hasValue = hasValue
+
+  const validationResult = runValidation(field, formData)
+
+  field.isValid = validationResult.isValid
+  field.errorMessage = validationResult.errorMessage
+  field.hasValue = validationResult.hasValue
   field.isPristine = true
 
   return field

--- a/packages/cerebral-forms/src/utils/runValidation.js
+++ b/packages/cerebral-forms/src/utils/runValidation.js
@@ -1,6 +1,7 @@
+import checkHasValue from './checkHasValue'
 import rules from '../rules.js'
 
-export default function validate (form, value, validations) {
+function validate (form, value, validations) {
   const initialValidation = {
     isValid: true,
     failedRuleIndex: null
@@ -47,5 +48,26 @@ export default function validate (form, value, validations) {
         failedRuleIndex: index
       }
     }, initialValidation)
+  }
+}
+
+export default function runValidation (field, form) {
+  const hasValue = checkHasValue(form, field.value, field.isValueRules)
+  const result = validate(form, field.value, field.validationRules)
+  const isValid = result.isValid && (
+    (field.isRequired && hasValue) ||
+    !field.isRequired
+  )
+  const errorMessage = field.isRequired && !hasValue
+    ? field.requiredMessage
+    : result.isValid
+        ? null
+        : field.validationMessages[result.failedRuleIndex]
+
+  return {
+    isValid,
+    isPristine: false,
+    hasValue: checkHasValue(form, field.value, field.isValueRules),
+    errorMessage: errorMessage
   }
 }

--- a/packages/cerebral-forms/src/utils/util.test.js
+++ b/packages/cerebral-forms/src/utils/util.test.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 import assert from 'assert'
 import checkHasValue from './checkHasValue'
-import validate from './validate'
 
 describe('utils', () => {
   it('should return false due to not having a value', () => {
@@ -12,15 +11,5 @@ describe('utils', () => {
   it('should return true due to having a value', () => {
     const hasValue = checkHasValue(null, ' ', ['isValue'])
     assert.equal(hasValue, true)
-  })
-
-  it('should return an undefined valid because rule does not exists', () => {
-    const valid = validate(null, ' ', ['notFound'])
-    assert.equal(valid.isValid, undefined)
-  })
-
-  it('should return true and not be able to parse json', () => {
-    const valid = validate(null, '3,1', ['equals:3,1'])
-    assert.equal(valid.isValid, true)
   })
 })


### PR DESCRIPTION
Move runValidation from validateField to validate.
As runValidation becomes the default export rename file to runValidation.js.
Reuse runValidation in validateForm and configureField.