### PR TITLE
fix(firebase): always resolve onauthchange

### DIFF
--- a/packages/cerebral-provider-firebase/src/getUser.js
+++ b/packages/cerebral-provider-firebase/src/getUser.js
@@ -18,13 +18,9 @@ export default function getUser () {
         } else {
           const unsubscribe = firebase.auth().onAuthStateChanged(user => {
             unsubscribe()
-            if (user) {
-              resolve({
-                user: createUser(user)
-              })
-            } else {
-              reject()
-            }
+            resolve({
+              user: user ? createUser(user) : null
+            })
           })
         }
       },


### PR DESCRIPTION
Firebase should not reject `onauthchange` event when there is no user. No user is considered a "success", there just is no user there. It is not the same as an HTTP request, because there are no error codes. Either it fails or it works... and "no user" works, so should be success.