### PR TITLE
feat(Controller): add recorder events and tracking

### DIFF
--- a/packages/cerebral/src/providers/Recorder.js
+++ b/packages/cerebral/src/providers/Recorder.js
@@ -44,6 +44,14 @@ export default function RecorderProvider (options = {}) {
       }
     })
 
+    function addExternalEvent (type, data) {
+      currentRecording.events.push({
+        type,
+        timestamp: Date.now(),
+        data
+      })
+    }
+
     function updateDebugger (method, path, args) {
       if (context.debugger) {
         const event = new window.CustomEvent('cerebral2.client.message', {
@@ -78,6 +86,8 @@ export default function RecorderProvider (options = {}) {
           mutate(event)
         } else if (event.type === 'flush') {
           controller.flush()
+        } else {
+          controller.emit(event.type, event.data)
         }
 
         lastEventTimestamp = event.timestamp
@@ -123,6 +133,7 @@ export default function RecorderProvider (options = {}) {
         }
 
         resetState()
+        controller.emit('recorder:seek', seek)
       },
       play (options = {}) {
         if (isPlaying || isRecording) {
@@ -142,6 +153,7 @@ export default function RecorderProvider (options = {}) {
         }
         controller.flush(true)
         runNextEvent()
+        controller.emit('recorder:play', currentSeek, options)
       },
       record (options = {}) {
         // If we are recording over the previous stuff, go back to start
@@ -165,7 +177,11 @@ export default function RecorderProvider (options = {}) {
           start: Date.now(),
           events: []
         }
+
+        controller.on('recorder:event', addExternalEvent)
+
         isRecording = true
+        controller.emit('recorder:record', options)
       },
       stop () {
         const wasPlaying = isPlaying
@@ -173,6 +189,7 @@ export default function RecorderProvider (options = {}) {
         isPlaying = false
         isRecording = false
         controller.runSignal = originalRunSignal
+        controller.off('recorder:event', addExternalEvent)
 
         if (wasPlaying) {
           return
@@ -184,12 +201,14 @@ export default function RecorderProvider (options = {}) {
           type: 'flush',
           timestamp: Date.now()
         })
+        controller.emit('recorder:stop')
       },
       pause () {
         ended = Date.now()
         currentSeek = ended - started
         clearTimeout(nextEventTimeout)
         isPlaying = false
+        controller.emit('recorder:pause', currentSeek)
       },
       getRecording () {
         return currentRecording

--- a/packages/cerebral/src/providers/Recorder.test.js
+++ b/packages/cerebral/src/providers/Recorder.test.js
@@ -305,4 +305,85 @@ describe('Recorder', () => {
     })
     controller.getSignal('stop')()
   })
+  it('should emit events', () => {
+    const timeout = timeoutMock()
+    const RecorderProvider = require('./Recorder').default
+    const controller = new Controller({
+      state: {
+        foo: 'bar'
+      },
+      signals: {
+        record: [({recorder}) => recorder.record({
+          initialState: ['foo']
+        })],
+        update: [({state}) => state.set('foo', 'bar2')],
+        update2: [({state}) => state.set('foo', 'bar3')],
+        stop: [({recorder}) => recorder.stop()],
+        play: [({recorder}) => recorder.play({
+          allowedSignals: ['stop']
+        })]
+      },
+      providers: [RecorderProvider({
+        setTimeout: timeout
+      })]
+    })
+    let eventsCount = 0
+    controller.on('recorder:record', () => {
+      eventsCount++
+    })
+    controller.on('recorder:stop', () => {
+      eventsCount++
+    })
+    controller.on('recorder:play', () => {
+      eventsCount++
+    })
+    controller.getSignal('record')()
+    controller.getSignal('update')()
+    controller.getSignal('stop')()
+    controller.getSignal('play')()
+    timeout.tick() // flush
+    timeout.tick()
+    controller.getSignal('update2')()
+    assert.deepEqual(controller.getState(), {foo: 'bar2'})
+    controller.getSignal('stop')()
+    assert(eventsCount, 4)
+  })
+  it('should add external events', () => {
+    const timeout = timeoutMock()
+    const RecorderProvider = require('./Recorder').default
+    const controller = new Controller({
+      state: {
+        foo: 'bar'
+      },
+      signals: {
+        record: [({recorder}) => recorder.record({
+          initialState: ['foo']
+        })],
+        update: [({state}) => state.set('foo', 'bar2')],
+        update2: [({state}) => state.set('foo', 'bar3')],
+        stop: [({recorder}) => recorder.stop()],
+        play: [({recorder}) => recorder.play({
+          allowedSignals: ['stop']
+        })]
+      },
+      providers: [RecorderProvider({
+        setTimeout: timeout
+      })]
+    })
+    let eventsCount = 0
+    controller.on('test', (data) => {
+      assert.equal(data, 'foo')
+      eventsCount++
+    })
+    controller.getSignal('record')()
+    controller.getSignal('update')()
+    controller.emit('recorder:event', 'test', 'foo')
+    controller.getSignal('stop')()
+    controller.getSignal('play')()
+    timeout.tick() // flush
+    timeout.tick()
+    timeout.tick()
+    controller.getSignal('stop')()
+    assert(eventsCount, 1)
+  })
 })


### PR DESCRIPTION
Okay, so I tried implementing general events recording, but I meet problems.

1. For the debugger to replay the events it needs to manipulate the execution ID, meaning it needs to track whenever the recorder starts from scratch, so that all events get manipulated with same ID extension... it is messy

2. There is sooo much data recorded. execution data, functionDetails, payloads... it serializes, deserializes to avoid mutation... it is just so much extra overhead compared to current implementation

3. Mutations are tracked separately from function tree events and I could not get them to match up in the debugger... maybe a small mistake, but been at this for a couple of hours now and I have lost my patience ;-)

4. When seeking a recording it replays all events up to that point. This will overload the debugger with information

Before I started this I spent a few minutes implementing what you see in this PR. To make it work with router you just have to, on every router change:

```js
controller.emit('recorder:event', {
  type: 'route',
  data: {} // Whatever you need
})
```

The recorder automatically picks it up during recording, so you can safely just fire it off. Then you listen to the event:

```js
controller.on('recorder:event:route', (data) => {
  // update url only. Probably need a loop tick here, as multiple events might trigger
  // (on seek for example) and you only want to act on the last event
})
```

Now the recorder works exactly the same, though just gives possibility to add custom events to the recording. 