### PR TITLE
feat(function-tree): add abort sequence to sequence and parallel

### DIFF
--- a/debugger/src/components/Debugger/Signals/List/index.js
+++ b/debugger/src/components/Debugger/Signals/List/index.js
@@ -78,7 +78,7 @@ export default connect({
       }
 
       let groupCount = 1
-      for (let x = index + 1; x < this.props.signalsList.length - 1; x++) {
+      for (let x = index + 1; x <= this.props.signalsList.length - 1; x++) {
         if (this.props.signalsList[x].groupId === signal.groupId) {
           groupCount++
         } else {

--- a/debugger/src/components/Debugger/Signals/Signal/index.js
+++ b/debugger/src/components/Debugger/Signals/Signal/index.js
@@ -140,7 +140,9 @@ export default connect({
           onActionClick={this.onActionClick}
           executed={executedBySignal ? (
             <Signal
-              className={'executedBy'}
+              className={classnames('executedBy', {
+                'abort': executedBySignal.executedBy.isAbort
+              })}
               style={{
                 backgroundColor: '#FAFAFA'
               }}

--- a/debugger/src/components/Debugger/Signals/Signal/styles.css
+++ b/debugger/src/components/Debugger/Signals/Signal/styles.css
@@ -12,6 +12,8 @@
   overflow: auto;
 }
 
+.executedBy.abort h3 {}
+
 .executedByLine {
   height: 3px;
   border-bottom: 1px solid #DDD;

--- a/debugger/src/modules/Debugger/actions/endSignalExecution.js
+++ b/debugger/src/modules/Debugger/actions/endSignalExecution.js
@@ -1,13 +1,15 @@
 function endSignalExecution ({props, state}) {
   const type = state.get('type')
   const execution = props.data.execution
-  const signalPath = state.get(`debugger.executedBySignals.${execution.executionId}`) ? (
-    `debugger.executedBySignals.${execution.executionId}`
-  ) : (
-    `debugger.signals.${execution.executionId}`
-  )
+  const executedBySignal = state.get(`debugger.executedBySignals.${execution.executionId}`)
 
-  state.set(`${signalPath}.isExecuting`, false)
+  if (executedBySignal) {
+    state.set(`debugger.executedBySignals.${execution.executionId}.isExecuting`, false)
+    state.set(`debugger.signals.${executedBySignal.executedBy.id}.isExecuting`, false)
+  } else {
+    state.set(`debugger.signals.${execution.executionId}.isExecuting`, false)
+  }
+
   if (
     (props.source === 'c' && (type === 'c' || type === 'cft')) ||
     (props.source === 'ft' && type === 'ft')

--- a/demos/todomvc/src/controller.js
+++ b/demos/todomvc/src/controller.js
@@ -1,4 +1,4 @@
-import {Controller} from 'cerebral'
+import {Controller, sequence} from 'cerebral'
 import Devtools from 'cerebral/devtools'
 import {ContextProvider} from 'cerebral/providers'
 import uuid from 'uuid'
@@ -35,15 +35,25 @@ const controller = Controller({
   signals: {
     rootRouted: redirect('/all'),
     newTodoTitleChanged: set(state`newTodoTitle`, props`title`),
-    newTodoSubmitted: [
+    newTodoSubmitted: sequence([
       when(state`newTodoTitle`), {
         true: [
           addTodo,
           set(state`newTodoTitle`, '')
         ],
         false: []
+      },
+      function abort ({abort}) {
+        return abort()
+      },
+      function couldContinue () {
+
       }
-    ],
+    ], [
+      function aborted () {
+
+      }
+    ]),
     todoNewTitleChanged: set(state`todos.${props`uid`}.editedTitle`, props`title`),
     todoNewTitleSubmitted: [
       when(state`todos.${props`uid`}.editedTitle`), {

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -131,3 +131,12 @@ You have access to function tree execution as well. This holds information about
 ```js
 function someAction ({execution}) {}
 ```
+
+## Abort
+To abort execution you can use the abort provider:
+
+```js
+function someAction ({abort}) {
+  return abort({}) // Optional payload
+}
+```

--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -12,6 +12,7 @@ export default parallel([
 ])
 ```
 
+## Name
 You can name a parallel, which will be displayed in debugger:
 ```js
 import {parallel} from 'cerebral'
@@ -24,6 +25,7 @@ export default parallel('my parallel', [
 ])
 ```
 
+## Compose
 You can compose parallel into any existing sequence:
 ```js
 import {parallel} from 'cerebral'
@@ -39,3 +41,31 @@ export default [
   ])
 ]
 ```
+
+## Abort
+You can abort a parallel execution:
+
+```js
+import {parallel} from 'cerebral'
+
+function someActionAborting ({abort}) {
+  return abort({}) // Optional payload
+}
+function someAction () {}
+function someActionHandlingAbort () {}
+
+export default parallel('my parallel', [
+  someActionAborting, {
+    success: [], // Will not run
+    error: [] // Will not run
+  },
+  someAction, { // Runs until resolved
+    success: [], // Will not run if executed after abort
+    error: [] // Will not run if executed after abort
+  }
+], [
+  someActionHandlingAbort
+])
+```
+
+Abort does not **bubble**, meaning actions that abort will only reach its specific abort sequence.

--- a/docs/api/sequence.md
+++ b/docs/api/sequence.md
@@ -20,6 +20,7 @@ export default sequence([
 ])
 ```
 
+## Name
 You can name a sequence, which will be displayed in debugger:
 ```js
 import {sequence} from 'cerebral'
@@ -30,6 +31,7 @@ export default sequence('my sequence', [
 ])
 ```
 
+## Compose
 You can compose a sequence into existing sequence. The debugger will show this composition:
 ```js
 import someAction from '../actions/someAction'
@@ -40,3 +42,25 @@ export default [
   someOtherSequence
 ]
 ```
+
+## Abort
+You can abort a sequence execution:
+
+```js
+import {sequence} from 'cerebral'
+
+function someActionAborting ({abort}) {
+  return abort({}) // Optional payload
+}
+function someAction () {}
+function someActionHandlingAbort () {}
+
+export default sequence('my sequence', [
+  someActionAborting,
+  someAction // will not run
+], [
+  someActionHandlingAbort
+])
+```
+
+Abort does not **bubble**, meaning actions that abort will only reach its specific abort sequence.

--- a/docs/developer_guide/signals.md
+++ b/docs/developer_guide/signals.md
@@ -1,10 +1,12 @@
 # Signals
 
-The signals of Cerebral are named in past tense. So typically you would name a signal **inputChanged** or **mounted**. Going through this guide you will see what benefits this approach gives you. To trigger a signal you call it just like you would call a function, the difference is that you start a function tree execution.
+You trigger a signal when something happens in your application. For example a button is clicked, but also if a websocket connection receives a message. The signal runs the business logic of your application. You compose together state changes, side effects and other logic in one coherent flow. The signals of Cerebral are named in past tense. So typically you would name a signal **inputChanged** or **mounted**. Going through this guide you will see what benefits this approach gives you. To trigger a signal you call it just like you would call a function, the difference is that you start a function-tree execution.
 
 Cerebral uses the [function-tree](https://github.com/cerebral/function-tree) project to implement its signals. A function-tree allows you to define a tree of functions to be executed. In Cerebral world we call the functions in this tree **actions**.
 
-You can define this execution tree with a single action:
+## Sequence
+
+You can define an execution tree with a single action:
 
 ```js
 function myAction () {}
@@ -12,7 +14,7 @@ function myAction () {}
 export default myAction
 ```
 
-Or you can group them together in a *sequence* using an array:
+This will automatically be converted to a *sequence* with a single action. By using an array you can define multiple actions in one sequence:
 
 ```js
 function actionA () {}
@@ -25,6 +27,53 @@ export default [
 ```
 
 In a sequence Cerebral runs one action after the other synchronously. When an action returns a promise it will hold until the promise resolves and then continue the sequence.
+
+You can define a sequence explicitly:
+
+```js
+import {sequence} from 'cerebral'
+
+function actionA () {}
+function actionB () {}
+
+export default sequence([
+  actionA,
+  actionB
+])
+```
+
+This is exactly the same as the example above, but we have a couple of new possibilities now.
+
+### Name
+You can give a sequence a name:
+
+```js
+import {sequence} from 'cerebral'
+
+export default sequence('My sequence', [])
+```
+
+This name is picked up by the debugger and will be displayed in the visualization of the signal. This is useful in very complex compositions.
+
+### Abort
+You can also abort the execution of a sequence. This is useful when you for example have failing HTTP requests etc. and there is no reason to continue signal execution.
+
+```js
+import {sequence} from 'cerebral'
+
+function actionA () {}
+function actionB () {}
+function actionC () {}
+
+export default sequence('My sequence', [
+  actionA,
+  actionB
+], [
+  actionC
+])
+```
+
+The third argument is the "abort sequence". If any of these actions return an **abort** it will stop execution and rather start a new execution on the abort sequence. The debugger will show you exactly what action caused an abort and its execution. Read more about how to abort in the API documentation.
 
 ## Parallel execution
 You can also run these actions in parallel. You do that by using the **parallel** function:
@@ -46,6 +95,8 @@ export default [
 ```
 
 If actionA returns a promise actionB will still be run instantly, meaning that they run in parallel. When both actionA and actionB is done, actionC is run.
+
+Parallel also has naming and abort possibilities, just like sequence.
 
 ## Composing
 Actions and a sequence of actions can be composed into other sequences of actions. This is a powerful concept that allows you to decouple a lot of your logic and compose it together wherever it is needed:

--- a/docs/packages/function_tree.md
+++ b/docs/packages/function_tree.md
@@ -107,6 +107,26 @@ module.exports = sequence('My awesome sequence', [
 ])
 ```
 
+You can also add a second sequence. This is the **abort sequence**. When one of the functions return an abort it will run this sequence.
+
+```js
+const sequence = require('function-tree').sequence
+
+function someFunction (context) {
+  return context.abort()
+}
+function someOtherFunction (context) {}
+
+module.exports = sequence('My awesome sequence', [
+  someFunction,
+  someOtherFunction // does not run
+], [
+  someAbortHandlingFunction
+])
+```
+
+Note that aborting a sequence does not cause **bubbling** up to other abort sequences.
+
 ### parallel
 ```js
 const parallel = require('function-tree').parallel
@@ -120,7 +140,7 @@ module.exports = parallel([
 ])
 ```
 
-Even though **someFunction** returns a Promise, **someOtherFunction** will be run immediately.
+Even though **someFunction** returns a Promise, **someOtherFunction** will be run immediately. Parallel has the same naming and abort possibilities as a sequence.
 
 ### context
 
@@ -213,7 +233,7 @@ const FunctionTree = require('function-tree').default
 const execute = FunctionTree([])
 
 function funcA (context) {
-  return context.execution.abort()
+  return context.execution.abort({}) // optional payload
 }
 
 function funcB (context) {
@@ -225,9 +245,19 @@ const tree = [
   funcB
 ]
 
+// If not caught by an abort chain and event is triggered
 execute.on('abort', (functionDetails, payload) => {})
 
 execute(tree)
+```
+
+### abort
+Just short for **execution.abort**.
+
+```js
+function funcA (context) {
+  return context.abort({}) // optional payload
+}
 ```
 
 ### error

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -237,7 +237,7 @@ class Devtools {
     called again
   */
   watchExecution () {
-    this.controller.on('start', (execution) => {
+    this.controller.on('start', (execution, payload) => {
       const message = JSON.stringify({
         type: 'executionStart',
         source: 'c',
@@ -246,7 +246,8 @@ class Devtools {
             executionId: execution.id,
             name: execution.name,
             staticTree: execution.staticTree,
-            datetime: execution.datetime
+            datetime: execution.datetime,
+            executedBy: payload._execution ? payload._execution : null
           }
         }
       })

--- a/packages/function-tree/src/FunctionTree.test.js
+++ b/packages/function-tree/src/FunctionTree.test.js
@@ -407,4 +407,75 @@ describe('FunctionTree', () => {
 
     execute(tree)
   })
+  it('should use abort chain using sequence', (done) => {
+    let executedCount = 0
+    const execute = FunctionTree([])
+
+    function funcA ({abort}) { return abort() }
+    function funcB () { executedCount++ }
+
+    const tree = sequence([
+      funcA
+    ], [
+      funcB
+    ])
+
+    execute.once('end', () => {
+      assert.equal(executedCount, 1)
+      done()
+    })
+
+    execute(tree)
+  })
+  it('should use abort chain using parallel', (done) => {
+    let executedCount = 0
+    const execute = FunctionTree([])
+
+    function funcA ({abort}) { return abort() }
+    function funcB () { executedCount++ }
+
+    const tree = parallel([
+      funcA
+    ], [
+      funcB
+    ])
+
+    execute.once('end', () => {
+      assert.equal(executedCount, 1)
+      done()
+    })
+
+    execute(tree)
+  })
+  it('should not continue async execution when aborted', (done) => {
+    let executedCount = 0
+    const execute = FunctionTree([])
+
+    function funcA ({path}) {
+      return Promise.resolve(path.test())
+    }
+    function funcB ({abort}) {
+      return abort()
+    }
+    function funcC () { executedCount++ }
+    function funcD () { executedCount++ }
+
+    const tree = parallel([
+      funcA, {
+        test: funcC
+      },
+      funcB
+    ], [
+      funcD
+    ])
+
+    execute.once('end', () => {
+      setTimeout(() => {
+        assert.equal(executedCount, 1)
+        done()
+      })
+    })
+
+    execute(tree)
+  })
 })

--- a/packages/function-tree/src/primitives.js
+++ b/packages/function-tree/src/primitives.js
@@ -3,9 +3,11 @@ export class Sequence {
     if (typeof args[0] === 'string') {
       this.name = args[0]
       this.items = args[1]
+      this.abortChain = args[2]
     } else {
       this.name = null
       this.items = args[0]
+      this.abortChain = args[1]
     }
 
     if (!Array.isArray(this.items)) {
@@ -27,9 +29,11 @@ export class Parallel {
     if (typeof args[0] === 'string') {
       this.name = args[0]
       this.items = args[1]
+      this.abortChain = args[2]
     } else {
       this.name = null
       this.items = args[0]
+      this.abortChain = args[1]
     }
 
     if (!Array.isArray(this.items)) {

--- a/packages/function-tree/src/providers/Abort.js
+++ b/packages/function-tree/src/providers/Abort.js
@@ -1,0 +1,11 @@
+function AbortProviderFactory () {
+  function AbortProvider (context) {
+    context.abort = context.execution.abort
+
+    return context
+  }
+
+  return AbortProvider
+}
+
+export default AbortProviderFactory

--- a/packages/function-tree/src/providers/Execution.test.js
+++ b/packages/function-tree/src/providers/Execution.test.js
@@ -15,21 +15,19 @@ describe('ExecutionProvider', () => {
       }
     ])
   })
-  it('should be able to retry execution', () => {
+  it('should be able to retry execution', (done) => {
     const execute = FunctionTree()
     let count = 0
 
     function funcA () {
-      return new Promise(resolve => {
-        resolve()
-      })
+      return Promise.resolve()
     }
 
-    function funcB ({input, execution}) {
-      if (input.retryCount < 3) {
+    function funcB ({props, execution}) {
+      if (props.retryCount < 3) {
         count++
         return execution.retry({
-          retryCount: input.retryCount + 1
+          retryCount: props.retryCount + 1
         })
       }
     }
@@ -41,6 +39,7 @@ describe('ExecutionProvider', () => {
       retryCount: 0
     }, () => {
       assert.equal(count, 3)
+      done()
     })
   })
   it('should be able to abort execution', () => {

--- a/packages/function-tree/src/staticTree.js
+++ b/packages/function-tree/src/staticTree.js
@@ -18,12 +18,12 @@ function isPaths (item) {
   )
 }
 
-function analyze (functions, item, isParallel) {
+function analyze (functions, item, isParallel, abortChain) {
   if (item instanceof Parallel || item instanceof Sequence) {
     const instance = item.toJSON()
 
     return Object.assign(instance, {
-      items: analyze(functions, instance.items, item instanceof Parallel).items
+      items: analyze(functions, instance.items, item instanceof Parallel, item.abortChain).items
     })
   } else if (Array.isArray(item)) {
     return new Sequence(item.reduce((allItems, subItem, index) => {
@@ -39,6 +39,11 @@ function analyze (functions, item, isParallel) {
           functionIndex: functions.push(subItem) - 1,
           function: subItem
         }
+
+        if (abortChain) {
+          funcDetails.getAbortChain = () => abortChain
+        }
+
         const nextItem = item[index + 1]
 
         if (isPaths(nextItem)) {


### PR DESCRIPTION
- Added **abort** logic to function tree, with new tests
- Added **AbortProvider** to function tree, making `abort` available directly on context
- Updated docs
- Updated debugger to show abort sequence inline, just like the demo of merged client/server execution

I have already released new debugger as nothing breaking there.