### PR TITLE
fix(Operators): set should make copy of object and array when used as static value

### DIFF
--- a/packages/cerebral/src/operators/set.js
+++ b/packages/cerebral/src/operators/set.js
@@ -1,11 +1,29 @@
+import {isObject} from '../utils'
+
 export default function (target, value) {
   function set ({state, props, resolve}) {
     if (!resolve.isTag(target, 'state', 'props')) {
       throw new Error('Cerebral operator.set: You have to use the STATE or PROPS TAG as first argument')
     }
 
+    let resolvedValue = resolve.value(value)
+
+    if (
+      !resolve.isTag(value) &&
+      !resolve.isCompute(value) &&
+      isObject(value)
+    ) {
+      resolvedValue = Object.assign({}, resolvedValue)
+    } else if (
+      !resolve.isTag(value) &&
+      !resolve.isCompute(value) &&
+      Array.isArray(value)
+    ) {
+      resolvedValue = resolvedValue.slice()
+    }
+
     if (target.type === 'state') {
-      state.set(resolve.path(target), resolve.value(value))
+      state.set(resolve.path(target), resolvedValue)
     } else {
       const result = Object.assign({}, props)
       const parts = resolve.path(target).split('.')
@@ -13,7 +31,7 @@ export default function (target, value) {
       const targetObj = parts.reduce((target, key) => {
         return (target[key] = Object.assign({}, target[key] || {}))
       }, result)
-      targetObj[key] = resolve.value(value)
+      targetObj[key] = resolvedValue
 
       return result
     }

--- a/packages/cerebral/src/operators/set.test.js
+++ b/packages/cerebral/src/operators/set.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import Controller from '../Controller'
 import assert from 'assert'
-import {set} from './'
+import {set, push} from './'
 import {props, state, string} from '../tags'
 
 describe('operator.set', () => {
@@ -108,6 +108,52 @@ describe('operator.set', () => {
       done()
     })
 
+    controller.getSignal('test')()
+  })
+  it('should copy plain object', () => {
+    const controller = Controller({
+      state: {
+        foo: {}
+      },
+      signals: {
+        test: [
+          set(state`foo`, {}),
+          set(state`foo.${props`key`}`, 'bar')
+        ]
+      }
+    })
+    controller.once('end', () => {
+      assert.deepEqual(controller.getState('foo'), {'key1': 'bar'})
+    })
+    controller.getSignal('test')({
+      key: 'key1'
+    })
+    controller.once('end', () => {
+      assert.deepEqual(controller.getState('foo'), {'key2': 'bar'})
+    })
+    controller.getSignal('test')({
+      key: 'key2'
+    })
+  })
+  it('should copy array object', () => {
+    const controller = Controller({
+      state: {
+        foo: []
+      },
+      signals: {
+        test: [
+          set(state`foo`, []),
+          push(state`foo`, 'bar')
+        ]
+      }
+    })
+    controller.once('end', () => {
+      assert.deepEqual(controller.getState('foo'), ['bar'])
+    })
+    controller.getSignal('test')()
+    controller.once('end', () => {
+      assert.deepEqual(controller.getState('foo'), ['bar'])
+    })
     controller.getSignal('test')()
   })
 })

--- a/packages/cerebral/src/utils.js
+++ b/packages/cerebral/src/utils.js
@@ -224,6 +224,9 @@ export function createResolver (getters) {
 
       return true
     },
+    isCompute (arg) {
+      return arg instanceof Compute
+    },
     value (arg, overrideProps) {
       if (arg instanceof Tag || arg instanceof Compute) {
         return arg.getValue(overrideProps ? Object.assign({}, getters, {props: overrideProps}) : getters)


### PR DESCRIPTION
Fixed issue when doing things like this:

```js
[
  set(state`foo`, {}),
  set(state`bar`, [])
]
```

It is the same object/array being set every time, meaning that they can get mutated in the meantime. And this only happens in production due to debugger serialization