### PR TITLE
fix(website): import input from tags

### DIFF
--- a/docs/docs/docs/best_practices/long_running_side_effects.md
+++ b/docs/docs/docs/best_practices/long_running_side_effects.md
@@ -57,7 +57,7 @@ Now we can implement our signals and their corresponding action chains in our **
 *src/modules/navbar/index.js*
 ```js
 import {set} from 'cerebral/operators'
-import {input, state} from 'cerebral/tags'
+import {props, state} from 'cerebral/tags'
 import pollMessageCounts from './actions/pollMessageCounts'
 
 export default {
@@ -69,7 +69,7 @@ export default {
       pollMessageCounts
     ],
     messageCountsFetched: [
-      set(state`navbar.messageCounts`, input`result`)
+      set(state`navbar.messageCounts`, props`result`)
     ]
   }
 }

--- a/docs/docs/docs/best_practices/long_running_side_effects.md
+++ b/docs/docs/docs/best_practices/long_running_side_effects.md
@@ -56,8 +56,8 @@ Now we can implement our signals and their corresponding action chains in our **
 
 *src/modules/navbar/index.js*
 ```js
-import {input, set} from 'cerebral/operators'
-import {state} from 'cerebral/tags'
+import {set} from 'cerebral/operators'
+import {input, state} from 'cerebral/tags'
 import pollMessageCounts from './actions/pollMessageCounts'
 
 export default {


### PR DESCRIPTION
`input` should be imported from `cerebral/tags` instead of `cerebral/operators`