### PR TITLE
feat(Controller): automatically unregister throwing error if custom e…

### DIFF
--- a/packages/cerebral/src/Controller.js
+++ b/packages/cerebral/src/Controller.js
@@ -67,15 +67,23 @@ class Controller extends FunctionTree {
       }
     })
     this.on('end', () => this.flush())
-    this.on('error', (error) => {
-      throw error
-    })
 
     if (this.devtools) {
       this.devtools.init(this)
+      this.on('error', function throwErrorCallback (error) {
+        if (Array.isArray(this._events.error) && this._events.error.length > 2) {
+          this.removeListener('error', throwErrorCallback)
+        } else {
+          throw error
+        }
+      })
     } else {
-      this.on('error', (error) => {
-        throw error
+      this.on('error', function throwErrorCallback (error) {
+        if (Array.isArray(this._events.error) && this._events.error.length > 1) {
+          this.removeListener('error', throwErrorCallback)
+        } else {
+          throw error
+        }
       })
     }
 

--- a/packages/cerebral/src/Controller.test.js
+++ b/packages/cerebral/src/Controller.test.js
@@ -226,4 +226,29 @@ describe('Controller', () => {
     })
     controller.getSignal('test')()
   })
+  it('should remove default error listener when overriden', (done) => {
+    const controller = new Controller({
+      signals: {
+        test: [() => { foo.bar = 'baz' }] // eslint-disable-line
+      }
+    })
+    controller.on('error', () => {
+      assert(true)
+      done()
+    })
+    controller.getSignal('test')()
+  })
+  it('should remove default error listener when overriden using devtools', (done) => {
+    const controller = new Controller({
+      devtools: {init (ctrl) { ctrl.on('error', () => {}) }},
+      signals: {
+        test: [() => { foo.bar = 'baz' }] // eslint-disable-line
+      }
+    })
+    controller.on('error', () => {
+      assert(true)
+      done()
+    })
+    controller.getSignal('test')()
+  })
 })

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -369,8 +369,6 @@ class Devtools {
       } else {
         this.backlog.push(message)
       }
-
-      throw error
     })
   }
   /*


### PR DESCRIPTION
…rror handler added

Normally Cerebral will throw any error caught by function-tree, but you might want to manually handle it. By just registering the error handler:

```js
controller.on('error', () => {})
```

Cerebral will automatically deregister its own error handling, not throwing it. If you still want to throw you would:

```js
controller.on('error', (error) => {
  // Handle the error however you want
  throw error
})
```

Will document this on new website.