### PR TITLE
feat(StateContainer): Add support for signals on the dummyController

### DIFF
--- a/docs/docs/content/best-practices/03_testing.en.md
+++ b/docs/docs/content/best-practices/03_testing.en.md
@@ -17,16 +17,23 @@ import {StateContainer} from 'cerebral/react'
 import Foo from './Foo'
 
 describe('<Foo />', () => {
-  it('allows us to set props', () => {
+  it('allows us to set props and invoke signals', () => {
     const state = {
       foo: 'bar'
     }
+    const signals = {
+      'form.submitted': (input) => {
+        // should be called when form is submitted
+        // assert input is as expected
+      }
+    }
     const wrapper = mount(
-      <StateContainer state={state}>
+      <StateContainer state={state} signals={signals}>
         <Foo />
       </StateContainer>
     )
     expect(wrapper.find('.foo')).to.have.length(1)
+    wrapper.find('.submit-button').simulate('click')
   })
 })
 ```

--- a/packages/cerebral/src/viewFactories/StateContainer.js
+++ b/packages/cerebral/src/viewFactories/StateContainer.js
@@ -51,7 +51,7 @@ function createDummyController (state = {}, signals = {}) {
       get: getState
     },
     getSignal (signal) {
-      return signals[signal] || () => {}
+      return signals[signal] || (() => {})
     }
   }
 }

--- a/packages/cerebral/src/viewFactories/StateContainer.js
+++ b/packages/cerebral/src/viewFactories/StateContainer.js
@@ -3,7 +3,7 @@ import {ensurePath, noop} from '../utils'
 export default (View) => {
   class StateContainer extends View.Component {
     getChildContext () {
-      const controller = createDummyController(this.props.state)
+      const controller = createDummyController(this.props.state, this.props.signals)
       return {
         cerebral: {
           controller: controller,
@@ -37,7 +37,7 @@ export default (View) => {
   to this Container it will create a dummy version which inserts
   state and mocks any signals when connecting the component.
 */
-function createDummyController (state = {}) {
+function createDummyController (state = {}, signals = {}) {
   const getState = (path) => {
     return ensurePath(path).reduce((currentState, pathKey) => {
       return currentState[pathKey]
@@ -50,8 +50,8 @@ function createDummyController (state = {}) {
     model: {
       get: getState
     },
-    getSignal () {
-      return () => {}
+    getSignal (signal) {
+      return signals[signal] || () => {}
     }
   }
 }


### PR DESCRIPTION
You can now add dummy signals to the test controller

```js
import { StateContainer } from 'cerebral/react'

describe('<Form />', () => {
  it('handles submit button click', () => {
    const testSignal = (input) => { /* assert something */ }
    const wrapper = mount(
      <StateContainer state={global.fixtures} signals={{ 'form.submitted': testSignal }}
        <Form />
      </StateContainer>
    )
    const button = wrapper.find('button')
    button.simulate('click')
  })
})
```