### PR TITLE
feat(http): add support for status code paths

### DIFF
--- a/packages/cerebral-provider-http/README.md
+++ b/packages/cerebral-provider-http/README.md
@@ -161,6 +161,19 @@ export default [
 ]
 ```
 
+To check the response for a specific http status code, simply use the code for the path name and it will be called when the response code matches.
+
+```js
+export default [
+  httpPut('/items/1', { title: 'updated' }), {
+    '201': [],
+    success: [], // all other success codes will call this path
+    '401': [],
+    error: [] // all other error codes will call this path
+  }
+]
+```
+
 ### Response
 
 ```js

--- a/packages/cerebral-provider-http/src/factories/httpDelete.js
+++ b/packages/cerebral-provider-http/src/factories/httpDelete.js
@@ -1,16 +1,8 @@
-import {convertObjectWithTemplates} from '../utils'
+import {convertObjectWithTemplates, processResponse} from '../utils'
 
 function httpDeleteFactory (url, query = {}) {
   function httpDelete ({http, path, resolveArg}) {
-    return http.delete(resolveArg.value(url), convertObjectWithTemplates(query, resolveArg))
-      .then(path.success)
-      .catch((response) => {
-        if (response.isAborted) {
-          return path.abort(response)
-        }
-
-        return path.error(response)
-      })
+    return processResponse(http.delete(resolveArg.value(url), convertObjectWithTemplates(query, resolveArg)), path)
   }
 
   return httpDelete

--- a/packages/cerebral-provider-http/src/factories/httpGet.js
+++ b/packages/cerebral-provider-http/src/factories/httpGet.js
@@ -1,16 +1,8 @@
-import {convertObjectWithTemplates} from '../utils'
+import {convertObjectWithTemplates, processResponse} from '../utils'
 
 function httpGetFactory (url, query = {}) {
   function httpGet ({http, path, resolveArg}) {
-    return http.get(resolveArg.value(url), convertObjectWithTemplates(query, resolveArg))
-      .then(path.success)
-      .catch((response) => {
-        if (response.isAborted) {
-          return path.abort(response)
-        }
-
-        return path.error(response)
-      })
+    return processResponse(http.get(resolveArg.value(url), convertObjectWithTemplates(query, resolveArg)), path)
   }
 
   return httpGet

--- a/packages/cerebral-provider-http/src/factories/httpPatch.js
+++ b/packages/cerebral-provider-http/src/factories/httpPatch.js
@@ -1,16 +1,8 @@
-import {convertObjectWithTemplates} from '../utils'
+import {convertObjectWithTemplates, processResponse} from '../utils'
 
 function httpPatchFactory (url, body = {}) {
   function httpPatch ({http, path, resolveArg}) {
-    return http.patch(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg))
-      .then(path.success)
-      .catch((response) => {
-        if (response.isAborted) {
-          return path.abort(response)
-        }
-
-        return path.error(response)
-      })
+    return processResponse(http.patch(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg)), path)
   }
 
   return httpPatch

--- a/packages/cerebral-provider-http/src/factories/httpPost.js
+++ b/packages/cerebral-provider-http/src/factories/httpPost.js
@@ -1,16 +1,8 @@
-import {convertObjectWithTemplates} from '../utils'
+import {convertObjectWithTemplates, processResponse} from '../utils'
 
 function httpPostFactory (url, body = {}) {
   function httpPost ({http, path, resolveArg}) {
-    return http.post(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg))
-      .then(path.success)
-      .catch((response) => {
-        if (response.isAborted) {
-          return path.abort(response)
-        }
-
-        return path.error(response)
-      })
+    return processResponse(http.post(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg)), path)
   }
 
   return httpPost

--- a/packages/cerebral-provider-http/src/factories/httpPut.js
+++ b/packages/cerebral-provider-http/src/factories/httpPut.js
@@ -1,16 +1,8 @@
-import {convertObjectWithTemplates} from '../utils'
+import {convertObjectWithTemplates, processResponse} from '../utils'
 
 function httpPutFactory (url, body = {}) {
   function httpPut ({http, path, resolveArg}) {
-    return http.put(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg))
-      .then(path.success)
-      .catch((response) => {
-        if (response.isAborted) {
-          return path.abort(response)
-        }
-
-        return path.error(response)
-      })
+    return processResponse(http.put(resolveArg.value(url), convertObjectWithTemplates(body, resolveArg)), path)
   }
 
   return httpPut

--- a/packages/cerebral-provider-http/src/http.test.js
+++ b/packages/cerebral-provider-http/src/http.test.js
@@ -258,4 +258,26 @@ describe('Http Provider', () => {
       data: 1
     })
   })
+  it('should call status code paths', (done) => {
+    mock.get('/items/201', (req, res) => {
+      return res.status(201).header('Content-Type', 'application/json')
+    })
+
+    let responseCount = 0
+    const controller = Controller({
+      providers: [HttpProvider()],
+      signals: {
+        test: [
+          httpGet('/items/201'), {
+            '201': [() => { responseCount++ }]
+          },
+          () => {
+            assert.equal(responseCount, 1)
+            done()
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
+  })
 })

--- a/packages/cerebral-provider-http/src/utils.js
+++ b/packages/cerebral-provider-http/src/utils.js
@@ -80,3 +80,21 @@ export function parseHeaders (rawHeaders) {
     return parsedHeaders
   }, {})
 }
+
+function callNextPath (response, path, defaultPath) {
+  return path['' + response.status]
+    ? path['' + response.status](response)
+    : path[defaultPath](response)
+}
+
+export function processResponse(httpAction, path) {
+  return httpAction
+    .then((response) => callNextPath(response, path, 'success'))
+    .catch((response) => {
+      if (response.isAborted) {
+        return path.abort(response)
+      }
+
+      return callNextPath(response, path, 'error')
+    })
+}

--- a/packages/cerebral-provider-http/src/utils.js
+++ b/packages/cerebral-provider-http/src/utils.js
@@ -87,7 +87,7 @@ function callNextPath (response, path, defaultPath) {
     : path[defaultPath](response)
 }
 
-export function processResponse(httpAction, path) {
+export function processResponse (httpAction, path) {
   return httpAction
     .then((response) => callNextPath(response, path, 'success'))
     .catch((response) => {


### PR DESCRIPTION
```js
export default [
  httpPut('/items/1', { title: 'updated' }), {
    '201': [],
    success: [], // all other success codes will call this path
    '401': [],
    error: [] // all other error codes will call this path
  }
]
```