### PR TITLE
RFC: Cerebral Service

### DIFF
--- a/packages/cerebral/src/Service.js
+++ b/packages/cerebral/src/Service.js
@@ -1,0 +1,104 @@
+import {FunctionTree} from 'function-tree'
+import ServiceModule from './ServiceModule'
+import {ensurePath, isDeveloping, throwError, isSerializable, forceSerializable, isObject, getProviders} from './utils'
+import VerifyPropsProvider from './providers/VerifyProps'
+import DebuggerProvider from './providers/Debugger'
+import ControllerProvider from './providers/Controller'
+import PropsProvider from './providers/Props'
+
+class Service extends FunctionTree {
+  constructor ({signals = {}, providers = [], modules = {}, devtools = null, options = {}}) {
+    super()
+    this.options = options
+    this.devtools = devtools
+    this.module = new ServiceModule(this, [], {
+      signals,
+      modules
+    })
+
+    this.contextProviders = [
+      PropsProvider(),
+      ControllerProvider(this)
+    ].concat((
+      this.devtools ? [
+        DebuggerProvider()
+      ] : []
+    )).concat((
+      isDeveloping() ? [
+        VerifyPropsProvider
+      ] : []
+    )).concat(
+      providers.concat(getProviders(this.module))
+    )
+
+    if (this.devtools) {
+      this.devtools.init(this)
+      this.on('error', function throwErrorCallback (error) {
+        if (Array.isArray(this._events.error) && this._events.error.length > 2) {
+          this.removeListener('error', throwErrorCallback)
+        } else {
+          throw error
+        }
+      })
+    } else {
+      this.on('error', function throwErrorCallback (error) {
+        if (Array.isArray(this._events.error) && this._events.error.length > 1) {
+          this.removeListener('error', throwErrorCallback)
+        } else {
+          throw error
+        }
+      })
+    }
+
+    this.emit('initialized')
+  }
+  /*
+    Uses function tree to run the array and optional
+    payload passed in. The payload will be checkd
+  */
+  runSignal (name, signal, payload = {}) {
+    if (this.devtools && (!isObject(payload) || !isSerializable(payload))) {
+      console.warn(`You passed an invalid payload to signal "${name}". Only serializable payloads can be passed to a signal. The payload has been ignored. This is the object:`, payload)
+      payload = {}
+    }
+
+    if (this.devtools) {
+      payload = Object.keys(payload).reduce((currentPayload, key) => {
+        if (!isSerializable(payload, this.devtools.allowedTypes)) {
+          console.warn(`You passed an invalid payload to signal "${name}", on key "${key}". Only serializable values like Object, Array, String, Number and Boolean can be passed in. Also these special value types:`, this.devtools.allowedTypes)
+
+          return currentPayload
+        }
+
+        currentPayload[key] = forceSerializable(payload[key])
+
+        return currentPayload
+      }, {})
+    }
+
+    this.runTree(name, signal, payload)
+  }
+  /*
+    Returns a function which binds the name/path of signal,
+    and the array. This allows view layer to just call it with
+    an optional payload and it will run
+  */
+  getSignal (path) {
+    const pathArray = ensurePath(path)
+    const signalKey = pathArray.pop()
+    const module = pathArray.reduce((currentModule, key) => {
+      return currentModule ? currentModule.modules[key] : undefined
+    }, this.module)
+    const signal = module && module.signals[signalKey]
+
+    if (!signal) {
+      throwError(`There is no signal at path "${path}"`)
+    }
+
+    return signal
+  }
+}
+
+export default function (...args) {
+  return new Service(...args)
+}

