### PR TITLE
feat(Operators): support setting deep path inside "input"

### DIFF
--- a/packages/cerebral/src/operators/set.js
+++ b/packages/cerebral/src/operators/set.js
@@ -14,9 +14,15 @@ export default function (target, value) {
     if (targetTemplate.target === 'state') {
       context.state.set(targetTemplate.path, setValue)
     } else {
-      return {
-        [targetTemplate.path]: setValue
-      }
+      const result = Object.assign({}, context.input)
+      const parts = targetTemplate.path.split('.')
+      const key = parts.pop()
+      const target = parts.reduce((target, key) => {
+        return (target[key] = Object.assign({}, target[key] || {}))
+      }, result)
+      target[key] = setValue
+
+      return result
     }
   }
 

--- a/packages/cerebral/src/operators/set.test.js
+++ b/packages/cerebral/src/operators/set.test.js
@@ -31,6 +31,21 @@ describe('operator.set', () => {
     })
     controller.getSignal('test')()
   })
+  it('should set deep value to input', () => {
+    const controller = new Controller({
+      signals: {
+        test: [
+          set(input`foo`, {bing: 'bor'}),
+          set(input`foo.bar`, 'baz'),
+          ({input}) => {
+            assert.equal(input.foo.bar, 'baz')
+            assert.equal(input.foo.bing, 'bor')
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
+  })
   it('should set non string value to model', () => {
     const controller = new Controller({
       state: {


### PR DESCRIPTION
Add support in "set" operator for:

```js
set(input`foo.bar`, 'baz')
```

To set **input.foo.bar**. Currently this sets `input['foo.bar']`.