### PR TITLE
fix(firebase): pass payload also on onValue and onChildChanged

### DIFF
--- a/packages/cerebral-provider-firebase/README.md
+++ b/packages/cerebral-provider-firebase/README.md
@@ -237,10 +237,12 @@ When you also want to know when your queried data updates you have the following
 *action*
 ```js
 function someAction({ firebase }) {
-  firebase.onValue('someKey.foo', 'someModule.fooUpdated');
+  firebase.onValue('someKey.foo', 'someModule.fooUpdated',  {
+    payload: {}, // Merged with the payload passed on new data
+  });
 }
 ```
-This will immediately grab the value and trigger the signal passed. Any other updates to the value will trigger the same signal.
+This will **NOT** immediately grab the value and trigger the signal passed, the first event is discarded for more predictable behaviour. To grab existing value, just use `value`.
 
 To stop listening for updates to the value:
 ```js

--- a/packages/cerebral-provider-firebase/src/createOnChildChanged.js
+++ b/packages/cerebral-provider-firebase/src/createOnChildChanged.js
@@ -11,10 +11,20 @@ export default function createOnChildChanged (controller) {
       'child_changed',
       signal,
       (data) => {
-        controller.getSignal(signal)(Object.assign({
+        const initialPayload = {
           key: data.key,
           value: data.val()
-        }, options.payload))
+        }
+        let payload = initialPayload
+
+        if (options.payload) {
+          payload = Object.keys(options.payload).reduce((payload, key) => {
+            payload[key] = options.payload[key]
+
+            return payload
+          }, initialPayload)
+        }
+        controller.getSignal(signal)(payload)
       }
     )
   }

--- a/packages/cerebral-provider-firebase/src/createOnValue.js
+++ b/packages/cerebral-provider-firebase/src/createOnValue.js
@@ -4,16 +4,32 @@ import {
 } from './helpers'
 
 export default function createOnValue (controller) {
-  return (path, signal, options) => {
+  return (path, signal, options = {}) => {
+    let hasEmittedInitialValue = false
     listenTo(
       createRef(path, options),
       path,
       'value',
       signal,
       (data) => {
-        controller.getSignal(signal)({
+        if (!hasEmittedInitialValue) {
+          hasEmittedInitialValue = true
+          return
+        }
+
+        const initialPayload = {
           value: data.val()
-        })
+        }
+        let payload = initialPayload
+
+        if (options.payload) {
+          payload = Object.keys(options.payload).reduce((payload, key) => {
+            payload[key] = options.payload[key]
+
+            return payload
+          }, initialPayload)
+        }
+        controller.getSignal(signal)(payload)
       }
     )
   }


### PR DESCRIPTION
- Can now pass payload on other listeners as well
- `onValue` does not trigger initial value for more predictable behaviour... it is a listener for change, not grab initial value.. that is why you have `value`