--- a/packages/cerebral/src/Service.test.js
+++ b/packages/cerebral/src/Service.test.js
@@ -1,0 +1,147 @@
+/* eslint-env mocha */
+import Service from './Service'
+import assert from 'assert'
+
+describe('Service', () => {
+  it('should instantiate with signals defined', () => {
+    const service = new Service({
+      signals: {
+        foo: []
+      }
+    })
+    assert.ok(service.getSignal('foo'))
+  })
+  it('should instantiate providers defined', () => {
+    const service = new Service({
+      signals: {
+        foo: [
+          function testAction (context) {
+            assert.equal(context.foo, 'bar')
+          }
+        ]
+      },
+      providers: [
+        function TestProvider (context) {
+          context.foo = 'bar'
+
+          return context
+        }
+      ]
+    })
+    service.getSignal('foo')()
+  })
+  it('should instantiate modules defined as objects', () => {
+    const service = new Service({
+      modules: {
+        foo: {
+          signals: {
+            bar: []
+          }
+        }
+      }
+    })
+    assert.deepEqual(service.getSignal('foo.bar'), [])
+  })
+  it('should instantiate modules defined as functions', () => {
+    const service = new Service({
+      modules: {
+        foo: () => ({
+          signals: {
+            bar: []
+          }
+        })
+      }
+    })
+    assert.deepEqual(service.getSignal('foo.bar'), [])
+  })
+  it('should pass instance of service and path info on functions module instantiation', () => {
+    const service = new Service({
+      modules: {
+        foo: {
+          modules: {
+            bar: ({service, path, name}) => {
+              assert.ok(service)
+              assert.equal(name, 'bar')
+              assert.equal(path, 'foo.bar')
+              return {
+                signals: {
+                  foo: []
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+    assert.deepEqual(service.getSignal('foo.bar.foo'), [])
+  })
+  it('should expose method to get signals', () => {
+    const service = new Service({
+      signals: {
+        foo: []
+      },
+      modules: {
+        moduleA: {
+          signals: {
+            foo: []
+          }
+        }
+      }
+    })
+    assert.ok(service.getSignal('foo'))
+    assert.ok(service.getSignal('moduleA.foo'))
+  })
+  it('should create JSON stringify friendly value of unserializable payload property to signal', () => {
+    const service = new Service({
+      devtools: {init () {}},
+      signals: {
+        foo: [({props}) => assert.equal(JSON.stringify(props), '{"date":"[Date]"}')]
+      }
+    })
+    service.getSignal('foo')({
+      date: new Date()
+    })
+  })
+  it('should ignore when passing in unserializable payload to signal', () => {
+    const service = new Service({
+      devtools: {init () {}},
+      signals: {
+        foo: [
+          ({props}) => assert.deepEqual(props, {})
+        ]
+      }
+    })
+    service.getSignal('foo')(new Date())
+  })
+  it('should throw when pointing to a non existing signal', () => {
+    const service = new Service({})
+    assert.throws(() => {
+      service.getSignal('foo.bar')()
+    })
+  })
+  it('should remove default error listener when overriden', (done) => {
+    const service = new Service({
+      signals: {
+        test: [() => { foo.bar = 'baz' }] // eslint-disable-line
+      }
+    })
+    service.on('error', () => {
+      assert(true)
+      done()
+    })
+    service.getSignal('test')()
+  })
+  it('should remove default error listener when overriden using devtools', (done) => {
+    const service = new Service({
+      devtools: {init (ctrl) { ctrl.on('error', () => {}) }},
+      signals: {
+        test: [() => { foo.bar = 'baz' }] // eslint-disable-line
+      }
+    })
+    service.on('error', () => {
+      assert(true)
+      done()
+    })
+    service.getSignal('test')()
+  })
+})

--- a/packages/cerebral/src/ServiceModule.js
+++ b/packages/cerebral/src/ServiceModule.js
@@ -1,0 +1,32 @@
+class ServiceModule {
+  constructor (service, path, moduleDescription) {
+    const moduleStub = {
+      service,
+      path: path.join('.'),
+      name: path.slice().pop()
+    }
+
+    const module = typeof moduleDescription === 'function' ? moduleDescription(moduleStub) : moduleDescription
+
+    /* Convert arrays to actually runable signals */
+    module.signals = Object.keys(module.signals || {}).reduce((currentSignals, signalKey) => {
+      const signal = module.signals[signalKey]
+
+      currentSignals[signalKey] = (payload) => {
+        service.runSignal(path.concat(signalKey).join('.'), signal, payload)
+      }
+
+      return currentSignals
+    }, {})
+
+    /* Instantiate submodules */
+    module.modules = Object.keys(module.modules || {}).reduce((registered, moduleKey) => {
+      registered[moduleKey] = new ServiceModule(service, path.concat(moduleKey), module.modules[moduleKey])
+      return registered
+    }, {})
+
+    return module
+  }
+}
+
+export default ServiceModule

--- a/packages/cerebral/src/ServiceModule.test.js
+++ b/packages/cerebral/src/ServiceModule.test.js
@@ -1,0 +1,80 @@
+/* eslint-env mocha */
+import Service from './Service'
+import assert from 'assert'
+
+describe('ServiceModule', () => {
+  it('should instantiate with signals', () => {
+    const service = new Service({
+      modules: {
+        foo: {
+          signals: {
+            bar: []
+          }
+        }
+      }
+    })
+
+    assert.ok(service.getSignal('foo.bar'))
+  })
+  it('should run signals with providers', () => {
+    const service = new Service({
+      modules: {
+        foo: {
+          signals: {
+            signalA: [(context) => {
+              assert.equal(context.foo, 'foo')
+              assert.equal(context.bar, 'bar')
+            }]
+          },
+          provider (context) {
+            context.foo = 'foo'
+
+            return context
+          }
+        },
+        bar: {
+          signals: {
+            signalB: [(context) => {
+              assert.equal(context.bar, 'bar')
+              assert.equal(context.foo, 'foo')
+            }]
+          },
+          provider (context) {
+            context.bar = 'bar'
+
+            return context
+          }
+        }
+      }
+    })
+
+    service.getSignal('foo.signalA')()
+    service.getSignal('bar.signalB')()
+  })
+  it('should keep module instance', () => {
+    class Foo {
+      constructor () {
+        this.state = {foo: 'bar'}
+        this.signals = {bar: [(context) => { assert.equal(context.foo, 'foo') }]}
+        this.provider = (context) => {
+          context.foo = 'foo'
+
+          return context
+        }
+      }
+
+      getBar () {
+        return 'bar'
+      }
+    }
+
+    const service = new Service({
+      modules: {
+        foo: new Foo()
+      }
+    })
+
+    service.getSignal('foo.bar')()
+    assert.equal(service.module.modules.foo.getBar(), 'bar')
+  })
+})


### PR DESCRIPTION
This is a followup from the previous RFC #693. After lots of great feedback it was clear that a full blown server component has to make too many assumptions.

The idea to put cerebral on the server has been very well received though.

Ideally we should just be able to use the regular controller, but without the bits that are browser specific.

So presented here for your feedback is cerebral `Service`. `Service` is the same as the cerebral `Controller` except that it doesn't have state, tags (no `resolve`) or router support. Ideally the primary cerebral Controller could be based on this Service.

Since the Service is a cut down controller the docs are almost the same:

# Service

```js
import Service from 'cerebral/lib/Service'

const service = Service({
  // Defines the top level signals
  signals: {},

  // Defines the top level modules
  modules: {}
})

export default service
```

## Errors
Cerebral knows about any errors that happen during a signal execution, synchronous and asynchronous. By default Cerebral just throws these errors to the console, but you can take control if you want to pass them to error tracking services etc.

```js
service.on('error', function (error, execution, functionDetails) {})
```

## Methods

### getSignal(path)
Returns signal from Cerebral

```js
const someSignal = service.getSignal('some.signal')
// Run signal
someSignal({foo: 'bar'})
```

### runSignal(name, definition, payload)
Allows you to run an arbitrary function tree definition

```js
service.runSignal('someSignal', [actionA, actionB], {foo: 'bar'})
```

## Events

### initialized
Triggers when Cerebral service has initialized.

```js
service.on('initialized', () => {})
```

### start
Triggered whenever Cerebral starts a signal execution.

```js
service.on('start', (execution, payload) => {})
```

### end
Triggered whenever Cerebral ends a signal execution.

```js
service.on('end', (execution, payload) => {})
```

### pathStart
Triggered whenever Cerebral starts execution a path in a signal

```js
service.on('pathStart', (execution, payload) => {})
```

### pathEnd
Triggered whenever Cerebral ends execution a path in a signal

```js
service.on('pathEnd', (execution, payload) => {})
```

### functionStart
Triggered whenever Cerebral starts executing an action.

```js
service.on('functionStart', (execution, functionDetails, payload) => {})
```

### functionEnd
Triggered whenever Cerebral ends executing an action.

```js
service.on('functionEnd', (execution, functionDetails, payload) => {})
```

### asyncFunction
Triggered whenever Cerebral executed an async action.

```js
service.on('asyncFunction', (execution, functionDetails, payload) => {})
```

### parallelStart
Triggered whenever Cerebral executes actions in parallel.

```js
service.on('parallelStart', (execution, payload, functionsToResolveCount) => {})
```

### parallelProgress
Triggered whenever Cerebral executes actions in parallel.

```js
service.on('parallelProgress', (execution, payload, functionsStillResolvingCount) => {})
```

### parallelEnd
Triggered whenever Cerebral executes actions in parallel.

```js
service.on('parallelEnd', (execution, payload, functionsExecutedCount) => {})
```
