### PR TITLE
fix(Model): don't need to verifyValue two times

### DIFF
--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -170,8 +170,6 @@ class Model {
     })
   }
   merge (path, ...values) {
-    this.verifyValues(values, path)
-
     const value = Object.assign(...values)
 
     // If we already have an object we make it behave


### PR DESCRIPTION
We don't need to verify values in merge method. set method has own verifyValue function