### PR TITLE
feat(compute): add resolve.compute(compute, props) to signal context

### DIFF
--- a/packages/cerebral/src/utils.js
+++ b/packages/cerebral/src/utils.js
@@ -238,6 +238,13 @@ export function createResolver (getters) {
 
       return arg
     },
+    compute (arg, props = {}) {
+      if (arg instanceof Compute) {
+        return arg.getValue(Object.assign({}, getters, { props }))
+      }
+
+      return arg
+    },
     path (arg) {
       if (arg instanceof Tag) {
         return arg.getPath(getters)


### PR DESCRIPTION
Enables computes that require props to be called from within actions