### PR TITLE
fix(computed): include the computed fn name in the output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "cerebral",
   "version": "0.0.0-semantically-released",
   "description": "A state controller with its own debugger",
+  "release": {
+    "branch": "v1"
+  },
   "main": "src/index.js",
   "scripts": {
     "pretest": "standard",

--- a/src/Computed.js
+++ b/src/Computed.js
@@ -52,6 +52,7 @@ function Computed (paths, cb) {
       getDepsMap: function () {
         return deps
       },
+      computedName: cb.name,
       get: function (passedState, force) {
         if (!force && Computed.cache[cacheKey]) {
           return Computed.cache[cacheKey]


### PR DESCRIPTION
include the computed fn name in the output to fix nested computed cache