### PR TITLE
feat(Controller): add ability to handle binary like values

### DIFF
--- a/packages/cerebral/src/Controller.test.js
+++ b/packages/cerebral/src/Controller.test.js
@@ -109,29 +109,27 @@ describe('Controller', () => {
     })
     assert.equal(controller.getModel(), controller.model)
   })
-  it('should throw when passing in unserializable payload property to signal', () => {
+  it('should create JSON stringify friendly value of unserializable payload property to signal', () => {
     const controller = new Controller({
-      devtools: {enforceSerializable: true, init () {}},
+      devtools: {init () {}},
       signals: {
-        foo: []
+        foo: [({input}) => assert.equal(JSON.stringify(input), '{"date":"[Date]"}')]
       }
     })
-    assert.throws(() => {
-      controller.getSignal('foo')({
-        date: new Date()
-      })
+    controller.getSignal('foo')({
+      date: new Date()
     })
   })
-  it('should throw when passing in unserializable payload to signal', () => {
+  it('should ignore when passing in unserializable payload to signal', () => {
     const controller = new Controller({
-      devtools: {enforceSerializable: true, init () {}},
+      devtools: {init () {}},
       signals: {
-        foo: []
+        foo: [
+          ({input}) => assert.deepEqual(input, {})
+        ]
       }
     })
-    assert.throws(() => {
-      controller.getSignal('foo')(new Date())
-    })
+    controller.getSignal('foo')(new Date())
   })
   it('should throw when pointing to a non existing signal', () => {
     const controller = new Controller({})

--- a/packages/cerebral/src/Model.test.js
+++ b/packages/cerebral/src/Model.test.js
@@ -257,21 +257,29 @@ describe('Model', () => {
       })
     })
   })
-  describe('Enforce serializable', () => {
+  describe('Serializable', () => {
     it('should throw error if value inserted is not serializable', () => {
       const model = new Model({
         foo: 'bar'
-      }, {enforceSerializable: true})
+      }, {})
       assert.throws(() => {
         model.set(['foo'], new Date())
       })
     })
-    it('should throw error if value inserted is not serializable', () => {
+    it('should NOT throw error if value inserted is serializable', () => {
       const model = new Model({
         foo: 'bar'
-      }, {enforceSerializable: true})
+      }, {})
       assert.doesNotThrow(() => {
         model.set(['foo'], [])
+      })
+    })
+    it('should NOT throw error if passing allowed type in devtools', () => {
+      const model = new Model({
+        foo: 'bar'
+      }, {allowedTypes: [Date]})
+      assert.doesNotThrow(() => {
+        model.set(['foo'], new Date())
       })
     })
   })

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -1,4 +1,4 @@
-/* global CustomEvent WebSocket */
+/* global CustomEvent WebSocket File FileList Blob */
 import {debounce} from '../utils'
 const PLACEHOLDER_INITIAL_MODEL = 'PLACEHOLDER_INITIAL_MODEL'
 const PLACEHOLDER_DEBUGGING_DATA = '$$DEBUGGING_DATA$$'
@@ -13,7 +13,6 @@ class Devtools {
   constructor (options = {
     storeMutations: true,
     preventExternalMutations: true,
-    enforceSerializable: true,
     verifyStrictRender: true,
     preventInputPropReplacement: false,
     bigComponentsWarning: {
@@ -21,14 +20,14 @@ class Devtools {
       signals: 5
     },
     remoteDebugger: null,
-    multipleApps: true
+    multipleApps: true,
+    allowedTypes: []
   }) {
     this.VERSION = VERSION
     this.debuggerComponentsMap = {}
     this.debuggerComponentDetailsId = 1
     this.storeMutations = typeof options.storeMutations === 'undefined' ? true : options.storeMutations
     this.preventExternalMutations = typeof options.preventExternalMutations === 'undefined' ? true : options.preventExternalMutations
-    this.enforceSerializable = typeof options.enforceSerializable === 'undefined' ? true : options.enforceSerializable
     this.verifyStrictRender = typeof options.verifyStrictRender === 'undefined' ? true : options.verifyStrictRender
     this.preventInputPropReplacement = options.preventInputPropReplacement || false
     this.bigComponentsWarning = options.bigComponentsWarning || {state: 5, signals: 5}
@@ -43,6 +42,7 @@ class Devtools {
     this.originalRunTreeFunction = null
     this.ws = null
     this.isResettingDebugger = false
+    this.allowedTypes = [File, FileList, Blob].concat(options.allowedTypes || [])
 
     this.sendInitial = this.sendInitial.bind(this)
     this.sendComponentsMap = debounce(this.sendComponentsMap, 50)

--- a/packages/cerebral/src/utils.js
+++ b/packages/cerebral/src/utils.js
@@ -25,18 +25,30 @@ export function isObject (obj) {
   return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
 }
 
-export function isSerializable (value) {
+export function isSerializable (value, additionalTypes = []) {
+  const validType = additionalTypes.reduce((currentValid, type) => {
+    if (currentValid || value instanceof type) {
+      return true
+    }
+
+    return currentValid
+  }, false)
+
   if (
+    value !== undefined &&
     (
-      isObject(value) &&
-      Object.prototype.toString.call(value) === '[object Object]' &&
-      value.constructor === Object
-    ) ||
-    typeof value === 'number' ||
-    typeof value === 'string' ||
-    typeof value === 'boolean' ||
-    value === null ||
-    Array.isArray(value)
+      validType ||
+      (
+        isObject(value) &&
+        Object.prototype.toString.call(value) === '[object Object]' &&
+        value.constructor === Object
+      ) ||
+      typeof value === 'number' ||
+      typeof value === 'string' ||
+      typeof value === 'boolean' ||
+      value === null ||
+      Array.isArray(value)
+    )
   ) {
     return true
   }
@@ -107,3 +119,19 @@ export function debounce (func, wait) {
 }
 
 export const noop = () => {}
+
+export const forceSerializable = (value) => {
+  if (value && !isSerializable(value)) {
+    const name = value.constructor.name
+
+    try {
+      Object.defineProperty(value, 'toJSON', {
+        value () {
+          return `[${name}]`
+        }
+      })
+    } catch (e) {}
+  }
+
+  return value
+}

--- a/packages/docs/content/api/02_state.en.md
+++ b/packages/docs/content/api/02_state.en.md
@@ -3,7 +3,7 @@ title: State
 ---
 
 ## State
-State can be defined at the top level in the controller and/or in each module. State is defined as plain JavaScript value types. Arrays, objects, strings, numbers and booleans. This means that the state is serializable. There are no classes or other abstractions around state. This makes it easier to reason about how state is translated into user interface, it can be stored on server/local storage and the debugger can now visualize all the state of the application.
+State can be defined at the top level in the controller and/or in each module. State is defined as plain JavaScript value types. Objects, arrays, strings, numbers and booleans. This means that the state is serializable. There are no classes or other abstractions around state. This is an important choice in Cerebral that makes it possible to track changes to update the UI, store state on server/local storage and passing state information to the debugger.
 
 ```js
 import {Controller} from 'cerebral'
@@ -19,15 +19,26 @@ const controller = Controller({
   }
 })
 ```
+### Special values support
+When building an application you often need to keep things like files and blobs in your state for further processing. Cerebral supports these kinds of values because they will never change, or changing them can be used with existing state API. This is the list of supported types:
+
+- **File**
+- **FilesList**
+- **Blob**
+
+If you want to force Cerebral to support other types as well, you can do that with a devtools option. This is perfectly okay, but remember all state changes has to be done though the state API.
+
 ### Get state
 The only way to get state in your application is by connecting it to a component or grabbing it in an action.
 
 ```js
 function someAction({state}) {
   // Get all state
-  state.get()
+  const allState = state.get()
   // Get by path
-  state.get('some.path')
+  const stateAtSomePath = state.get('some.path')
+  // Get computed state by passing in a computed
+  const computedState = state.compute(someComputed)
 }
 ```
 

--- a/packages/docs/content/in-depth/01_the-architecture.en.md
+++ b/packages/docs/content/in-depth/01_the-architecture.en.md
@@ -47,7 +47,7 @@ With a single state tree we can point to parts of the state using paths (the fir
 #### Optimized rendering
 Cerebral does not look at the updates in your application as "value updates", but as "path updates". This allows Cerebral to make optimizations not possible in other frameworks:
 
-1. There is no need for immutability in Cerebral because a change to a path means that any component depending on that path should render (no value comparison). In applications with large data structures immutability has a high cost.
+1. There is no need for immutability in Cerebral because a change to a path means that any component depending on that path should render (no value comparison). In applications with large data structures immutability has a high cost. There is no need to hack objects and arrays to observe changes to them either. There is nothing special about the state you put into Cerebrals state tree
 
 2. Since there is no value comparison in Cerebral it has a **strict render mode**. Traditionally if you change an item in an array, also the array itself has a change. This means that the component handling the array will render whenever an item needs to render. In large applications **strict render mode** will give you a lot more control of how your components should react to a state change.
 

--- a/packages/docs/content/in-depth/03_state.en.md
+++ b/packages/docs/content/in-depth/03_state.en.md
@@ -12,7 +12,7 @@ Cerebral uses a single state tree to store all the state of your application. It
 
 Thats it.
 
-You can only store other objects, arrays, strings, booleans and numbers in it. Forcing you to think of your state in this simple form gives us benefits.
+You will normally store other objects, arrays, strings, booleans and numbers in it. Forcing you to think of your state in this simple form gives us benefits.
 
 1. The state of the application is exposed as simple values. There are no classes or other abstractions hiding the state of your application
 
@@ -50,4 +50,20 @@ const conroller = Controller({
 
 You can now point to this state with a path: **"app.foo"**. To handle large amounts of state you simply namespace it by putting the state into a module.
 
-And that is basically all there is to state in Cerebral. If you know how to use work with basic JavaScript types, you can work with state in Cerebral.
+Using the plain value types of JavaScript gives Cerebral all its power. That said, there are times you need to store things like files or blobs. Cerebral supports this as well. The reason files are supported, but not **Date** for example, is because a date can be mutated directly. For example:
+
+```js
+const date = new Date()
+date.setHours(8)
+```
+
+There is no way to keep track of these kinds of changes. Object oriented programming like this definitely makes things easier, but a functional approach opens up for new possibilities. For example...
+
+```js
+const date = Date.now()
+const newDate = setHours(date, 8)
+```
+
+...allows us to pass and store the date wherever we want, because it is just a number. But do not worry about this. You can still use the Date object, or [Moment](http://momentjs.com/), in your app. It is only related to storing state you in this case use a number or a string.
+
+And that is basically all there is to state in Cerebral. If you know about the basic JavaScript types, you know what can be stored in the Cerebral state tree :)

--- a/packages/docs/content/in-depth/04_signals.en.md
+++ b/packages/docs/content/in-depth/04_signals.en.md
@@ -56,3 +56,5 @@ connect({
   }
 )
 ```
+
+The payload passed to a signal is typically the main value types of JavaScript. Object, Array, String, Number or Boolean. It is also possible to pass in some special value types, like files. For a full list of supported value types, check the [state API documentation](../api/02_state.html).

--- a/packages/docs/content/install/02_debugger.en.md
+++ b/packages/docs/content/install/02_debugger.en.md
@@ -44,8 +44,6 @@ const controller = Controller({
     storeMutations: true,
     // Warnings on mutating outside "state" API
     preventExternalMutations: true,
-    // Warnings when passing in non-serializable data to signals and state tree
-    enforceSerializable: true,
     // Warnings when strict render path usage is wrong
     verifyStrictRender: true,
     // Throw error when overwriting existing input property
@@ -54,7 +52,11 @@ const controller = Controller({
     // or signals above the set number
     bigComponentsWarning: {state: 5, signals: 5},
     // Will reset debugger to currently focused application
-    multipleApps: true
+    multipleApps: true,
+    // In addition to basic JavaScript types Object, Array, String, Number
+    // and Boolean, File, FileList and Blob is allowed to be stored in state
+    // tree. You can add additional types if you know what you are doing :)
+    allowedTypes: []
   })
 })
 ```

--- a/packages/docs/content/tutorial/04_update-state.en.md
+++ b/packages/docs/content/tutorial/04_update-state.en.md
@@ -30,7 +30,7 @@ const controller = Controller({
   }
 })
 ```
-We now defined a signal named **buttonClicked**. The signal tells us "what happened to make this signal run". A signal is defined using a **chain**, which is basically an **array of actions**. What we want to happen when this signal triggers is to update the **subTitle** in our state with a static value. That is why we use **set**, a Cerebral operator. Calling set will create an action for us that will put the value *Updating some state* on the state path *subTitle*. If you are unfamiliar with [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in JavaScript, you should read about them.
+We now defined a signal named **buttonClicked**. The signal tells us "what happened to make this signal run". A signal is defined using an array containing functions. What we want to happen when this signal triggers is to update the **subTitle** in our state with a static value. That is why we use **set**, a Cerebral operator. Calling set will create a function for us that will put the value *Updating some state* on the state path *subTitle*. If you are unfamiliar with [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in JavaScript, you should read about them.
 
 Please take a closer look at *./src/components/App/index.js*:
 

--- a/packages/docs/content/tutorial/05_using-chains.en.md
+++ b/packages/docs/content/tutorial/05_using-chains.en.md
@@ -6,7 +6,7 @@ title: ch04. Chains
 
 **Load up chapter 04** - [Preview](04)
 
-A signal can trigger a chain of actions. For now we have seen it trigger the **set**-action. In this chapter we have added a **Toast** component which displays any message set on its related state.
+A signal can trigger an array of functions. This array we call a **chain** and the functions we call **actions**. For now we have seen it trigger the **set**-action. In this chapter we have added a **Toast** component which displays any message set on its related state.
 
 Let us add another operator named **wait** and another **set** to close our toast message after a few seconds. So go ahead and change our **buttonClicked** signal in *src/index.js* to execute a 2 more actions:
 ```js

--- a/packages/docs/content/tutorial/06_using-inputoutput.en.md
+++ b/packages/docs/content/tutorial/06_using-inputoutput.en.md
@@ -28,7 +28,7 @@ import {set, state, wait, input} from 'cerebral/operators'
 ```
 
 We would like to access the input-object from within our action.
-So lets have a look at such a sample action. You can create on the lint above the instantiation of the controller:
+So lets have a look at such a sample action. You can create on the line above the instantiation of the controller:
 
 ```js
 ...


### PR DESCRIPTION
Allrighty... after long and good discussions on handling binary like things (not serializable stuff) I think I found a really good solution.

We talked about identifying these on the input or use a special `.keyName` convention... but we already check the keys if they are serializable, so only thing now is to handle it differently when they are not (The payload to signal itself still has a check on being serializable though, like it needs to be a plain object):

```js
someSignal({
  file: event.target.files[0]
})
```

There is so little code it is silly, the only thing it does when it is not serializable is that it attaches a `toJSON` method to the object :) 

In actual state tree it looks like:
```js
{
  file: FileObject
}
```

And when serialized it looks like:
```js
{
  files: '[NON_SERIALIZABLE]'
}
```

Feel free to suggest some other naming there... but now we do not even have to mention binary. We just allow you to pass in whatever on the keys. Some is serializable some is not. We just note to people that time travel debugging does not work with "non serializable" state :)