### PR TITLE
feat(function-tree): parallel execution events, improve Cerebral flushing

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -53,8 +53,17 @@ class Controller extends EventEmitter {
     )
 
     this.runTree = new FunctionTree(allProviders)
-    this.runTree.on('asyncFunction', () => this.flush())
-    this.runTree.on('pathEnd', () => this.flush())
+    this.runTree.on('asyncFunction', (execution, funcDetails) => {
+      if (!funcDetails.isParallel) {
+        this.flush()
+      }
+    })
+    this.runTree.on('parallelStart', () => this.flush())
+    this.runTree.on('parallelProgress', (execution, currentPayload, functionsResolving) => {
+      if (functionsResolving === 1) {
+        this.flush()
+      }
+    })
     this.runTree.on('end', () => this.flush())
     this.runTree.on('error', (error) => {
       throw error

--- a/packages/function-tree/README.md
+++ b/packages/function-tree/README.md
@@ -344,6 +344,7 @@ const execute = FunctionTree([
     functionDetails.name // Name of the function
     functionDetails.functionIndex // The index of the function in the tree, like an ID
     functionDetails.function // A reference to the running function
+    functionDetails.isParallel // If the function is running in parallel with others
 
     context.execution.name // Function tree id
     context.execution.id // Current execution id
@@ -525,6 +526,15 @@ execute.on('functionEnd', (execution, functionDetails, payload) => {})
 
 // Triggers when an async function has been run
 execute.on('asyncFunction', (execution, functionDetails, payload) => {})
+
+// When a parallel execution is about to happen (array in array)
+execute.on('parallelStart', (execution, payload, functionsToResolveCount) => {})
+
+// When a function in parallel execution is done executing
+execute.on('parallelProgress', (execution, payload, functionsStillResolvingCount) => {})
+
+// When a parallel execution is done
+execute.on('parallelEnd', (execution, payload, functionsExecutedCount) => {})
 
 execute(tree)
 ```

--- a/packages/function-tree/src/index.js
+++ b/packages/function-tree/src/index.js
@@ -221,6 +221,15 @@ class FunctionTree extends EventEmitter {
       (currentPayload) => {
         this.emit('pathEnd', execution, currentPayload)
       },
+      (currentPayload, functionsToResolve) => {
+        this.emit('parallelStart', execution, currentPayload, functionsToResolve)
+      },
+      (currentPayload, functionsResolved) => {
+        this.emit('parallelProgress', execution, currentPayload, functionsResolved)
+      },
+      (currentPayload, functionsResolved) => {
+        this.emit('parallelEnd', execution, currentPayload, functionsResolved)
+      },
       (finalPayload) => {
         this.emit('end', execution, finalPayload)
         cb && cb(null, execution, finalPayload)

--- a/packages/function-tree/src/staticTree.js
+++ b/packages/function-tree/src/staticTree.js
@@ -6,7 +6,7 @@ function getFunctionName (fn) {
   return ret
 }
 
-function traverse (functions, item, isChain) {
+function traverse (functions, item, isChain, isParallel) {
   if (Array.isArray(item) && typeof isChain === 'boolean') {
     item = item.slice()
     return item.map((subItem, index) => {
@@ -14,12 +14,12 @@ function traverse (functions, item, isChain) {
         let nextSubItem = item[index + 1]
         if (!Array.isArray(nextSubItem) && typeof nextSubItem === 'object') {
           item.splice(index + 1, 1)
-          return traverse(functions, subItem, nextSubItem)
+          return traverse(functions, subItem, nextSubItem, !isChain)
         } else {
-          return traverse(functions, subItem, null)
+          return traverse(functions, subItem, null, !isChain)
         }
       } else if (Array.isArray(item) && isChain) {
-        return traverse(functions, subItem, false)
+        return traverse(functions, subItem, false, !isChain)
       }
       throw new Error('Signal Tree - Unexpected entry in signal chain')
     }).filter((func) => {
@@ -31,7 +31,8 @@ function traverse (functions, item, isChain) {
     const funcDetails = {
       name: func.displayName || getFunctionName(func),
       functionIndex: functions.push(func) - 1,
-      function: func
+      function: func,
+      isParallel: isParallel
     }
     if (outputs) {
       funcDetails.outputs = {}


### PR DESCRIPTION
Currently Cerebral triggers a flush on every `pathEnd` event from function-tree. This was added to handle situations of:

```js
[
  [
    asyncA, {success: [actionA], error: []}, // Need to flush as asyncB is still processing
    asyncB, {success: [actionB], error: []},
  ]
]
```

The problem here is that there are many times `pathEnd` executes without needing to, like when paths are not related to async execution. This causes renders of app in between plain synchronous actions.

Now Cerebral is smarter. It triggers flushes on:

- Async action that is not parallel
- When parallel execution starts
- When parallel actions resolve, except the last one (handled by other events)
- When signal ends

This generally improves performance and makes Cerebral more predictable.

Fixed the bug in our app  as well, tested :)