### PR TITLE
fix(debugger): fix default port on first startup

### DIFF
--- a/packages/cerebral-debugger/electron/main.js
+++ b/packages/cerebral-debugger/electron/main.js
@@ -50,7 +50,7 @@ function createWindow () {
       throw error
     }
 
-    wss = new WebSocketServer({ port: parseInt(selectedPort || 8585) })
+    wss = new WebSocketServer({ port: typeof selectedPort === 'string' ? parseInt(selectedPort) : 8585 })
     menu.splice(4, 0, {
       label: 'Port',
       submenu: [


### PR DESCRIPTION
So stupid... the storage thing returns an object when there is no value there