### PR TITLE
feat(babel): add initial babel plugins and preset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
   email: false
 before_script:
 - npm prune
-- lerna bootstrap --scope '@(function-tree|cerebral|cerebral-forms|cerebral-provider-http|cerebral-router)'
+- lerna bootstrap --scope '@(function-tree|cerebral|cerebral-forms|cerebral-provider-http|cerebral-router|babel-*)'
 after_success:
 - |
   echo $TRAVIS_BRANCH; echo $TRAVIS_PULL_REQUEST;

--- a/babel/babel-plugin-cerebral-optimize-tags/README.md
+++ b/babel/babel-plugin-cerebral-optimize-tags/README.md
@@ -1,4 +1,4 @@
-babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-plugin-cerebral-optimize-tags.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-optimize-tags/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-optimize-tags)
+babel-plugin-cerebral-proxy-tags
 =========================
 This plugin optimize the tagged templates into `new Tag()` calls trying to reduce the time it takes to
 build them.

--- a/babel/babel-plugin-cerebral-optimize-tags/README.md
+++ b/babel/babel-plugin-cerebral-optimize-tags/README.md
@@ -1,0 +1,4 @@
+babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-plugin-cerebral-optimize-tags.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-optimize-tags/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-optimize-tags)
+=========================
+This plugin optimize the tagged templates into `new Tag()` calls trying to reduce the time it takes to
+build them.

--- a/babel/babel-plugin-cerebral-optimize-tags/__tests__/__snapshots__/compile.js.snap
+++ b/babel/babel-plugin-cerebral-optimize-tags/__tests__/__snapshots__/compile.js.snap
@@ -1,0 +1,34 @@
+exports[`Transform tags to constructor calls should allow imported variable to be renamed 1`] = `
+"import { Tag as _Tag } from \'cerebral/tags\';
+
+state => new _Tag(\'state\', {
+      \'isStateDependency\': true
+}, [\'hello.\', \'\'], [new _Tag(\'state\', {
+      \'isStateDependency\': true
+}, [\'world\'], [])]);"
+`;
+
+exports[`Transform tags to constructor calls should ignore default imports 1`] = `
+"
+import state from \'cerebral/tags\';
+state.hello.world;"
+`;
+
+exports[`Transform tags to constructor calls should ignore variable when shadowed 1`] = `
+"import { Tag as _Tag } from \'cerebral/tags\';
+
+state => state.notChanged();"
+`;
+
+exports[`Transform tags to constructor calls should throw when import is not allowed 1`] = `"unknown: The Tag \"wrongImport\" can\'t be imported"`;
+
+exports[`Transform tags to constructor calls should transforms simple proxies 1`] = `
+"import { Tag as _Tag } from \'cerebral/tags\';
+
+const otherTag = () => {};
+otherTag\`hello.world\`;
+
+new _Tag(\'state\', {
+      \'isStateDependency\': true
+}, [\'hello.world\'], []);"
+`;

--- a/babel/babel-plugin-cerebral-optimize-tags/__tests__/__snapshots__/run.js.snap
+++ b/babel/babel-plugin-cerebral-optimize-tags/__tests__/__snapshots__/run.js.snap
@@ -1,0 +1,39 @@
+exports[`Run optimized tags should evaluate to a tag 1`] = `
+Tag {
+  "options": Object {
+    "hasValue": true,
+    "isStateDependency": true,
+  },
+  "strings": Array [
+    "hello.world",
+  ],
+  "type": "state",
+  "values": Array [],
+}
+`;
+
+exports[`Run optimized tags should evaluate to a tag with nested tags 1`] = `
+Tag {
+  "options": Object {
+    "hasValue": true,
+    "isStateDependency": true,
+  },
+  "strings": Array [
+    "a.",
+    "",
+  ],
+  "type": "state",
+  "values": Array [
+    Tag {
+      "options": Object {
+        "hasValue": true,
+      },
+      "strings": Array [
+        "b",
+      ],
+      "type": "input",
+      "values": Array [],
+    },
+  ],
+}
+`;

