### PR TITLE
feat(forms): fixed default requiredMessage and global props factory example

### DIFF
--- a/packages/cerebral-forms/README.md
+++ b/packages/cerebral-forms/README.md
@@ -96,29 +96,21 @@ export default function MyAction({state}) {
 #### Set a default value for the whole form
 You can set a default value for a property using a factory:
 ```js
-import {Form, getFormFields} from 'cerebral-forms'
+import {form, getFormFields} from 'cerebral-forms'
 
-const MyFormFactory = (form) => {
-  const myForm = Form(form)
+const MyFormFactory = (formObject) => {
+  const myForm = form(formObject)
   const fields = getFormFields(myForm)
-
+  
+  // You can also set some special properties for the whole form
+  newForm.showErrors = false
+  
   fields.forEach((field) => {
     field.requiredMessage = field.requiredMessage || 'This field is required'
     field.someProp = field.someProp || 'Some default'
   })
 
   return myForm
-}
-
-import {form} from 'cerebral-forms'
-
-export default function MyAction({state}) {
-  state.set('some.new.form', form({
-    name: {
-      value: '',
-    },
-    showErrors = false
-  }))
 }
 ```
 

--- a/packages/cerebral-forms/README.md
+++ b/packages/cerebral-forms/README.md
@@ -112,6 +112,17 @@ const MyFormFactory = (formObject) => {
 
   return myForm
 }
+
+import {form} from 'cerebral-forms'
+
+export default function MyAction({state}) {
+  state.set('some.new.form', form({
+    name: {
+      value: '',
+    },
+    showErrors: false
+  }))
+}
 ```
 
 ### field


### PR DESCRIPTION
Hi guys,
Form should be lowercase 
Related to cerebral/cerebral#462, you decided to keep global props outside the form. So I deleted this example and put it in factory. 
Thanks for the great library :)