### PR TITLE
feat(Operators): add support for multiple arguments to 'when'

### DIFF
--- a/packages/cerebral/src/operators/when.js
+++ b/packages/cerebral/src/operators/when.js
@@ -1,7 +1,9 @@
-function whenFactory (target, whenFunc) {
+function whenFactory (...args) {
+  const whenFunc = args.length > 1 ? args[args.length - 1] : null
+  const valueTemplates = args.length > 1 ? args.slice(0, -1) : args
   function when (context) {
-    const targetValue = target(context).value
-    const isTrue = Boolean(typeof whenFunc === 'function' ? whenFunc(targetValue) : targetValue)
+    const values = valueTemplates.map(value => typeof value === 'function' ? value(context).value : value)
+    const isTrue = Boolean(whenFunc ? whenFunc(...values) : values[0])
 
     return isTrue ? context.path.true() : context.path.false()
   }

--- a/packages/cerebral/src/operators/when.test.js
+++ b/packages/cerebral/src/operators/when.test.js
@@ -82,4 +82,47 @@ describe('operator.when', () => {
     controller.getSignal('test')()
     assert.equal(discarded, 1)
   })
+  it('should check truthy state using function and multiple values', () => {
+    const results = []
+    const controller = new Controller({
+      state: {
+        foo: 'bar'
+      },
+      signals: {
+        test: [
+          when(state`foo`, input`bar`, (foo, bar) => foo === bar), {
+            true: [
+              () => { results.push('true') }
+            ],
+            false: [
+              () => { results.push('false') }
+            ]
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')({bar: 'bar'})
+    controller.getSignal('test')({bar: 'nope'})
+    assert.deepEqual(results, ['true', 'false'])
+  })
+  it('should check truthy state using function and literal values', () => {
+    const results = []
+    const controller = new Controller({
+      signals: {
+        test: [
+          when(input`foo`, 'bar', (foo, bar) => foo === bar), {
+            true: [
+              () => { results.push('true') }
+            ],
+            false: [
+              () => { results.push('false') }
+            ]
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')({foo: 'bar'})
+    controller.getSignal('test')({foo: 'nope'})
+    assert.deepEqual(results, ['true', 'false'])
+  })
 })

--- a/packages/docs/content/api/07_operators.en.md
+++ b/packages/docs/content/api/07_operators.en.md
@@ -131,6 +131,8 @@ export default [
 ]
 ```
 
+#### debounce
+
 The **debounce** operator cancels out the existing call to the action returned when the signal triggers again within the milliseconds set. This is typically used with factories, for example to show notifications:
 
 ```js
@@ -156,6 +158,26 @@ function showNotificationFactory(message, ms) {
 ```
 
 Wherever this **showNofication** factory is used, in whatever signal, it will cancel out any other. This makes sure that notifications are always shown at the set time, no matter what existing notification is already there.
+
+#### when
+
+When used with a truth function, the **when** operator supports more then a single "value" argument. The truth function must come last:
+
+```js
+import {input, state, when} from 'cerebral/operators'
+
+export default [
+  when(state`clients.$draft.key`, input`key`,
+    (draftKey, updatedKey) => draftKey === updatedKey
+  ), {
+    true: [
+      // Another person edited client, reset form to new value
+      set(state`clients.$draft`, input`value`)
+    ],
+    false: []
+  }
+]
+```
 
 ### Custom operators
 You can easily create your own operators and use the operator tags. Here showing the implementation of **set**


### PR DESCRIPTION
Add support for these kind of things:

```js
when(state`clients.$draft.key`, input`key`, (a, b) => a === b), {
  // maybe update the form as well
}
```