### PR TITLE
feat(Operators): add signal operator to pass a signal to action/factory

### DIFF
--- a/packages/cerebral/src/operators/debounce.test.js
+++ b/packages/cerebral/src/operators/debounce.test.js
@@ -34,7 +34,6 @@ describe('operator.debounce', () => {
           [ debounce(50), {
             continue: [
               () => {
-                console.log(result)
                 assert.deepEqual(result, ['parallel', 'parallel', 'discard'])
                 done()
               }

--- a/packages/cerebral/src/operators/index.js
+++ b/packages/cerebral/src/operators/index.js
@@ -6,6 +6,7 @@ export {default as equals} from './equals'
 export {default as state} from './state'
 export {default as input} from './input'
 export {default as string} from './string'
+export {default as signal} from './signal'
 
 export {default as concat} from './concat'
 export {default as merge} from './merge'

--- a/packages/cerebral/src/operators/signal.js
+++ b/packages/cerebral/src/operators/signal.js
@@ -1,0 +1,14 @@
+import populatePath from './helpers/populatePath'
+
+export default function signal (strings, ...values) {
+  return (context) => {
+    const target = 'signal'
+    const path = populatePath(context, strings, values)
+
+    return {
+      target,
+      path,
+      value: context.controller.getSignal(path)
+    }
+  }
+}

--- a/packages/cerebral/src/operators/signal.test.js
+++ b/packages/cerebral/src/operators/signal.test.js
@@ -1,0 +1,47 @@
+/* eslint-env mocha */
+import Controller from '../Controller'
+import assert from 'assert'
+import {input, set, signal} from './'
+
+describe('operator.signal', () => {
+  it('should return signal from path', (done) => {
+    const barSignal = [
+      (context) => {
+        assert.ok(true)
+        done()
+      }
+    ]
+    const controller = new Controller({
+      signals: {
+        bar: barSignal,
+        test: [
+          set(input`progress`, signal`bar`),
+          ({input: {progress}}) => {
+            setTimeout(progress)
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
+  })
+  it('should allow input in template literal', (done) => {
+    const barSignal = [
+      (context) => {
+        assert.ok(true)
+        done()
+      }
+    ]
+    const controller = new Controller({
+      signals: {
+        refbar: barSignal,
+        test: [
+          set(input`progress`, signal`ref${input`ref`}`),
+          ({input: {progress}}) => {
+            setTimeout(progress)
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')({ref: 'bar'})
+  })
+})

--- a/packages/docs/content/api/06_operators.en.md
+++ b/packages/docs/content/api/06_operators.en.md
@@ -80,6 +80,21 @@ You might want to use it for a notification factory or similar:
 showMessage(string`Hi there ${state`user.name`}, whatup?`)
 ```
 
+#### signal
+
+The signal operator tag is used when you want to pass another signal as
+parameter to a factory or action. For example as the signal to call on upload
+progress.
+
+```js
+firebase.upload('remote.path', state`$draft.imageFile`,
+  {progress: signal`clients.$draft.imageProgress`}
+), {
+  success: [],
+  error: []
+}
+```
+
 ### State operators
 
 The methods for changing state within actions is also available as operators.


### PR DESCRIPTION
Usage example:

```js
firebase.upload('remote.path', state`$draft.imageFile`,
  {progress: signal`clients.$draft.imageProgress`}
), {
  success: [],
  error: []
}
```