### PR TITLE
feat(Views): add dynamic paths based on state

### DIFF
--- a/packages/docs/content/api/04_connect.en.md
+++ b/packages/docs/content/api/04_connect.en.md
@@ -55,6 +55,21 @@ export default connect((props) => ({
 )
 ```
 
+Expose state based on existing state:
+
+```js
+import React from 'react'
+import {connect} from 'cerebral/react'
+
+export default connect((props, state) => ({
+  user: `users.${state('currentUserKey')}`
+}),
+  function App(props) {
+    props.user
+  }
+)
+```
+
 ### Exposing signals
 ```js
 import React from 'react'


### PR DESCRIPTION
@Guria @gaspard After playing around with it I figured it was the wrong way to go with operators here. It is not necessary, does not fit the signature as well and we would have an issue explaining why operators can be used with connect as well. But I think this looks way better anyways:

```js
connect((props, state) => {
  const currentUserKey = state('currentUserKey')

  return {
    user: `users.${currentUserKey}`
  }
}, ...)
```