### PR TITLE
Expose field on cerebral-provider-forms

### DIFF
--- a/docs/packages/forms.md
+++ b/docs/packages/forms.md
@@ -113,6 +113,31 @@ export default connect({
 )
 ```
 
+You can also use the **field*** computed, pointing to the field.
+
+To use a form you use the **form** computed, pointing to the form. Typically:
+
+```js
+import React from 'react'
+import {connect} from 'cerebral/react'
+import {field} from 'cerebral-provider-forms'
+
+export default connect({
+  field: field(state`path.to.form.name`)
+},
+  function MyForm ({field}) {
+    // Value of some field
+    field.value
+    // A true/false if field has a value
+    field.hasValue
+    // A true/false if field has been changed
+    field.isPristine
+    // A true/false if field is valid
+    field.isValid
+  }
+)
+```
+
 ## provider
 You can also access your forms in actions.
 

--- a/docs/packages/forms.md
+++ b/docs/packages/forms.md
@@ -115,8 +115,6 @@ export default connect({
 
 You can also use the **field*** computed, pointing to the field.
 
-To use a form you use the **form** computed, pointing to the form. Typically:
-
 ```js
 import React from 'react'
 import {connect} from 'cerebral/react'

--- a/packages/cerebral-provider-forms/src/field.test.js
+++ b/packages/cerebral-provider-forms/src/field.test.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+import {field} from '.'
+import assert from 'assert'
+import {runCompute} from 'cerebral/test'
+import {state} from 'cerebral/tags'
+import {Field} from './form'
+
+describe('field', () => {
+  it('should not be a valid field due to required', () => {
+    let compute = {
+      state: {
+        form: {
+          name: {
+            value: '',
+            isRequired: true
+          }
+        }
+      }
+    }
+    const nameField = runCompute(field(state`form.name`), compute)
+    assert.equal(nameField.isValid, false)
+    assert.equal(nameField.hasValue, false)
+  })
+
+  it('should  be a valid field', () => {
+    let compute = {
+      state: {
+        form: {
+          name: {
+            value: 'Some name',
+            isRequired: true
+          }
+        }
+      }
+    }
+    const nameField = runCompute(field(state`form.name`), compute)
+    assert.equal(nameField.isValid, true)
+    assert.equal(nameField.value, 'Some name')
+    assert.ok(nameField instanceof Field)
+  })
+})

--- a/packages/cerebral-provider-forms/src/form.js
+++ b/packages/cerebral-provider-forms/src/form.js
@@ -68,6 +68,21 @@ export class Form {
 
 }
 
+export function computedField (fieldValueTag) {
+  return compute(
+    fieldValueTag,
+    (fieldValue) => {
+      if (!fieldValue || typeof fieldValue !== 'object') {
+        console.warn(`Cerebral Forms - Field value: ${fieldValueTag} did not resolve to an object`)
+        return {}
+      }
+      const field = new Field(fieldValue, null)
+      field._validate()
+      return field
+    }
+  )
+}
+
 export default function computedForm (formValueTag) {
   return compute(
     formValueTag,

--- a/packages/cerebral-provider-forms/src/index.js
+++ b/packages/cerebral-provider-forms/src/index.js
@@ -5,6 +5,7 @@ import resetForm from './helpers/resetForm'
 import formToJSON from './helpers/formToJSON'
 export {default as form} from './form'
 export {default as rules} from './rules'
+export {computedField as field} from './form'
 
 function FormsProvider (options = {}) {
   if (options.rules) {


### PR DESCRIPTION
This will allow 

```js
import {state} from 'cerebral/tags'
import {field} from 'cerebral-provider-forms'

export default connect({
 myField: field(state`some.field`)
})
```

Validate will run and you will have `myField.isValid` etc