### PR TITLE
refactor(function-tree): improve error message on missing promise or path

### DIFF
--- a/packages/function-tree/src/FunctionTree.test.js
+++ b/packages/function-tree/src/FunctionTree.test.js
@@ -172,7 +172,7 @@ describe('FunctionTree', () => {
       })
     })
   })
-  it('should give error when path and no path returned', () => {
+  it('should give error when path and no path returned', (done) => {
     function actionA () {
       return {
         foo: 'bar'
@@ -185,8 +185,9 @@ describe('FunctionTree', () => {
         success: []
       }
     ]
-    execute.once('error', () => {
-      assert.ok(true)
+    execute.once('error', (error) => {
+      assert.ok(error.message.match(/needs to be a path or a Promise/))
+      done()
     })
     execute(tree)
   })

--- a/packages/function-tree/src/index.js
+++ b/packages/function-tree/src/index.js
@@ -116,7 +116,7 @@ class FunctionTreeExecution extends EventEmitter {
       functionTree.emit('functionEnd', execution, funcDetails, payload)
       next(result.toJS())
     } else if (funcDetails.outputs) {
-      let error = new Error('The result ' + JSON.stringify(result) + ' from function ' + funcDetails.name + ' needs to be a path')
+      let error = new Error('The result ' + JSON.stringify(result) + ' from function ' + funcDetails.name + ' needs to be a path or a Promise')
 
       errorCallback(error)
     } else if (isValidResult(result)) {


### PR DESCRIPTION
When an action contains a promise but the promise is not returned, the current error message can be confusing because all parts of the Promise may be returning a path. Maybe this message can slightly help: ...should return a path **or a Promise**

BTW, the previous test was a noop and would always pass.