### PR TITLE
fix(router): Don't overwrite mapper option when passed to router

### DIFF
--- a/packages/cerebral-router/src/index.js
+++ b/packages/cerebral-router/src/index.js
@@ -31,7 +31,7 @@ export function goTo (url) {
 }
 
 export default function Router (options = {}) {
-  options.mapper = urlMapper({query: options.query})
+  options.mapper = options.mapper || urlMapper({query: options.query})
 
   return (controller) => {
     if (!options.mapper || typeof options.mapper.map !== 'function') {


### PR DESCRIPTION
I realise that this may just be a temporary fix until router is updated, but it would help out a lot of have it merged until the next router stuff is ready.