### PR TITLE
feat(demos): add onSubmit, onBlur validation and reset

### DIFF
--- a/packages/forms-demo/src/components/Fields/Input/index.js
+++ b/packages/forms-demo/src/components/Fields/Input/index.js
@@ -5,8 +5,8 @@ import styles from './styles'
 
 export default connect((props) => (
   {
-    'field': `${props.path}.**`,
-    'settings': 'app.settings.**'
+    field: `${props.path}.**`,
+    settings: 'app.settings.**'
   }),
   {
     fieldChanged: 'simple.fieldChanged'
@@ -15,22 +15,30 @@ export default connect((props) => (
     function onChange (e) {
       fieldChanged({
         field: path,
-        value: e.target.value
+        value: e.target.value,
+        settingsField: 'app.settings.validateOnChange'
       })
     }
-
+    function onBlur (e) {
+      fieldChanged({
+        field: path,
+        value: e.target.value,
+        settingsField: 'app.settings.validateInputOnBlur'
+      })
+    }
     function renderError () {
       const {errorMessage} = field
+      const {showErrors} = settings
       return (
         <div style={{color: '#d64242', fontSize: 11}}>
-          {errorMessage}
+          {showErrors && errorMessage}
         </div>
       )
     }
     return (
       <div style={{marginTop: 10, fontSize: 14}}>
         {name} {field.isRequired ? '*' : ''}<br />
-        <input onChange={(e) => onChange(e)} type={'text'} className={css(styles.input)} />
+        <input onChange={(e) => onChange(e)} onBlur={(e) => onBlur(e)} value={field.value} type={'text'} className={css(styles.input)} />
         {renderError()}
       </div>
     )

--- a/packages/forms-demo/src/components/Menu/index.js
+++ b/packages/forms-demo/src/components/Menu/index.js
@@ -27,7 +27,10 @@ export default connect(
         </div>
         <div className={css(styles.settingsContainer)}>
           {Object.keys(settings).map((settingKey, index) => {
-            return <SettingsCheckbox key={index} path={`app.settings.${settingKey}`} />
+            if (settings[settingKey] === Object(settings[settingKey])) {
+              return <SettingsCheckbox key={index} path={`app.settings.${settingKey}`} />
+            }
+            return null
           })}
         </div>
       </div>

--- a/packages/forms-demo/src/components/PrettyPrint/index.js
+++ b/packages/forms-demo/src/components/PrettyPrint/index.js
@@ -7,9 +7,13 @@ import styles from './styles'
 
 export default connect((props) => (
   {
-    'form': `${props.currentView}.form.**`
+    form: `${props.currentView}.form.**`,
+    showPanel: 'app.settings.showErrors'
   }),
-  function PrettyPrint ({form}) {
+  function PrettyPrint ({form, showPanel}) {
+    if (!showPanel) {
+      return null
+    }
     const isValid = isValidForm(form)
     let invalidFormFields = getInvalidFormFields(form)
     let result = Object.keys(invalidFormFields).reduce((acc, field) => {

--- a/packages/forms-demo/src/components/Simple/index.js
+++ b/packages/forms-demo/src/components/Simple/index.js
@@ -11,15 +11,17 @@ export default connect(
     settings: 'app.settings.**'
   },
   {
-    validateEntireForm: 'simple.validateEntireForm'
+    onSubmitted: 'simple.onSubmitted',
+    onReset: 'simple.onReset'
   },
-  function Simple ({form, settings, validateEntireForm}) {
+  function Simple ({form, settings, onSubmitted, onReset}) {
     const {disableSubmitWhenFormIsInValid} = settings
     let enabled = true
     let buttonStyle = css(
       styles.button,
       styles.enabled
     )
+    const resetButtonStyle = buttonStyle
     if (disableSubmitWhenFormIsInValid.value) {
       enabled = isValidForm(form)
       buttonStyle = css(
@@ -40,7 +42,8 @@ export default connect(
           <Input name={'Email'} path={'simple.form.email'} />
         </div>
         <div style={{marginTop: 50}}>
-          <button onClick={(e) => validateEntireForm({formPath: 'simple.form'})} disabled={!enabled} className={buttonStyle}>Submit</button>
+          <button onClick={(e) => onSubmitted({formPath: 'simple.form'})} disabled={!enabled} className={buttonStyle}>Submit</button>
+          <button onClick={(e) => onReset({formPath: 'simple.form'})} className={resetButtonStyle}>Reset</button>
         </div>
       </div>
     )

--- a/packages/forms-demo/src/components/Simple/styles.js
+++ b/packages/forms-demo/src/components/Simple/styles.js
@@ -12,7 +12,8 @@ const styles = StyleSheet.create({
     paddingTop: 5,
     paddingBottom: 5,
     borderRadius: 3,
-    outline: 'none'
+    outline: 'none',
+    marginRight: 10
   },
   disabled: {
     opacity: 0.5

--- a/packages/forms-demo/src/modules/app/actions/hidePanel.js
+++ b/packages/forms-demo/src/modules/app/actions/hidePanel.js
@@ -1,0 +1,6 @@
+export default function hidePanel ({state, input}) {
+  const neverHidePanel = state.get(`${input.field}.neverHidePanel`)
+  if (!neverHidePanel) {
+    state.set('app.settings.showErrors', false)
+  }
+}

--- a/packages/forms-demo/src/modules/app/actions/unToggleSettings.js
+++ b/packages/forms-demo/src/modules/app/actions/unToggleSettings.js
@@ -1,5 +1,5 @@
 export default function unToggleSettings ({state, input}) {
-  let unToggleFieldsWhenChecked = state.get(`${input.field}.unToggleFieldsWhenChecked`)
+  const unToggleFieldsWhenChecked = state.get(`${input.field}.unToggleFieldsWhenChecked`)
   if (unToggleFieldsWhenChecked) {
     unToggleFieldsWhenChecked.forEach((unToggle) => {
       state.set(`${unToggle}.value`, false)

--- a/packages/forms-demo/src/modules/app/chains/toggleSelectSettings.js
+++ b/packages/forms-demo/src/modules/app/chains/toggleSelectSettings.js
@@ -1,4 +1,5 @@
 import unToggleSettings from '../actions/unToggleSettings'
+import hidePanel from '../actions/hidePanel'
 import {changeField} from 'cerebral-forms'
 import {when, input} from 'cerebral/operators'
 
@@ -6,6 +7,7 @@ export default [
   ...changeField,
   when(input`value`), {
     true: [
+      hidePanel,
       unToggleSettings
     ],
     false: [

--- a/packages/forms-demo/src/modules/app/index.js
+++ b/packages/forms-demo/src/modules/app/index.js
@@ -6,24 +6,27 @@ export default {
   state: {
     currentView: 'Simple',
     settings: form({
-      /**
       validateOnChange: {
         value: true,
         description: 'Show error messages on change',
-        unToggleFieldsWhenChecked: ['app.settings.validateInputOnBlur']
+        unToggleFieldsWhenChecked: ['app.settings.validateInputOnBlur', 'app.settings.validateFormOnSubmit']
       },
-      */
       disableSubmitWhenFormIsInValid: {
         value: false,
-        description: 'Disable submit when form is invalid'
-      }
-      /** ,
+        description: 'Disable submit when form is invalid',
+        neverHidePanel: true
+      },
       validateInputOnBlur: {
         value: false,
         description: 'Show error message on blur',
-        unToggleFieldsWhenChecked: ['app.settings.validateOnChange']
-      }
-      */
+        unToggleFieldsWhenChecked: ['app.settings.validateOnChange', 'app.settings.validateFormOnSubmit']
+      },
+      validateFormOnSubmit: {
+        value: false,
+        description: 'Show error message on submit',
+        unToggleFieldsWhenChecked: ['app.settings.validateOnChange', 'app.settings.validateInputOnBlur']
+      },
+      showErrors: false
     })
   },
   signals: {

--- a/packages/forms-demo/src/modules/simple/index.js
+++ b/packages/forms-demo/src/modules/simple/index.js
@@ -1,5 +1,5 @@
-import {set, state, input} from 'cerebral/operators'
-import {form, changeField, validateForm} from 'cerebral-forms'
+import {set, state, input, when} from 'cerebral/operators'
+import {form, changeField, validateForm, resetForm} from 'cerebral-forms'
 
 export default {
   state: {
@@ -17,16 +17,31 @@ export default {
         validationRules: ['isEmail'],
         validationMessages: ['You must enter a valid email'],
         isRequired: false
-      }
+      },
+      showErrors: false
     })
   },
   signals: {
     routed: [
       set(state`app.currentView`, 'Simple')
     ],
-    fieldChanged: changeField,
-    validateEntireForm: [
+    fieldChanged: [
+      when(state`${input`settingsField`}.value`), {
+        true: [
+          set(state`app.settings.showErrors`, true),
+          changeField
+        ],
+        false: [
+          set(state`${input`field`}.value`, input`value`)
+        ]
+      }
+    ],
+    onSubmitted: [
+      set(state`app.settings.showErrors`, true),
       validateForm(input`formPath`)
+    ],
+    onReset: [
+      resetForm(input`formPath`)
     ]
   }
 }


### PR DESCRIPTION
@edgesoft Sorry, I had no time to push it early today :( 
I created a simple task list according to your summary. 

**Simple demo**
- [x]  should be able to validate directly when typing (as it does now)
- [x]  should be able to validate only onBlur
- [x]  should be able to validate only onSubmit.
- [x]  should be able to reset the form 

**Checkout demo**
- [ ] masked inputs like credit cards
- [ ] show how to dynamically add forms and fields ( adding products .. )

**Sign up demo** (confirm password)
- [ ] using dependsOn

**Fileupload demo**
- [ ] using https://github.com/cerebral/cerebral/pull/528
- [ ] support multiple uploads
- [ ] progress bar

**Dependent DropDown List**



