### PR TITLE
fix(forms): import input from tags

### DIFF
--- a/packages/cerebral-forms/README.md
+++ b/packages/cerebral-forms/README.md
@@ -200,7 +200,7 @@ export default connect({
 An **action** factory you can use to validate any field in any chain.
 
 ```js
-import {input} from 'cerebral/tags'
+import {props} from 'cerebral/tags'
 import {validateField} from 'cerebral-forms'
 
 export default [
@@ -208,7 +208,7 @@ export default [
   // static
   validateField('path.to.form.field'),
   // dynamic
-  validateField(input`fieldPath`),
+  validateField(props`fieldPath`),
   doThat
 ]
 ```
@@ -217,14 +217,14 @@ export default [
 An **action** factory you can use to validate a whole form.
 
 ```js
-import {input} from 'cerebral/tags'
+import {props} from 'cerebral/tags'
 import {validateForm} from 'cerebral-forms'
 
 export default [
   // static
   validateForm('path.to.form'),
   // dynamic
-  validateForm(input`formPath`),
+  validateForm(props`formPath`),
   isFormValid, {
     true: [
       passInForm
@@ -240,7 +240,7 @@ export default [
 An **action** factory you can use to reset any form from any chain. It will replace current value with the initial or default value defined. And revalidate.
 
 ```js
-import {input} from 'cerebral/tags'
+import {props} from 'cerebral/tags'
 import {resetForm} from 'cerebral-forms'
 
 export default [
@@ -248,7 +248,7 @@ export default [
   // static
   resetForm('path.to.form'),
   // dynamic
-  resetForm(input`formPath`),
+  resetForm(props`formPath`),
   doThat
 ]
 ```
@@ -339,14 +339,14 @@ export default connect({
 You can also use this function inside a chain:
 
 ```js
-import {input} from 'cerebral/tags'
+import {props} from 'cerebral/tags'
 import {isValidForm} from 'cerebral-forms'
 
 export default [
   // static
   isValidForm('path.to.form')
   // dynamic
-  isValidForm(input`formPath`), {
+  isValidForm(props`formPath`), {
     true: [],
     false: []
   }

--- a/packages/cerebral-forms/README.md
+++ b/packages/cerebral-forms/README.md
@@ -200,7 +200,7 @@ export default connect({
 An **action** factory you can use to validate any field in any chain.
 
 ```js
-import {input} from 'cerebral/operators'
+import {input} from 'cerebral/tags'
 import {validateField} from 'cerebral-forms'
 
 export default [
@@ -217,7 +217,7 @@ export default [
 An **action** factory you can use to validate a whole form.
 
 ```js
-import {input} from 'cerebral/operators'
+import {input} from 'cerebral/tags'
 import {validateForm} from 'cerebral-forms'
 
 export default [
@@ -240,7 +240,7 @@ export default [
 An **action** factory you can use to reset any form from any chain. It will replace current value with the initial or default value defined. And revalidate.
 
 ```js
-import {input} from 'cerebral/operators'
+import {input} from 'cerebral/tags'
 import {resetForm} from 'cerebral-forms'
 
 export default [
@@ -339,7 +339,7 @@ export default connect({
 You can also use this function inside a chain:
 
 ```js
-import {input} from 'cerebral/operators'
+import {input} from 'cerebral/tags'
 import {isValidForm} from 'cerebral-forms'
 
 export default [


### PR DESCRIPTION
`input` should be imported from `cerebral/tags` instead of `cerebral/operators`