### PR TITLE
feat(Controller): flush async state changes

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -82,6 +82,10 @@ class Controller extends EventEmitter {
   flush (force) {
     const changes = this.model.flush()
 
+    if (!force && !Object.keys(changes).length) {
+      return
+    }
+
     this.updateComputeds(changes, force)
     this.updateComponents(changes, force)
     this.emit('flush', changes, Boolean(force))

--- a/packages/cerebral/src/providers/Recorder.js
+++ b/packages/cerebral/src/providers/Recorder.js
@@ -77,7 +77,7 @@ export default function RecorderProvider (options = {}) {
         if (event.type === 'mutation') {
           mutate(event)
         } else if (event.type === 'flush') {
-          controller.flush(currentEventIndex === 0)
+          controller.flush()
         }
 
         lastEventTimestamp = event.timestamp
@@ -140,6 +140,7 @@ export default function RecorderProvider (options = {}) {
             originalRunSignal.apply(controller, args)
           }
         }
+        controller.flush(true)
         runNextEvent()
       },
       record (options = {}) {

--- a/packages/cerebral/src/providers/Recorder.test.js
+++ b/packages/cerebral/src/providers/Recorder.test.js
@@ -39,7 +39,7 @@ describe('Recorder', () => {
           assert.equal(recording.initialState[0].value, JSON.stringify({
             foo: 'bar'
           }))
-          assert.equal(recording.events.length, 4)
+          assert.equal(recording.events.length, 3)
         }]
       },
       providers: [RecorderProvider({
@@ -170,7 +170,6 @@ describe('Recorder', () => {
           initialState: ['foo']
         })],
         update: [({state}) => state.set('foo', 'bar2')],
-        update2: [({state}) => state.set('foo', 'bar3')],
         stop: [({recorder}) => recorder.stop()],
         play: [({recorder}) => recorder.play({
           allowedSignals: ['stop']
@@ -183,24 +182,20 @@ describe('Recorder', () => {
     controller.getSignal('record')()
     controller.getSignal('update')()
     controller.getSignal('stop')()
-    controller.getSignal('play')()
-    controller.once('flush', (changes) => {
-      assert.deepEqual(changes, {})
-    })
-    timeout.tick()
-    timeout.tick()
     controller.once('flush', (changes) => {
       assert.deepEqual(changes, {
         foo: true
       })
     })
+    controller.getSignal('play')()
     timeout.tick()
     controller.once('flush', (changes) => {
-      assert.deepEqual(changes, {})
+      assert.deepEqual(changes, {
+        foo: true
+      })
       controller.getSignal('stop')()
       done()
     })
-    timeout.tick()
   })
   it('should be able to pause and continue playback', () => {
     const timeout = timeoutMock()

--- a/packages/cerebral/src/providers/State.js
+++ b/packages/cerebral/src/providers/State.js
@@ -18,6 +18,7 @@ function StateProviderFactory () {
 
   function createProvider (context) {
     const model = context.controller.model
+    let asyncTimeout = null
 
     return methods.reduce((currentStateContext, methodKey) => {
       if (methodKey === 'compute') {
@@ -25,6 +26,11 @@ function StateProviderFactory () {
       } else if (typeof model[methodKey] === 'function') {
         currentStateContext[methodKey] = (...args) => {
           const path = ensurePath(args.shift())
+
+          if (methodKey !== 'get') {
+            clearTimeout(asyncTimeout)
+            asyncTimeout = setTimeout(() => context.controller.flush())
+          }
 
           return model[methodKey].apply(model, [path].concat(args))
         }


### PR DESCRIPTION
To handle async state changes we need to run an async flush on any state change. To avoid doing unnecessary flushes the async flush will of course be reset for every new state change. There is also a general optimization here where flushes which are not forced and has no changes, does not cause a flush to happen (avoid running lots of unnecessary code).

So even though more flushes, code is faster and handles async.

You might say, why not only have async flushes? React and inputs :)