### PR TITLE
More view tests and hoc.js bugs

### DIFF
--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -21,13 +21,13 @@ export default (View) => {
         this.depsMap = this.getDepsMap()
       }
       componentWillMount () {
-        if (!this.context.cerebral.controller) {
-          throw new Error('Can not find Cerebral controller, did you remember to use the Container component? Read more at: http://www.cerebraljs.com/documentation/cerebral-view-react')
+        if (!this.context.cerebral) {
+          throwError('Can not find Cerebral controller, did you remember to use the Container component? Read more at: http://www.cerebraljs.com/documentation/cerebral-view-react')
         }
 
-        if (!this.evaluatedPaths) {
+        /*if (!this.evaluatedPaths) {
           return
-        }
+        }*/
 
         this.context.cerebral.registerComponent(this, this.depsMap)
       }
@@ -65,7 +65,7 @@ export default (View) => {
         })
       }
       getDepsMap () {
-        return Object.keys(this.evaluatedPaths).reduce((currentDepsMap, pathKey) => {
+        return Object.keys(this.evaluatedPaths || {}).reduce((currentDepsMap, pathKey) => {
           if (this.evaluatedPaths[pathKey] instanceof Computed) {
             return Object.assign(currentDepsMap, this.evaluatedPaths[pathKey].depsMap)
           }

--- a/packages/cerebral/src/viewFactories/Hoc.js
+++ b/packages/cerebral/src/viewFactories/Hoc.js
@@ -25,9 +25,9 @@ export default (View) => {
           throwError('Can not find Cerebral controller, did you remember to use the Container component? Read more at: http://www.cerebraljs.com/documentation/cerebral-view-react')
         }
 
-        /*if (!this.evaluatedPaths) {
+        if (!this.evaluatedPaths) {
           return
-        }*/
+        }
 
         this.context.cerebral.registerComponent(this, this.depsMap)
       }

--- a/packages/cerebral/src/viewFactories/react.test.js
+++ b/packages/cerebral/src/viewFactories/react.test.js
@@ -157,10 +157,10 @@ describe('React', () => {
           <TestComponent />
         </Container>
       ))
-      const TestComponentRef = TestUtils.findRenderedComponentWithType(tree,TestComponent)
+      const TestComponentRef = TestUtils.findRenderedComponentWithType(tree, TestComponent)
       assert.equal(TestComponentRef._isUnmounting, undefined)
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
-      ReactDOM.unmountComponentAtNode(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').parentNode);
+      ReactDOM.unmountComponentAtNode(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').parentNode)
       assert.equal(TestComponentRef._isUnmounting, true)
       assert.deepEqual(controller.componentDependencyStore.getAllUniqueEntities(), [])
     })
@@ -246,13 +246,13 @@ describe('React', () => {
           <TestComponent />
         </Container>
       ))
-      //console.log(computed.factory.cache)
+      // console.log(computed.factory.cache)
       const TestComponentRef = TestUtils.findRenderedComponentWithType(tree, TestComponent)
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar computed')
-      ReactDOM.unmountComponentAtNode(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').parentNode);
+      ReactDOM.unmountComponentAtNode(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').parentNode)
       assert.equal(TestComponentRef._isUnmounting, true)
-      //console.log(TestComponentRef.depsMap)
-      //console.log(computed.factory.cache)
+      // console.log(TestComponentRef.depsMap)
+      // console.log(computed.factory.cache)
     })
     it('should be able to work undefined paths', () => {
       const controller = Controller({
@@ -295,11 +295,6 @@ describe('React', () => {
       assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
     })
     it('should throw an error if no container component provided', () => {
-      const controller = Controller({
-        state: {
-          foo: 'bar'
-        }
-      })
       const TestComponent = connect({
         foo: 'foo'
       }, (props) => {
@@ -651,7 +646,7 @@ describe('React', () => {
       })
       const tree = TestUtils.renderIntoDocument((
         <Container controller={controller}>
-          <TestComponent currentUser={0} changedUserSignalName='changedUser'/>
+          <TestComponent currentUser={ 0 } changedUserSignalName='changedUser'/>
         </Container>
       ))
 

--- a/packages/cerebral/src/viewFactories/react.test.js
+++ b/packages/cerebral/src/viewFactories/react.test.js
@@ -167,6 +167,11 @@ describe('React', () => {
   })
   describe('connect', () => {
     it('should log with devtools when component state/signals more than devtools', () => {
+      const originalConsoleWarn = console.warn
+      console.warn = (message) => {
+        assert.equal(message, 'Component named MyComponent has a lot of state dependencies, consider refactoring or adjust this option in devtools')
+        console.warn = originalConsoleWarn
+      }
       const controller = Controller({
         devtools: {bigComponentsWarning: {state: 1, signals: 1}, init () {}, send () {}, updateComponentsMap () {}},
         state: {
@@ -183,7 +188,7 @@ describe('React', () => {
         bar: 'bar'
       }, {
         fooCalled: 'fooCalled'
-      }, (props) => {
+      }, function MyComponent (props) {
         return (
           <div>{props.foo}</div>
         )
@@ -193,9 +198,13 @@ describe('React', () => {
           <TestComponent />
         </Container>
       ))
-      // how to get hasWarnedBigComponent or console.log??
     })
     it('should log with devtools when component state/signals more than devtools', () => {
+      const originalConsoleWarn = console.warn
+      console.warn = (message) => {
+        assert.equal(message, 'Component named MyComponent has a lot of signals, consider refactoring or adjust this option in devtools')
+        console.warn = originalConsoleWarn
+      }
       const controller = Controller({
         devtools: {bigComponentsWarning: {state: 1, signals: 1}, init () {}, send () {}, updateComponentsMap () {}},
         state: {
@@ -210,7 +219,7 @@ describe('React', () => {
       }, {
         fooCalled: 'fooCalled',
         barCalled: 'barCalled'
-      }, (props) => {
+      }, function MyComponent (props) {
         return (
           <div>{props.foo}</div>
         )
@@ -220,7 +229,6 @@ describe('React', () => {
           <TestComponent />
         </Container>
       ))
-      // how to get hasWarnedBigComponent or console.log??
     })
     it('should be able to remove computed from depsMap after unmounting component', () => {
       const controller = Controller({
@@ -646,7 +654,7 @@ describe('React', () => {
       })
       const tree = TestUtils.renderIntoDocument((
         <Container controller={controller}>
-          <TestComponent currentUser={ 0 } changedUserSignalName='changedUser'/>
+          <TestComponent currentUser={0} changedUserSignalName='changedUser' />
         </Container>
       ))
 


### PR DESCRIPTION
@christianalfoni  When I was trying to improve test coverage of hoc.js, I found some bugs. I fixed small ones, but I don't have time to fix one of the bug related to computed.
Computeds are not automatically removed before a component is unmounted (componentWillUnmount). There is a problem at https://github.com/cerebral/cerebral/blob/master/packages/cerebral/src/viewFactories/Hoc.js#L70 
