### PR TITLE
feat(tags): allow using whole tree of a tag (#678)

### DIFF
--- a/packages/cerebral/src/tags/Tag.js
+++ b/packages/cerebral/src/tags/Tag.js
@@ -71,7 +71,7 @@ export default class Tag {
         throwError(`A tag is extracting with path "${path}", but it is not valid`)
       }
 
-      return ''==key ? currentValue : currentValue[key];
+      return (key === '') ? currentValue : currentValue[key]
     }, obj)
   }
   /*

--- a/packages/cerebral/src/tags/Tag.js
+++ b/packages/cerebral/src/tags/Tag.js
@@ -71,7 +71,7 @@ export default class Tag {
         throwError(`A tag is extracting with path "${path}", but it is not valid`)
       }
 
-      return currentValue[key]
+      return ''==key ? currentValue : currentValue[key];
     }, obj)
   }
   /*


### PR DESCRIPTION
Also allows for using superfluous '.' path separators (e.g. "foo..bar")

CodeStyle: Just tell me if you want a full-fledged if-else statement instead....