### PR TITLE
Info about strict render should not be a warning

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -63,7 +63,7 @@ class Controller extends EventEmitter {
     if (this.devtools) {
       this.devtools.init(this)
     } else if (
-      process.env.NODE_ENV !== 'production' &&
+      isDeveloping() &&
       typeof navigator !== 'undefined' &&
       /Chrome/.test(navigator.userAgent)
     ) {
@@ -71,7 +71,7 @@ class Controller extends EventEmitter {
     }
 
     if (
-      process.env.NODE_ENV !== 'production' &&
+      isDeveloping() &&
       this.options.strictRender
     ) {
       console.info('We are just notifying you that STRICT RENDER is on')

--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -70,7 +70,10 @@ class Controller extends EventEmitter {
       console.warn('You are not using the Cerebral devtools. It is highly recommended to use it in combination with the debugger: https://cerebral.github.io/cerebral-website/install/02_debugger.html')
     }
 
-    if (this.options.strictRender) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      this.options.strictRender
+    ) {
       console.info('We are just notifying you that STRICT RENDER is on')
     }
 

--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -71,7 +71,7 @@ class Controller extends EventEmitter {
     }
 
     if (this.options.strictRender) {
-      console.warn('We are just notifying you that STRICT RENDER is on')
+      console.info('We are just notifying you that STRICT RENDER is on')
     }
 
     if (this.router) this.router.init()


### PR DESCRIPTION
As it's just a regular console information, it shouldn't be treated as a warning IMHO. In my build setup, I'm getting a notification each time there are new warning messages on the node server – which is a bit annoying if it's just a regular info like in this case.