### PR TITLE
forms-provider, adjust failedRule behaviour

### DIFF
--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -33,7 +33,6 @@ export default function validate (form, value, validationRules) {
     } else {
       arg = undefined
     }
-
     
     const isValid = rule(value, form, arg)
 

--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -33,7 +33,7 @@ export default function validate (form, value, validationRules) {
     } else {
       arg = undefined
     }
-    
+
     const isValid = rule(value, form, arg)
 
     return {

--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -41,7 +41,7 @@ export default function validate (form, value, validationRules) {
       isValid,
       failedRule: isValid ? null : {
         name: ruleKey,
-        arg: arg
+        arg
       },
       errorMessage: rules._errorMessages[ruleKey] ? rules._errorMessages[ruleKey](value, arg) : null
     }

--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -34,13 +34,16 @@ export default function validate (form, value, validationRules) {
       arg = undefined
     }
 
+    
+    const isValid = rule(value, form, arg)
+
     return {
-      isValid: rule(value, form, arg),
-      failedRule: {
+      isValid,
+      failedRule: isValid ? null : {
         name: ruleKey,
-        arg
+        arg: arg
       },
-      errorMessage: rules._errorMessages[ruleKey] ? rules._errorMessages[ruleKey](value, arg) : null
+      errorMessage: _rules2.default._errorMessages[ruleKey] ? _rules2.default._errorMessages[ruleKey](value, arg) : null
     }
   }, initialValidation)
 }

--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -43,7 +43,7 @@ export default function validate (form, value, validationRules) {
         name: ruleKey,
         arg: arg
       },
-      errorMessage: _rules2.default._errorMessages[ruleKey] ? _rules2.default._errorMessages[ruleKey](value, arg) : null
+      errorMessage: rules._errorMessages[ruleKey] ? rules._errorMessages[ruleKey](value, arg) : null
     }
   }, initialValidation)
 }


### PR DESCRIPTION
Currently failedRule is still set, even if it is valid. With this code change it gets set to null. As I am a JS beginner, I would appreciate, if someone else could write a test, thanks :)