--- a/babel/babel-plugin-cerebral-optimize-tags/__tests__/compile.js
+++ b/babel/babel-plugin-cerebral-optimize-tags/__tests__/compile.js
@@ -1,0 +1,58 @@
+/* globals describe it expect */
+import {transform} from 'babel-core'
+import plugin from '../index'
+
+const pluginOptions = {
+  babelrc: false,
+  plugins: [plugin]
+}
+
+describe('Transform tags to constructor calls', () => {
+  it('should transforms simple proxies', () => {
+    const code = `
+      import {state} from 'cerebral/tags';
+      const otherTag = () => {};
+      otherTag\`hello.world\`;
+
+      state\`hello.world\`;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should ignore variable when shadowed', () => {
+    const code = `
+      import {state} from 'cerebral/tags';
+      (state) => state.notChanged();
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should allow imported variable to be renamed', () => {
+    const code = `
+      import {state as anotherName} from 'cerebral/tags';
+      (state) => anotherName\`hello.\${anotherName\`world\`}\`;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should throw when import is not allowed', () => {
+    const code = `
+      import {wrongImport} from 'cerebral/tags';
+    `
+    expect(() => {
+      transform(code, pluginOptions)
+    }).toThrowErrorMatchingSnapshot()
+  })
+
+  it('should ignore default imports', () => {
+    const code = `
+      import state from 'cerebral/tags';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/babel/babel-plugin-cerebral-optimize-tags/__tests__/run.js
+++ b/babel/babel-plugin-cerebral-optimize-tags/__tests__/run.js
@@ -1,0 +1,67 @@
+/* globals describe it expect  */
+import {transform} from 'babel-core'
+import {Tag} from 'cerebral/tags'
+import plugin from '../index'
+
+const pluginOptions = {
+  babelrc: false,
+  presets: ['es2015'],
+  plugins: [plugin]
+}
+
+describe('Run optimized tags', () => {
+  it('should evaluate to a tag', () => {
+    const code = `
+      import {state} from 'cerebral/tags';
+      state\`hello.world\`;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    const tag = eval(result) // eslint-disable-line no-eval
+    expect(tag).toBeInstanceOf(Tag)
+    expect(tag).toMatchSnapshot()
+  })
+
+  it('should evaluate to a tag with nested tags', () => {
+    const code = `
+      import {state, input} from 'cerebral/tags';
+      state\`a.\${input\`b\`}\`;
+    `
+    const getters = {
+      state: {
+        a: {
+          c: 'Working!'
+        }
+      },
+      input: {
+        b: 'c'
+      }
+    }
+    const {code: result} = transform(code, pluginOptions)
+    const tag = eval(result) // eslint-disable-line no-eval
+    expect(tag).toMatchSnapshot()
+    expect(tag).toBeInstanceOf(Tag)
+    expect(tag.getValue(getters)).toEqual(getters.state.a.c)
+  })
+
+  it('should allow to access with expressions in ${}', () => {
+    const code = `
+      import {state} from 'cerebral/tags';
+      const name = 'c';
+      state\`a.\${name}.\${1+1}\`;
+    `
+
+    const getters = {
+      state: {
+        a: {
+          c: {
+            2: 'Working!'
+          }
+        }
+      }
+    }
+    const {code: result} = transform(code, pluginOptions)
+    const tag = eval(result) // eslint-disable-line no-eval
+    expect(tag).toBeInstanceOf(Tag)
+    expect(tag.getValue(getters)).toEqual(getters.state.a.c[2])
+  })
+})

--- a/babel/babel-plugin-cerebral-optimize-tags/index.js
+++ b/babel/babel-plugin-cerebral-optimize-tags/index.js
@@ -1,0 +1,78 @@
+const importNames = ['cerebral/tags']
+const allowedImports = ['state', 'props', 'input', 'signal', 'string']
+
+function isValidImportLocation (location) {
+  return importNames.indexOf(location.toLowerCase()) >= 0
+}
+
+function isAllowedImport (importName) {
+  return allowedImports.indexOf(importName.toLowerCase()) >= 0
+}
+
+export default function ({types: t}) {
+  const optionsMap = {
+    state: t.objectExpression([
+      t.objectProperty(t.stringLiteral('isStateDependency'), t.booleanLiteral(true))
+    ]),
+    string: t.objectExpression([
+      t.objectProperty(t.stringLiteral('hasValue'), t.booleanLiteral(false))
+    ])
+  }
+  return {
+    pre (path) {
+      // Used to track renaming imports in local file
+      // eg. import { state as s } from 'cerebral/proxies';
+      this.importedTagMap = new Map()
+      this.tagId = path.scope.generateUidIdentifier('Tag')
+    },
+    visitor: {
+      ImportDeclaration (path) {
+        const {node: {source: {value}, source, $$processed}} = path
+        if (
+          t.isStringLiteral(source) &&
+          isValidImportLocation(value) &&
+          $$processed === undefined
+        ) {
+          let foundImport = false
+          // Verify that all imports are allowed and track the localName
+          for (const {imported: {name: importName} = {}, local: {name: localName}} of path.node.specifiers) {
+            if (importName === undefined) {
+              continue
+            }
+            if (isAllowedImport(importName)) {
+              foundImport = true
+              this.importedTagMap.set(localName, importName)
+            } else {
+              throw path.buildCodeFrameError(`The Tag "${importName}" can't be imported`)
+            }
+          }
+          if (!foundImport) {
+            return
+          }
+          path.replaceWith(
+            t.importDeclaration(
+              [t.importSpecifier(this.tagId, t.identifier('Tag'))],
+              t.stringLiteral('cerebral/tags')
+            )
+          )
+          path.node.$$processed = true
+        }
+      },
+      TaggedTemplateExpression (path) {
+        const {node: {quasi: {quasis, expressions}, tag: {name: localName}}} = path
+        if (this.importedTagMap.has(localName)) {
+          const name = this.importedTagMap.get(localName)
+          const options = optionsMap[name] ? optionsMap[name] : t.identifier('undefined')
+          const fnQuasis = quasis.map(e => t.stringLiteral(e.value.raw))
+
+          path.replaceWith(
+            t.newExpression(
+              this.tagId,
+              [t.stringLiteral(name), options, t.arrayExpression(fnQuasis), t.arrayExpression(expressions)]
+            )
+          )
+        }
+      }
+    }
+  }
+}

--- a/babel/babel-plugin-cerebral-optimize-tags/package.json
+++ b/babel/babel-plugin-cerebral-optimize-tags/package.json
@@ -27,6 +27,7 @@
   },
   "jest": {
     "coverageReporters": [
+      "json",
       "text",
       "lcov"
     ],

--- a/babel/babel-plugin-cerebral-optimize-tags/package.json
+++ b/babel/babel-plugin-cerebral-optimize-tags/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "babel-plugin-cerebral-optimize-tags",
+  "version": "1.0.0",
+  "description": "Babel plugin that optimize tags into constructor calls",
+  "main": "dist/index.js",
+  "scripts": {
+		"test": "jest",
+    "test:watch": "npm test -- --watch",
+    "build": "BABEL_ENV=production babel -d dist ./*.js",
+    "coverage": "npm test -- --coverage",
+    "prepublish": "npm run build"
+  },
+  "author": "Fabrice Weinberg <Fabrice@weinberg.me>",
+  "license": "MIT",
+  "repository": "https://github.com/cerebral/cerebral/babel/babel-plugin-cerebral-optimize-tags",
+  "devDependencies": {
+    "@cerebral/monorepo": "0.0.1",
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.22.1",
+    "babel-jest": "^18.0.0",
+    "babel-preset-es2015": "^6.1.18",
+    "cerebral": "^2.0.0-b",
+    "jest": "^18.1.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
+  "jest": {
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
+        "statements": 95
+      }
+    }
+  }
+}

--- a/babel/babel-plugin-cerebral-optimize-tags/package.json
+++ b/babel/babel-plugin-cerebral-optimize-tags/package.json
@@ -4,7 +4,7 @@
   "description": "Babel plugin that optimize tags into constructor calls",
   "main": "dist/index.js",
   "scripts": {
-		"test": "jest",
+    "test": "jest",
     "test:watch": "npm test -- --watch",
     "build": "BABEL_ENV=production babel -d dist ./*.js",
     "coverage": "npm test -- --coverage",
@@ -15,12 +15,7 @@
   "repository": "https://github.com/cerebral/cerebral/babel/babel-plugin-cerebral-optimize-tags",
   "devDependencies": {
     "@cerebral/monorepo": "0.0.1",
-    "babel-cli": "^6.2.0",
-    "babel-core": "^6.22.1",
-    "babel-jest": "^18.0.0",
-    "babel-preset-es2015": "^6.1.18",
-    "cerebral": "^2.0.0-b",
-    "jest": "^18.1.0"
+    "cerebral": "^2.0.0-b"
   },
   "files": [
     "dist"

--- a/babel/babel-plugin-cerebral-proxy-tags/README.md
+++ b/babel/babel-plugin-cerebral-proxy-tags/README.md
@@ -1,0 +1,31 @@
+babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-proxy-tags/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-proxy-tags)
+=========================
+
+In Cerebral v2 tags are a way to target input, state, props or signals. They are
+implemented using a new ES2015 feature called [template tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).
+
+I implemented these using [Proxy Object](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Proxy) in [cerebral-proxy-tags](https://github.com/FWeinb/cerebral-proxy-tags). This babel-plugin is tracking the usage of these specific proxy tags and translates them into the tagged template syntax.
+
+## Usage
+
+Instead of this way:
+
+```js
+import {set} from 'cerebral/operators'
+import {state} from 'cerebral/tags'
+
+export default [
+  set(state`foo.bar`, 'baz')
+]
+```
+
+You can write the same like showen bellow and it will get transpiled automatically.
+
+```js
+import {set} from 'cerebral/operators'
+import {state} from 'cerebral-proxy-tags' // or 'cerebral/proxies'
+
+export default [
+  set(state.foo.bar, 'baz') // <-- usage
+]
+```

--- a/babel/babel-plugin-cerebral-proxy-tags/README.md
+++ b/babel/babel-plugin-cerebral-proxy-tags/README.md
@@ -1,4 +1,4 @@
-babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-proxy-tags/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-plugin-cerebral-proxy-tags)
+babel-plugin-cerebral-proxy-tags
 =========================
 
 In Cerebral v2 tags are a way to target input, state, props or signals. They are

--- a/babel/babel-plugin-cerebral-proxy-tags/README.md
+++ b/babel/babel-plugin-cerebral-proxy-tags/README.md
@@ -19,7 +19,7 @@ export default [
 ]
 ```
 
-You can write the same like showen bellow and it will get transpiled automatically.
+You can write the same like shown below and it will get transpiled automatically.
 
 ```js
 import {set} from 'cerebral/operators'

--- a/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/compile.js.snap
+++ b/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/compile.js.snap
@@ -1,0 +1,63 @@
+exports[`Transform proxies to template tags should allow access to variables 1`] = `
+"
+import { state } from \'cerebral/tags\';
+const a = \'a\';
+const b = \'b\';
+state\`a.\${a + b}\`;"
+`;
+
+exports[`Transform proxies to template tags should allow for string access 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state\`a.b\`;"
+`;
+
+exports[`Transform proxies to template tags should allow imported variable to be renamed 1`] = `
+"
+import { state as anotherName } from \'cerebral/tags\';
+state => anotherName\`hello.\${anotherName\`world\`}\`;"
+`;
+
+exports[`Transform proxies to template tags should allow nested tags should work 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state\`hello.\${state\`world\`}\`;"
+`;
+
+exports[`Transform proxies to template tags should ignore default imports 1`] = `
+"
+import state from \'cerebral/tags\';
+state.hello.world;"
+`;
+
+exports[`Transform proxies to template tags should ignore variable when shadowed 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state => state.hello[state.world];"
+`;
+
+exports[`Transform proxies to template tags should not do anything when cerebral/proxies is not imported 1`] = `
+"
+import { state } from \'other-module\';
+state.hello.world;"
+`;
+
+exports[`Transform proxies to template tags should support expression in property accessor 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state\`a.\${1 + 1}\`;"
+`;
+
+exports[`Transform proxies to template tags should throw when import is not allowed 1`] = `"unknown: The Tag \"wrongImport\" can\'t be imported"`;
+
+exports[`Transform proxies to template tags should transforms simple proxies 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state\`hello.world\`;"
+`;
+
+exports[`Transform proxies to template tags should work for cerebral-proxy-tags too 1`] = `
+"
+import { state } from \'cerebral/tags\';
+state\`hello.world\`;"
+`;

--- a/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/compile.js.snap
+++ b/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/compile.js.snap
@@ -3,7 +3,7 @@ exports[`Transform proxies to template tags should allow access to variables 1`]
 import { state } from \'cerebral/tags\';
 const a = \'a\';
 const b = \'b\';
-state\`a.\${a + b}\`;"
+state\`a.\${ a + b }\`;"
 `;
 
 exports[`Transform proxies to template tags should allow for string access 1`] = `
@@ -15,13 +15,13 @@ state\`a.b\`;"
 exports[`Transform proxies to template tags should allow imported variable to be renamed 1`] = `
 "
 import { state as anotherName } from \'cerebral/tags\';
-state => anotherName\`hello.\${anotherName\`world\`}\`;"
+state => anotherName\`hello.\${ anotherName\`world\` }\`;"
 `;
 
 exports[`Transform proxies to template tags should allow nested tags should work 1`] = `
 "
 import { state } from \'cerebral/tags\';
-state\`hello.\${state\`world\`}\`;"
+state\`hello.\${ state\`world\` }\`;"
 `;
 
 exports[`Transform proxies to template tags should ignore default imports 1`] = `
@@ -45,7 +45,7 @@ state.hello.world;"
 exports[`Transform proxies to template tags should support expression in property accessor 1`] = `
 "
 import { state } from \'cerebral/tags\';
-state\`a.\${1 + 1}\`;"
+state\`a.\${ 1 + 1 }\`;"
 `;
 
 exports[`Transform proxies to template tags should throw when import is not allowed 1`] = `"unknown: The Tag \"wrongImport\" can\'t be imported"`;

--- a/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/run.js.snap
+++ b/babel/babel-plugin-cerebral-proxy-tags/__tests__/__snapshots__/run.js.snap
@@ -1,0 +1,39 @@
+exports[`Run transformed proxies should evaluate to a tag 1`] = `
+Tag {
+  "options": Object {
+    "hasValue": true,
+    "isStateDependency": true,
+  },
+  "strings": Array [
+    "hello.world",
+  ],
+  "type": "state",
+  "values": Array [],
+}
+`;
+
+exports[`Run transformed proxies should evaluate to a tag with nested tags 1`] = `
+Tag {
+  "options": Object {
+    "hasValue": true,
+    "isStateDependency": true,
+  },
+  "strings": Array [
+    "a.",
+    "",
+  ],
+  "type": "state",
+  "values": Array [
+    Tag {
+      "options": Object {
+        "hasValue": true,
+      },
+      "strings": Array [
+        "b",
+      ],
+      "type": "input",
+      "values": Array [],
+    },
+  ],
+}
+`;

--- a/babel/babel-plugin-cerebral-proxy-tags/__tests__/compile.js
+++ b/babel/babel-plugin-cerebral-proxy-tags/__tests__/compile.js
@@ -1,0 +1,111 @@
+/* globals describe it expect */
+import {transform} from 'babel-core'
+import plugin from '../index'
+
+const pluginOptions = {
+  babelrc: false,
+  plugins: [plugin]
+}
+
+describe('Transform proxies to template tags', () => {
+  it('should transforms simple proxies', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should allow nested tags should work', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      state.hello[state.world];
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should ignore variable when shadowed', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      (state) => state.hello[state.world];
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should allow imported variable to be renamed', () => {
+    const code = `
+      import {state as anotherName} from 'cerebral/proxies';
+      (state) => anotherName.hello[anotherName.world];
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should throw when import is not allowed', () => {
+    const code = `
+      import {wrongImport} from 'cerebral/proxies';
+    `
+    expect(() => {
+      transform(code, pluginOptions)
+    }).toThrowErrorMatchingSnapshot()
+  })
+
+  it('should support expression in property accessor', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      state.a[1+1]
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should not do anything when cerebral/proxies is not imported', () => {
+    const code = `
+      import {state} from 'other-module';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should work for cerebral-proxy-tags too', () => {
+    const code = `
+      import {state} from 'cerebral-proxy-tags';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should allow for string access', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      state.a['b']
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should allow access to variables', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      const a = 'a';
+      const b = 'b'
+      state.a[a+b]
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should ignore default imports', () => {
+    const code = `
+      import state from 'cerebral/proxies';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/babel/babel-plugin-cerebral-proxy-tags/__tests__/run.js
+++ b/babel/babel-plugin-cerebral-proxy-tags/__tests__/run.js
@@ -1,0 +1,68 @@
+/* globals describe it expect  */
+import {transform} from 'babel-core'
+import {Tag} from 'cerebral/tags'
+import plugin from '../index'
+
+const pluginOptions = {
+  babelrc: false,
+  presets: ['es2015'],
+  plugins: [plugin]
+}
+
+describe('Run transformed proxies', () => {
+  it('should evaluate to a tag', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+      state.hello.world;
+    `
+    const {code: result} = transform(code, pluginOptions)
+    expect(eval(result)).toMatchSnapshot() // eslint-disable-line no-eval
+  })
+
+  it('should evaluate to a tag with nested tags', () => {
+    const code = `
+      import {state, input} from 'cerebral/proxies';
+      state.a[input.b];
+    `
+
+    const getters = {
+      state: {
+        a: {
+          c: 'Working!'
+        }
+      },
+      input: {
+        b: 'c'
+      }
+    }
+    const {code: result} = transform(code, pluginOptions)
+    const tag = eval(result) // eslint-disable-line no-eval
+    expect(tag).toMatchSnapshot()
+    expect(tag).toBeInstanceOf(Tag)
+    expect(tag.getValue(getters)).toEqual(getters.state.a.c)
+  })
+
+  it('should allow to access with expressions in ${}', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+
+      const name = 'c';
+
+      state.a[name][1+1];
+    `
+
+    const getters = {
+      state: {
+        a: {
+          c: {
+            2: 'Working!'
+          }
+        }
+      }
+    }
+    const {code: result} = transform(code, pluginOptions)
+    const tag = eval(result) // eslint-disable-line no-eval
+    expect(tag).toBeInstanceOf(Tag)
+    expect(tag.getValue(getters)).toEqual(getters.state.a.c[2])
+  })
+})

--- a/babel/babel-plugin-cerebral-proxy-tags/index.js
+++ b/babel/babel-plugin-cerebral-proxy-tags/index.js
@@ -1,0 +1,113 @@
+const importNames = ['cerebral/proxies', 'cerebral-proxy-tags']
+const allowedImports = ['state', 'props', 'input', 'signal']
+
+function isValidImportLocation (location) {
+  return importNames.indexOf(location.toLowerCase()) >= 0
+}
+
+function isAllowedImport (importName) {
+  return allowedImports.indexOf(importName.toLowerCase()) >= 0
+}
+
+function isTagValidInThisScope (scope, name) {
+  const binding = scope.getBinding(name)
+  return binding && binding.kind === 'module'
+}
+
+function isPlainPropertyAccess (t, property, computed) {
+  return (t.isIdentifier(property) && computed === false) ||
+          (t.isLiteral(property) && property.value)
+}
+
+export default function ({types: t}) {
+  return {
+    pre () {
+      // Used to track renaming imports in local file
+      // eg. import { state as s } from 'cerebral/proxies';
+      this.importedTagSet = new Set()
+    },
+    visitor: {
+      ImportDeclaration (path) {
+        const {node: {source: {value}, source}} = path
+        if (
+          t.isStringLiteral(source) &&
+          isValidImportLocation(value)
+        ) {
+          // Verify that all imports are allowed and track the localName
+          for (const {imported: {name: importName} = {}, local: {name: localName}} of path.node.specifiers) {
+            if (importName === undefined) {
+              continue
+            }
+            if (isAllowedImport(importName)) {
+              this.importedTagSet.add(localName)
+            } else {
+              throw path.buildCodeFrameError(`The Tag "${importName}" can't be imported`)
+            }
+          }
+          // Change import to the real 'cerebral/tags';
+          path.node.source.value = 'cerebral/tags'
+        }
+      },
+      MemberExpression (path) {
+        // Always use the innermost MemberExpression
+        if (!t.isIdentifier(path.node.object)) {
+          return
+        }
+
+        const tagName = path.node.object.name
+
+        if (!this.importedTagSet.has(tagName) || !isTagValidInThisScope(path.scope, tagName)) {
+          return
+        }
+
+        let quasi = []
+        let quasis = [quasi]
+        let expressions = []
+        let prevWasExpression = false
+
+        let rootMemberExpression
+        let currentMember = path
+
+        // Iterate trough all parents
+        while (t.isMemberExpression(currentMember)) {
+          const {node: {property, computed}} = currentMember
+
+          // Plain id like state.a[1].b['test']
+          if (isPlainPropertyAccess(t, property, computed)) {
+            const value = t.isLiteral(property) ? property.value : property.name
+            quasi.push((quasi.length !== 0 || prevWasExpression ? '.' : '') + value)
+            prevWasExpression = false
+          // Nested expressions like state.a[state.b]
+          } else {
+            quasi.push('.')
+            expressions.push(property)
+            quasi = []
+            quasis.push(quasi)
+            prevWasExpression = true
+          }
+
+          // Save the rootMember
+          rootMemberExpression = currentMember
+
+          // Advance to next parent
+          currentMember = currentMember.parentPath
+        }
+
+        // Replace the rootMemberExpression
+        // with the TaggedTemplate
+        rootMemberExpression.replaceWith(
+          t.taggedTemplateExpression(
+            t.identifier(tagName),
+            t.templateLiteral(
+              quasis.map(v => {
+                const str = v.join('')
+                return t.templateElement({raw: str, cooked: str})
+              }),
+              expressions
+            )
+          )
+        )
+      }
+    }
+  }
+}

--- a/babel/babel-plugin-cerebral-proxy-tags/package.json
+++ b/babel/babel-plugin-cerebral-proxy-tags/package.json
@@ -27,6 +27,7 @@
   },
   "jest": {
     "coverageReporters": [
+      "json",
       "text",
       "lcov"
     ],

--- a/babel/babel-plugin-cerebral-proxy-tags/package.json
+++ b/babel/babel-plugin-cerebral-proxy-tags/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "babel-plugin-cerebral-proxy-tags",
+  "version": "1.0.1",
+  "description": "Babel plugin that convertes proxy access to cerebral tagged templates.",
+  "main": "dist/index.js",
+  "scripts": {
+		"test": "jest",
+    "test:watch": "npm test -- --watch",
+    "build": "BABEL_ENV=production babel -d dist ./*.js",
+    "coverage": "npm test -- --coverage",
+    "prepublish": "npm run build"
+  },
+  "author": "Fabrice Weinberg <Fabrice@weinberg.me>",
+  "license": "MIT",
+  "repository": "https://github.com/cerebral/cerebral/babel/babel-plugin-cerebral-proxy-tags",
+  "devDependencies": {
+    "@cerebral/monorepo": "0.0.1",
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.22.1",
+    "babel-jest": "^18.0.0",
+    "babel-preset-es2015": "^6.1.18",
+    "cerebral": "^2.0.0-b",
+    "jest": "^18.1.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
+  "jest": {
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
+        "statements": 95
+      }
+    }
+  }
+}

--- a/babel/babel-plugin-cerebral-proxy-tags/package.json
+++ b/babel/babel-plugin-cerebral-proxy-tags/package.json
@@ -4,7 +4,7 @@
   "description": "Babel plugin that convertes proxy access to cerebral tagged templates.",
   "main": "dist/index.js",
   "scripts": {
-		"test": "jest",
+    "test": "jest",
     "test:watch": "npm test -- --watch",
     "build": "BABEL_ENV=production babel -d dist ./*.js",
     "coverage": "npm test -- --coverage",
@@ -15,12 +15,7 @@
   "repository": "https://github.com/cerebral/cerebral/babel/babel-plugin-cerebral-proxy-tags",
   "devDependencies": {
     "@cerebral/monorepo": "0.0.1",
-    "babel-cli": "^6.2.0",
-    "babel-core": "^6.22.1",
-    "babel-jest": "^18.0.0",
-    "babel-preset-es2015": "^6.1.18",
-    "cerebral": "^2.0.0-b",
-    "jest": "^18.1.0"
+    "cerebral": "^2.0.0-b"
   },
   "files": [
     "dist"

--- a/babel/babel-preset-cerebral/README.md
+++ b/babel/babel-preset-cerebral/README.md
@@ -1,4 +1,4 @@
-babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-preset-cerebral.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-preset-cerebral/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-preset-cerebral)
+babel-plugin-cerebral-proxy-tags
 =========================
 This plugin optimize the tagged templates into `new Tag()` calls trying to reduce the time it takes to
 build them.

--- a/babel/babel-preset-cerebral/README.md
+++ b/babel/babel-preset-cerebral/README.md
@@ -1,0 +1,4 @@
+babel-plugin-cerebral-proxy-tags [![Build Status](https://travis-ci.org/FWeinb/babel-preset-cerebral.svg?branch=master)](https://travis-ci.org/FWeinb/babel-plugin-cerebral-proxy-tags) [![codecov](https://codecov.io/gh/FWeinb/babel-preset-cerebral/branch/master/graph/badge.svg)](https://codecov.io/gh/FWeinb/babel-preset-cerebral)
+=========================
+This plugin optimize the tagged templates into `new Tag()` calls trying to reduce the time it takes to
+build them.

--- a/babel/babel-preset-cerebral/__tests__/__snapshots__/compile.js.snap
+++ b/babel/babel-preset-cerebral/__tests__/__snapshots__/compile.js.snap
@@ -1,0 +1,24 @@
+exports[`Preset transpiles cerebral specific syntax should not enable proxies by default 1`] = `
+"
+import { state } from \'cerebral/proxies\';
+
+state.hello.world;"
+`;
+
+exports[`Preset transpiles cerebral specific syntax should not transpile proxies when proxies: true 1`] = `
+"import { Tag as _Tag } from \'cerebral/tags\';
+
+
+new _Tag(\'state\', {
+      \'isStateDependency\': true
+}, [\'hello.world\'], []);"
+`;
+
+exports[`Preset transpiles cerebral specific syntax should optimize default options 1`] = `
+"import { Tag as _Tag } from \'cerebral/tags\';
+
+
+new _Tag(\'state\', {
+      \'isStateDependency\': true
+}, [\'hello.world\'], []);"
+`;

--- a/babel/babel-preset-cerebral/__tests__/compile.js
+++ b/babel/babel-preset-cerebral/__tests__/compile.js
@@ -1,0 +1,61 @@
+/* globals describe it expect */
+import {transform} from 'babel-core'
+import presetCerebral from '../index'
+
+const bableOptions = {
+  babelrc: false,
+  presets: [presetCerebral]
+}
+
+const bableOptionsProxies = {
+  babelrc: false,
+  presets: [[presetCerebral, {proxies: true}]]
+}
+
+describe('Preset transpiles cerebral specific syntax', () => {
+  it('should optimize default options', () => {
+    const code = `
+      import {state} from 'cerebral/tags';
+
+      state\`hello.world\`;
+    `
+    const {code: result} = transform(code, bableOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should not enable proxies by default', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+
+      state.hello.world;
+    `
+    const {code: result} = transform(code, bableOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should not transpile proxies when proxies: true', () => {
+    const code = `
+      import {state} from 'cerebral/proxies';
+
+      state.hello.world;
+    `
+    const {code: result} = transform(code, bableOptionsProxies)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should produce the same result', () => {
+    const proxyCode = `
+      import {state} from 'cerebral/proxies';
+      state.hello.world;
+    `
+    const {code: proxyResult} = transform(proxyCode, bableOptionsProxies)
+
+    const tagCode = `
+      import {state} from 'cerebral/tags';
+      state\`hello.world\`;
+    `
+    const {code: tagResult} = transform(tagCode, bableOptions)
+
+    expect(proxyResult).toBe(tagResult)
+  })
+})

--- a/babel/babel-preset-cerebral/index.js
+++ b/babel/babel-preset-cerebral/index.js
@@ -1,0 +1,12 @@
+import proxyTags from 'babel-plugin-cerebral-proxy-tags'
+import optimizeTags from 'babel-plugin-cerebral-optimize-tags'
+
+export default function (context, opts = {}) {
+  const config = {
+    plugins: [
+      opts.proxies && proxyTags,
+      optimizeTags
+    ].filter(Boolean)
+  }
+  return config
+}

--- a/babel/babel-preset-cerebral/package.json
+++ b/babel/babel-preset-cerebral/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "babel-preset-cerebral",
+  "version": "1.0.0",
+  "description": "Babel plugin that optimize tags into constructor calls",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "npm test -- --watch",
+    "build": "BABEL_ENV=production babel -d dist ./*.js",
+    "coverage": "npm test -- --coverage",
+    "prepublish": "npm run build"
+  },
+  "author": "Fabrice Weinberg <Fabrice@weinberg.me>",
+  "license": "MIT",
+  "repository": "https://github.com/cerebral/cerebral/babel/babel-preset-cerebral",
+  "dependencies": {
+    "@cerebral/monorepo": "0.0.1",
+    "babel-plugin-cerebral-proxy-tags": "^1.0.1",
+    "babel-plugin-cerebral-optimize-tags": "^1.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.22.1",
+    "babel-jest": "^18.0.0",
+    "babel-preset-es2015": "^6.1.18",
+    "jest": "^18.1.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
+  "jest": {
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
+        "statements": 95
+      }
+    }
+  }
+}

--- a/babel/babel-preset-cerebral/package.json
+++ b/babel/babel-preset-cerebral/package.json
@@ -14,16 +14,11 @@
   "license": "MIT",
   "repository": "https://github.com/cerebral/cerebral/babel/babel-preset-cerebral",
   "dependencies": {
-    "@cerebral/monorepo": "0.0.1",
     "babel-plugin-cerebral-proxy-tags": "^1.0.1",
     "babel-plugin-cerebral-optimize-tags": "^1.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.2.0",
-    "babel-core": "^6.22.1",
-    "babel-jest": "^18.0.0",
-    "babel-preset-es2015": "^6.1.18",
-    "jest": "^18.1.0"
+    "@cerebral/monorepo": "0.0.1"
   },
   "files": [
     "dist"

--- a/babel/babel-preset-cerebral/package.json
+++ b/babel/babel-preset-cerebral/package.json
@@ -30,6 +30,7 @@
   },
   "jest": {
     "coverageReporters": [
+      "json",
       "text",
       "lcov"
     ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "lerna": "2.0.0-beta.32",
   "version": "independent",
-  "packages": ["packages/*", "docs/*", "demos/*", "debugger/*", "."]
+  "packages": ["packages/*", "docs/*", "demos/*", "debugger/*", "babel/*", "."]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "setup": "lerna bootstrap",
     "setup:packages": "lerna bootstrap --scope '@(function-tree|cerebral*)'",
+    "setup:babel": "lerna bootstrap --scope '@(function-tree|cerebral*|babel*)'",
     "commitmsg": "node ./node_modules/cz-customizable-ghooks/lib/index.js .git/COMMIT_EDITMSG",
     "commit": "git-cz",
     "lint": "standard",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "run-s": "./node_modules/.bin/run-s",
     "sh-js": "./node_modules/.bin/sh-js",
     "shx": "./node_modules/.bin/shx",
-    "gh-pages": "./node_modules/.bin/gh-pages"
+    "gh-pages": "./node_modules/.bin/gh-pages",
+    "jest": "./node_modules/.bin/jest"
   },
   "dependencies": {
     "babel-cli": "^6.18.0",
@@ -38,10 +39,12 @@
     "babel-preset-stage-0": "^6.16.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.18.0",
+    "babel-jest": "^18.0.0",
     "gh-pages": "^0.11.0",
     "coveralls": "^2.11.15",
     "cross-env": "^3.1.3",
     "inquirer": "^1.2.3",
+    "jest": "^18.1.0",
     "jsdom": "^9.9.1",
     "mocha": "^3.2.0",
     "mocha-jsdom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pretest": "npm run lint",
     "test": "lerna run test --ignore @cerebral/monorepo",
     "coverage": "lerna run coverage --ignore @cerebral/monorepo",
-    "postcoverage": "istanbul-combine -d coverage -p summary -r lcov -r html packages/**/coverage/*.json",
+    "postcoverage": "istanbul-combine -d coverage -p summary -r lcov -r html packages/**/coverage/*.json babel/**/coverage/*.json",
     "coverage:upload": "cat ./coverage/lcov.info | coveralls",
     "deploy": "cd docs/website && npm run ci"
   },


### PR DESCRIPTION
Added a `babel-preset-cerebral` that by default included `babel-plugin-cerebral-optimize-tags` and behind the option `{proxies:true}` `babel-plugin-cerebral-proxy-tags`. 
I also added the `npm run setup:babel` that will run `setup:packages` and `babel-*`. 

There needs to be some documentation on how this can be used in the babel-loader. 