### PR TITLE
feat(binary): add support for passing binary files to signals via refs

### DIFF
--- a/packages/cerebral/src/binary.js
+++ b/packages/cerebral/src/binary.js
@@ -1,0 +1,15 @@
+let referenceRefCount = 0
+const storage = {}
+
+export default {
+  push (binary, fixedRef = null) {
+    const ref = `binary-ref-${fixedRef || ++referenceRefCount}`
+    storage[ref] = binary
+    return ref
+  },
+  pop (ref) {
+    const binary = storage[ref]
+    delete storage[ref]
+    return binary
+  }
+}

--- a/packages/cerebral/src/binary.test.js
+++ b/packages/cerebral/src/binary.test.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+import binary from './binary'
+import assert from 'assert'
+
+describe('binary', () => {
+  it('create new reference on each run', () => {
+    const obj = {}
+    const ref1 = binary.push(obj)
+    const ref2 = binary.push(obj)
+    assert.ok(ref1 !== ref2)
+  })
+  it('retrieves original element with ref', () => {
+    const obj = {}
+    const ref = binary.push(obj)
+    const objBack = binary.pop(ref)
+    assert.equal(obj, objBack)
+  })
+  it('removes element on pop', () => {
+    const ref = binary.push({})
+    binary.pop(ref)
+    assert.equal(undefined, binary.pop(ref))
+  })
+  it('supports fixed reference to replace object', () => {
+    const obj = {}
+    const ref1 = binary.push(obj, 'myUniqueRef')
+    const ref2 = binary.push(obj, 'myUniqueRef')
+    assert.ok(ref1 === ref2)
+  })
+})

--- a/packages/cerebral/src/index.js
+++ b/packages/cerebral/src/index.js
@@ -1,2 +1,3 @@
 export {default as Controller} from './Controller'
 export {default as Computed} from './Computed'
+export {default as binary} from './binary'

--- a/packages/cerebral/src/operators/debounce.test.js
+++ b/packages/cerebral/src/operators/debounce.test.js
@@ -34,7 +34,6 @@ describe('operator.debounce', () => {
           [ debounce(50), {
             continue: [
               () => {
-                console.log(result)
                 assert.deepEqual(result, ['parallel', 'parallel', 'discard'])
                 done()
               }


### PR DESCRIPTION
API:

```js
import {binary} from 'cerebral'

// in component
const ref = binary.push(e.target.files)
// in signal
const files = binary.pop(ref) // this also removes the ref from binary
```

Usage is for upload or other operations dealing with binary data. It helps to not implement signal logic in Component simply because the value cannot be serialized.

This also supports a fixed ref so that `ref` can be sent on fieldChange multiple times without memory leak:

```js
import {binary} from 'cerebral'

// in component
const onFileChange = e => {
  // This can be executed multiple times before form validation triggers upload
  // without memory leak.
  const ref = binary.push(e.target.files, 'clientLogo')
  fieldValueChanged({key: 'clientLogo', value: ref})
}
```
