### PR TITLE
feat(firebase): delete user and throw errors correctly

### DIFF
--- a/packages/cerebral-provider-firebase/src/createUserWithEmailAndPassword.js
+++ b/packages/cerebral-provider-firebase/src/createUserWithEmailAndPassword.js
@@ -2,25 +2,19 @@ import firebase from 'firebase'
 import {createUser} from './helpers'
 
 export default function createUserWithEmailAndPassword (email, password) {
-  return firebase.auth().createUserWithEmailAndPassword(email, password)
-    .then(
-      () => {
-        return new Promise((resolve) => {
-          const unsubscribe = firebase.auth().onAuthStateChanged(user => {
-            unsubscribe()
-            resolve({
-              user: createUser(user)
-            })
+  return new Promise((resolve, reject) => {
+    firebase.auth().createUserWithEmailAndPassword(email, password)
+      .then(() => {
+        const unsubscribe = firebase.auth().onAuthStateChanged(user => {
+          unsubscribe()
+          resolve({
+            user: createUser(user)
           })
         })
       },
       (error) => {
-        return {
-          error: {
-            code: error.code,
-            message: error.message
-          }
-        }
+        reject({error})
       }
     )
+  })
 }

--- a/packages/cerebral-provider-firebase/src/deleteUser.js
+++ b/packages/cerebral-provider-firebase/src/deleteUser.js
@@ -1,0 +1,9 @@
+import firebase from 'firebase'
+
+export default function deleteUser (password) {
+  return new Promise((resolve, reject) => {
+    const user = firebase.auth().currentUser
+
+    return user.delete().then(() => resolve(), (error) => reject({error}))
+  })
+}

--- a/packages/cerebral-provider-firebase/src/factories/deleteUser.js
+++ b/packages/cerebral-provider-firebase/src/factories/deleteUser.js
@@ -1,0 +1,13 @@
+function deleteUserFactory (passwordTemplate) {
+  function deleteUser (context) {
+    const password = typeof passwordTemplate === 'function' ? passwordTemplate(context).value : passwordTemplate
+
+    return context.firebase.deleteUser(password)
+      .then(context.path.success)
+      .catch(context.path.error)
+  }
+
+  return deleteUser
+}
+
+export default deleteUserFactory

--- a/packages/cerebral-provider-firebase/src/index.js
+++ b/packages/cerebral-provider-firebase/src/index.js
@@ -22,6 +22,8 @@ import signInWithEmailAndPassword from './signInWithEmailAndPassword'
 import signOutService from './signOut'
 import signInWithFacebook from './signInWithFacebook'
 import signInWithGoogle from './signInWithGoogle'
+import deleteUser from './deleteUser'
+import sendPasswordResetEmail from './sendPasswordResetEmail'
 
 export {default as createUserWithEmailAndPassword} from './factories/createUserWithEmailAndPassword'
 export {default as getUser} from './factories/getUser'
@@ -30,7 +32,6 @@ export {default as onChildAdded} from './factories/onChildAdded'
 export {default as onChildChanged} from './factories/onChildChanged'
 export {default as onChildRemoved} from './factories/onChildRemoved'
 export {default as onValue} from './factories/onValue'
-export {default as sendPasswordResetEmail} from './factories/sendPasswordResetEmail'
 export {default as signInAnonymously} from './factories/signInAnonymously'
 export {default as signInWithEmailAndPassword} from './factories/signInWithEmailAndPassword'
 export {default as signInWithFacebook} from './factories/signInWithFacebook'
@@ -45,6 +46,8 @@ export {default as put} from './factories/put'
 export {default as delete} from './factories/delete'
 export {default as remove} from './factories/remove'
 export {default as transaction} from './factories/transaction'
+export {default as deleteUser} from './factories/deleteUser'
+export {default as sendPasswordResetEmail} from './factories/sendPasswordResetEmail'
 
 export default function FirebaseProviderFactory (options = { payload: {} }) {
   firebase.initializeApp(options.config)
@@ -76,9 +79,8 @@ export default function FirebaseProviderFactory (options = { payload: {} }) {
         createUserWithEmailAndPassword,
         signInWithEmailAndPassword,
         signOut: signOutService,
-        sendPasswordResetEmail (email) {
-          return firebase.auth().sendPasswordResetEmail(email)
-        }
+        deleteUser,
+        sendPasswordResetEmail
       }
     }
 
@@ -91,15 +93,3 @@ export default function FirebaseProviderFactory (options = { payload: {} }) {
 
   return FirebaseProvider
 }
-
-/*
-export default (options = { payload: {} }) => (module, controller) => {
-  controller.addContextProvider({
-    'cerebral-module-firebase': module.path
-  })
-  firebase.initializeApp(options.config)
-  module.addServices({
-
-  })
-}
-*/

--- a/packages/cerebral-provider-firebase/src/sendPasswordResetEmail.js
+++ b/packages/cerebral-provider-firebase/src/sendPasswordResetEmail.js
@@ -1,0 +1,11 @@
+import firebase from 'firebase'
+
+export default function sendPasswordResetEmail (email) {
+  return new Promise((resolve, reject) => {
+    firebase.auth().sendPasswordResetEmail(email)
+      .then(
+        () => resolve(),
+        (error) => reject({error})
+      )
+  })
+}

--- a/packages/cerebral-provider-firebase/src/signInWithEmailAndPassword.js
+++ b/packages/cerebral-provider-firebase/src/signInWithEmailAndPassword.js
@@ -2,25 +2,20 @@ import firebase from 'firebase'
 import {createUser} from './helpers'
 
 export default function signInWithEmailAndPassword (email, password) {
-  return firebase.auth().signInWithEmailAndPassword(email, password)
-    .then(
-      () => {
-        return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    firebase.auth().signInWithEmailAndPassword(email, password)
+      .then(
+        () => {
           const unsubscribe = firebase.auth().onAuthStateChanged(user => {
             unsubscribe()
             resolve({
               user: createUser(user)
             })
           })
-        })
-      },
-      (error) => {
-        return {
-          error: {
-            code: error.code,
-            message: error.message
-          }
+        },
+        (error) => {
+          reject({error})
         }
-      }
-    )
+      )
+  })
 }


### PR DESCRIPTION
- Can not return values from `catch` as they will be no longer propagate as errors, have to reject or throw again

- Wrapped a few methods with normal promises, cause Firebase promise is not native