### PR TITLE
refactor(Controller): extend controller from function tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "standard": {
     "parser": "babel-eslint",
     "ignore": [
-      "**/node_modules/",
+      "**/node_modules/**",
       "**/build/"
     ],
     "globals": [

--- a/packages/cerebral-forms/src/utils/validate.test.js
+++ b/packages/cerebral-forms/src/utils/validate.test.js
@@ -192,7 +192,7 @@ describe('validate', () => {
       assert.equal(controller.getState('form.lastName.errorMessage'), null)
       assert.equal(controller.getState('form.age.errorMessage'), 'Must be numeric')
     })
-    it('should throw an error if dependsOn field path is not correct', () => {
+    it('should throw an error if dependsOn field path is not correct', (done) => {
       const controller = Controller({
         state: {
           form: form({
@@ -214,7 +214,12 @@ describe('validate', () => {
           ]
         }
       })
-      assert.throws(() => { controller.getSignal('fieldChanged')({value: 'Ben'}) }, Error, 'Error: The path form.someField used with "dependsOn" on field form.firstName is not correct, please check it')
+      controller.removeListener('error')
+      controller.once('error', (error) => {
+        assert(error)
+        done()
+      })
+      controller.getSignal('fieldChanged')({value: 'Ben'})
     })
     it('should show correct errorMessages', () => {
       const controller = Controller({

--- a/packages/cerebral/src/operators/concat.test.js
+++ b/packages/cerebral/src/operators/concat.test.js
@@ -34,7 +34,7 @@ describe('operator.concat', () => {
     controller.getSignal('test')()
     assert.deepEqual(controller.getState(), {list: ['one', 'two', 'three'], list2: ['two', 'three']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
         list: ['one']
@@ -46,8 +46,12 @@ describe('operator.concat', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.concat/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/merge.test.js
+++ b/packages/cerebral/src/operators/merge.test.js
@@ -43,7 +43,7 @@ describe('operator.merge', () => {
       largo: 'Largo Winch'
     }})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -54,9 +54,13 @@ describe('operator.merge', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.merge/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
   it('should create object if no value', () => {
     const controller = Controller({

--- a/packages/cerebral/src/operators/pop.test.js
+++ b/packages/cerebral/src/operators/pop.test.js
@@ -19,7 +19,7 @@ describe('operator.pop', () => {
     controller.getSignal('test')()
     assert.deepEqual(controller.getState(), {list: ['a', 'b']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -30,8 +30,12 @@ describe('operator.pop', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.pop/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/push.test.js
+++ b/packages/cerebral/src/operators/push.test.js
@@ -33,7 +33,7 @@ describe('operator.push', () => {
     controller.getSignal('test')({value: 'c'})
     assert.deepEqual(controller.getState(), {list: ['a', 'b', 'c']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -44,8 +44,12 @@ describe('operator.push', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.push/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/set.test.js
+++ b/packages/cerebral/src/operators/set.test.js
@@ -92,7 +92,7 @@ describe('operator.set', () => {
     controller.getSignal('test')()
     assert.equal(controller.getState().foo, 'bar2')
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -102,8 +102,12 @@ describe('operator.set', () => {
         ]
       }
     })
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.set/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/shift.test.js
+++ b/packages/cerebral/src/operators/shift.test.js
@@ -19,7 +19,7 @@ describe('operator.shift', () => {
     controller.getSignal('test')()
     assert.deepEqual(controller.getState(), {list: ['b', 'c']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -30,8 +30,12 @@ describe('operator.shift', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.shift/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/splice.test.js
+++ b/packages/cerebral/src/operators/splice.test.js
@@ -33,7 +33,7 @@ describe('operator.splice', () => {
     controller.getSignal('test')({idx: 2, x: 'one', y: 'two'})
     assert.deepEqual(controller.getState(), {list: ['a', 'b', 'one', 'two', 'd']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -44,8 +44,12 @@ describe('operator.splice', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.splice/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/toggle.test.js
+++ b/packages/cerebral/src/operators/toggle.test.js
@@ -36,7 +36,7 @@ describe('operator.toggle', () => {
     controller.getSignal('test')({ref: 'one'})
     assert.deepEqual(controller.getState(), {todos: {one: false, two: false}})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -47,8 +47,12 @@ describe('operator.toggle', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.toggle/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/unset.test.js
+++ b/packages/cerebral/src/operators/unset.test.js
@@ -20,7 +20,7 @@ describe('operator.unset', () => {
     controller.getSignal('test')()
     assert.deepEqual(controller.getState(), {bar: 'baz'})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -31,8 +31,12 @@ describe('operator.unset', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.unset/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/operators/unshift.test.js
+++ b/packages/cerebral/src/operators/unshift.test.js
@@ -33,7 +33,7 @@ describe('operator.unshift', () => {
     controller.getSignal('test')({value: 'x'})
     assert.deepEqual(controller.getState(), {list: ['x', 'a', 'b']})
   })
-  it('should throw on bad argument', () => {
+  it('should throw on bad argument', (done) => {
     const controller = Controller({
       state: {
       },
@@ -44,8 +44,12 @@ describe('operator.unshift', () => {
       }
     })
 
-    assert.throws(() => {
-      controller.getSignal('test')()
-    }, /operator.unshift/)
+    controller.removeListener('error')
+    controller.once('error', (error) => {
+      assert.ok(error)
+      done()
+    })
+
+    controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/viewFactories/react.test.js
+++ b/packages/cerebral/src/viewFactories/react.test.js
@@ -691,7 +691,7 @@ describe('React', () => {
         component.callSignal()
         assert.equal(renderCount, 2)
       })
-      it('should throw error with devtools when replacing path, causing render not to happen', () => {
+      it('should throw error with devtools when replacing path, causing render not to happen', (done) => {
         const controller = Controller({
           options: {strictRender: true},
           devtools: {verifyStrictRender: true, init () {}, send () {}, updateComponentsMap () {}},
@@ -726,9 +726,12 @@ describe('React', () => {
         ))
         assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'baz')
         const component = TestUtils.findRenderedComponentWithType(tree, TestComponentClass)
-        assert.throws(() => {
-          component.callSignal()
+        controller.removeListener('error')
+        controller.once('error', (error) => {
+          assert.ok(error)
+          done()
         })
+        component.callSignal()
       })
     })
     describe('DEFAULT render update', () => {


### PR DESCRIPTION
Tests needed to be refactored due to how controller async throws errors to not block function tree execution and messaging debugger