### PR TITLE
Replace RunSignal test helper with CerebralTest helper

### DIFF
--- a/docs/docs/docs/developer_guide/test.md
+++ b/docs/docs/docs/developer_guide/test.md
@@ -190,30 +190,33 @@ it('should handle button clicks', () => {
 })
 ```
 
-### RunSignal factory
+### CerebralTest factory
 
-The `RunSignal` factory is similar to run signal except that it will return a runSignal function that can be called many times without resetting the controller in between.
+The `CerebralTest` factory returns runSignal, setState and getState functions that can be called many times without resetting the controller in between.
 
 ```js
-const runSignal = Run(fixture. options)
-runSignal(signal, props).then((result) => {})
+const cerebral = CerebralTest(fixture. options)
+cerebral.setState(path, value)
+cerebral.runSignal(signal, props).then((result) => {})
+const value = cerebral.getState(path)
 ```
 
 #### Example
 
 ```js
-import {RunSignal} from 'cerebral/test'
+import {CerebralTest} from 'cerebral/test'
 
 it('should accumulate a count', () => {
-  const runMathSignal = RunSignal({
+  const cerebral = RunSignal({
     modules: {
       math: math()
     }
   })
-  return runMathSignal('math.plusOne').then(({state}) => {
+  cerebra.setState('math.count', 0)
+  return cerebral.runSignal('math.plusOne').then(({state}) => {
     assert.equal(state.math.count, 1)
-    return runMathSignal('math.plusTwo').then(({state}) => {
-      assert.equal(state.math.count, 3)
+    return cerebral.runSignal('math.plusTwo').then(() => {
+      assert.equal(cerebral.getState('math.count'), 3)
     })
   })
 })

--- a/docs/docs/docs/developer_guide/test.md
+++ b/docs/docs/docs/developer_guide/test.md
@@ -207,7 +207,7 @@ const value = cerebral.getState(path)
 import {CerebralTest} from 'cerebral/test'
 
 it('should accumulate a count', () => {
-  const cerebral = RunSignal({
+  const cerebral = CerebralTest({
     modules: {
       math: math()
     }

--- a/docs/docs/docs/developer_guide/test.md
+++ b/docs/docs/docs/developer_guide/test.md
@@ -212,7 +212,7 @@ it('should accumulate a count', () => {
       math: math()
     }
   })
-  cerebra.setState('math.count', 0)
+  cerebral.setState('math.count', 0)
   return cerebral.runSignal('math.plusOne').then(({state}) => {
     assert.equal(state.math.count, 1)
     return cerebral.runSignal('math.plusTwo').then(() => {

--- a/packages/cerebral/src/test/index.test.js
+++ b/packages/cerebral/src/test/index.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import {compute} from '..'
 import {state, props} from '../tags'
-import {runCompute, runAction, runSignal, RunSignal} from '.'
+import {runCompute, runAction, runSignal, RunSignal, CerebralTest} from '.'
 import assert from 'assert'
 
 describe('test helpers', () => {
@@ -103,6 +103,45 @@ describe('test helpers', () => {
         return runSignal('test.baz').then(({state}) => {
           assert.equal(state.test.foo, 2)
         })
+      })
+    })
+  })
+
+  describe('CerebralTest factory', () => {
+    let cerebral
+
+    beforeEach(() => {
+      cerebral = CerebralTest({
+        modules: {
+          test: {
+            state: {foo: 0},
+            signals: {
+              baz: [({state}) => state.set('test.foo', state.get('test.foo') + 1)]
+            }
+          }
+        }
+      })
+    })
+
+    it('should create a cerebral helper', () => {
+      return cerebral.runSignal('test.baz').then(({state}) => {
+        assert.equal(state.test.foo, 1)
+        return cerebral.runSignal('test.baz').then(({state}) => {
+          assert.equal(state.test.foo, 2)
+        })
+      })
+    })
+
+    it('can set state', () => {
+      cerebral.setState('test.foo', 10)
+      return cerebral.runSignal('test.baz').then(({state}) => {
+        assert.equal(state.test.foo, 11)
+      })
+    })
+
+    it('can get state', () => {
+      return cerebral.runSignal('test.baz').then(() => {
+        assert.equal(cerebral.getState('test.foo'), 1)
       })
     })
   })


### PR DESCRIPTION
RunSignal is still there but will show deprecation warning.

Test helper supports `getState` and `setState` as well as `runSignal`.

```js
import {CerebralTest} from 'cerebral/test'

it('should accumulate a count', () => {
  const cerebral = CerebralTest({
    modules: {
      math: math()
    }
  })
  cerebral.setState('math.count', 0)
  return cerebral.runSignal('math.plusOne').then(({state}) => {
    assert.equal(state.math.count, 1)
    return cerebral.runSignal('math.plusTwo').then(() => {
      assert.equal(cerebral.getState('math.count'), 3)
    })
  })
})
```