### PR TITLE
fix(tutorial): npm install did not work (tested on windows)

### DIFF
--- a/packages/tutorial/package.json
+++ b/packages/tutorial/package.json
@@ -15,9 +15,9 @@
     "shelljs": "^0.7.5"
   },
   "dependencies": {
-    "cerebral": "2.0.0-0",
-    "cerebral-provider-http": "1.0.0-0",
-    "cerebral-router": "1.0.0-0",
+    "cerebral": "next",
+    "cerebral-provider-http": "next",
+    "cerebral-router": "next",
     "js-logger": "1.3.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"


### PR DESCRIPTION
adding "next" - version for the cerebral stuff directly into the package.json solved the install

issue


@todo: the alpha instructions needs to be updated if this gets pulled int