### PR TITLE
test(function-tree): ensure inputs are passed correctly with empty paths

### DIFF
--- a/packages/function-tree/src/FunctionTree.test.js
+++ b/packages/function-tree/src/FunctionTree.test.js
@@ -240,4 +240,23 @@ describe('FunctionTree', () => {
     assert(branchStartCount, 2)
     assert(branchEndCount, 2)
   })
+  it('should pass correct input on empty paths', () => {
+    function actionA ({path}) {
+      return path.true()
+    }
+    function actionB ({input}) {
+      assert.deepEqual(input, {foo: 'bar'})
+    }
+    const execute = FunctionTree([])
+    const tree = [
+      actionA, {
+        true: [],
+        false: []
+      },
+      actionB
+    ]
+    execute(tree, {
+      foo: 'bar'
+    })
+  })
 })


### PR DESCRIPTION
Just a test to ensure that an edge case in Cerebral 1 does not happen in Cerebral 2