### PR TITLE
Added yarn for installing Cerebral 2 edge

### DIFF
--- a/packages/docs/content/install/01_cerebral.en.md
+++ b/packages/docs/content/install/01_cerebral.en.md
@@ -4,8 +4,10 @@ title: Cerebral
 
 ## Cerebral
 
-To install Cerebral you need to use the Node Package Manager. NPM is part of [Node](https://nodejs.org/en/), so please install that on your computer first. You should install Node version 5 or later. If you are not familiar with Node and/or Webpack it can be a good idea to start out with [the tutorial](../tutorial/01_introduction.html).
+To install Cerebral you need to use the Node Package Manager. NPM is part of [Node](https://nodejs.org/en/), so please install that on your computer first. You should install Node version 5 or later. If you are not familiar with Node and/or Webpack it can be a good idea to start out with [the tutorial](../tutorial/01_introduction.html). You should also install [yarn](https://www.npmjs.com/package/yarn) (it is used instead of `npm` in the latest `create-app-react`)
+
+`npm install -g yarn`
 
 To install Cerebral Alpha you have to explicitly install Cerebral and its dependency:
 
-`npm install cerebral@next function-tree@next --save --save-exact`
+`yarn add cerebral@next function-tree@next`


### PR DESCRIPTION
Added simpler yarn. It's already used by default in create-react-app, so it makes sense to use it also here.