### PR TITLE
feat(Views): add props function and fix warnings

### DIFF
--- a/packages/cerebral-debugger/src/components/Debugger/Inspector/index.js
+++ b/packages/cerebral-debugger/src/components/Debugger/Inspector/index.js
@@ -287,7 +287,7 @@ class Value extends React.Component {
           </span>
           {hasNext ? ',' : null}
         </div>
-        )
+      )
     } else {
       return (
         <div className={isExactHighlightPath ? 'inspector-highlight' : null}>

--- a/packages/cerebral-debugger/src/components/Debugger/Model/index.js
+++ b/packages/cerebral-debugger/src/components/Debugger/Model/index.js
@@ -28,7 +28,7 @@ export default connect({
             />
           </div>
         </div>
-        )
+      )
     }
   }
 )

--- a/packages/cerebral-debugger/src/components/Debugger/index.js
+++ b/packages/cerebral-debugger/src/components/Debugger/index.js
@@ -35,7 +35,7 @@ export default connect({
           mutationsError
           ? <div className='debugger-mutationsError'>
             <h1>Ops!</h1>
-            <h4>Signal "{mutationsError.signalName}" causes an error doing <strong>{mutationsError.mutation.name}</strong>("{mutationsError.mutation.path.join('.')}", {JSON.stringify(mutationsError.mutation.args).replace(/^\[/, '').replace(/\]$/, '')})</h4>
+            <h4>Signal "{mutationsError.signalName}" causes an error doing <strong>{mutationsError.mutation.name}</strong>("{mutationsError.mutation.path.join('.')}", {JSON.stringify(mutationsError.mutation.args).replace(/^\[/, '').replace(/]$/, '')})</h4>
           </div>
           : <div className='debugger-toolbar'>
             <Toolbar />

--- a/packages/cerebral-forms/src/rules.js
+++ b/packages/cerebral-forms/src/rules.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 const rules = {
   isExisty (value) {
     return value !== null && value !== undefined

--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -67,7 +67,11 @@ class Controller extends EventEmitter {
       typeof navigator !== 'undefined' &&
       /Chrome/.test(navigator.userAgent)
     ) {
-      console.warn('You are not using the Cerebral devtools. It is highly recommended to use it in combination with the debugger: https://cerebral.github.io/cerebral-website/getting-real/03_devtools.html')
+      console.warn('You are not using the Cerebral devtools. It is highly recommended to use it in combination with the debugger: https://cerebral.github.io/cerebral-website/install/02_debugger.html')
+    }
+
+    if (this.options.strictRender) {
+      console.warn('We are just notifying you that STRICT RENDER is on')
     }
 
     if (this.router) this.router.init()

--- a/packages/cerebral/src/operators/debounce.test.js
+++ b/packages/cerebral/src/operators/debounce.test.js
@@ -31,17 +31,19 @@ describe('operator.debounce', () => {
     const controller = new Controller({
       signals: {
         test: [
-          [ debounce(50), {
-            continue: [
-              () => {
-                assert.deepEqual(result, ['parallel', 'parallel', 'discard'])
-                done()
-              }
-            ],
-            discard: [() => { result.push('discard') }]
-          },
-          () => { result.push('parallel') }
-        ]]
+          [
+            debounce(50), {
+              continue: [
+                () => {
+                  assert.deepEqual(result, ['parallel', 'parallel', 'discard'])
+                  done()
+                }
+              ],
+              discard: [() => { result.push('discard') }]
+            },
+            () => { result.push('parallel') }
+          ]
+        ]
       }
     })
     controller.getSignal('test')()

--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -18,6 +18,7 @@ export default (View) => {
         this.Component = Component
         this.cachedSignals = null
         this.depsMap = this.getDepsMap()
+        this.hasWarnedBigComponent = false
       }
       componentWillMount () {
         if (!this.context.cerebral.controller) {
@@ -88,9 +89,11 @@ export default (View) => {
         if (
           this.context.cerebral.controller.devtools &&
           this.context.cerebral.controller.devtools.bigComponentsWarning &&
+          !this.hasWarnedBigComponent &&
           Object.keys(statePaths || {}).length >= this.context.cerebral.controller.devtools.bigComponentsWarning.state
         ) {
-          console.warn(`Component named ${Component.displayName || Component.name} has a lot of state dependencies, consider refactoring. Adjust this option in devtools`)
+          console.warn(`Component named ${Component.displayName || Component.name} has a lot of state dependencies, consider refactoring or adjust this option in devtools`)
+          this.hasWarnedBigComponent = true
         }
 
         if (this.signals) {
@@ -99,9 +102,11 @@ export default (View) => {
           if (
             this.context.cerebral.controller.devtools &&
             this.context.cerebral.controller.devtools.bigComponentsWarning &&
+            !this.hasWarnedBigComponent &&
             Object.keys(extractedSignals).length >= this.context.cerebral.controller.devtools.bigComponentsWarning.signals
           ) {
-            console.warn(`Component named ${Component.displayName || Component.name} has a lot of signals, consider refactoring. Adjust this option in devtools`)
+            console.warn(`Component named ${Component.displayName || Component.name} has a lot of signals, consider refactoring or adjust this option in devtools`)
+            this.hasWarnedBigComponent = true
           }
           propsToPass = Object.keys(extractedSignals).reduce((currentProps, key) => {
             currentProps[key] = controller.getSignal(extractedSignals[key])

--- a/packages/cerebral/src/viewFactories/react.test.js
+++ b/packages/cerebral/src/viewFactories/react.test.js
@@ -398,6 +398,38 @@ describe('React', () => {
 
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
     })
+    it('should be able to adjust props with function', () => {
+      const controller = Controller({
+        state: {
+          foo: 'bar'
+        },
+        signals: {
+          foo: []
+        }
+      })
+      const TestComponent = connect({
+        foo: 'foo'
+      }, {
+        fooSignal: 'foo'
+      }, (ownProps, stateProps, signalProps) => {
+        assert.deepEqual(ownProps, {mip: 'mop'})
+        assert.deepEqual(stateProps, {foo: 'bar'})
+        assert.equal(typeof signalProps.fooSignal, 'function')
+
+        return stateProps
+      }, (props) => {
+        return (
+          <div>{props.foo}</div>
+        )
+      })
+      const tree = TestUtils.renderIntoDocument((
+        <Container controller={controller}>
+          <TestComponent mip='mop' />
+        </Container>
+      ))
+
+      assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+    })
     it('should update on props change', () => {
       const controller = Controller({})
       class TestComponentClass2 extends React.Component {

--- a/packages/demo/src/components/Header/index.js
+++ b/packages/demo/src/components/Header/index.js
@@ -5,7 +5,7 @@ import translations from '../../common/computed/translations'
 
 import LangSelector from '../LangSelector'
 
-const TaglineRe = /^(.*)\[Cerebral\](.*)$/
+const TaglineRe = /^(.*)\[Cerebral](.*)$/
 
 export default connect(
   {

--- a/packages/forms-demo/src/helpers/syntaxHighlight.js
+++ b/packages/forms-demo/src/helpers/syntaxHighlight.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 export default function syntaxHighlight (json) {
   const regExp = /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g
   return json.replace(regExp, (match) => {


### PR DESCRIPTION
- now throws error when a state path definition is undefined, typically when importing computeds wrong
- Should only warn once now for big components
- Now warns when strict render is active
- Added:

```js
connect({}, {}, (ownProps, stateProps, signalProps) => {
  return {} // Overrides everything
}
```

Have not documented this yet, can do it in another pull. Got some other doc updates to do as well