### PR TITLE
feat(Views): add react fiber support

### DIFF
--- a/packages/cerebral/src/viewFactories/react.js
+++ b/packages/cerebral/src/viewFactories/react.js
@@ -1,10 +1,13 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import ContainerFactory from './Container'
 import StateContainerFactory from './StateContainer'
 import HocFactory from './Hoc'
 import connectFactory, { decoratorFactory } from './connect'
 
+const deferredUpdates = ReactDOM.unstable_deferredUpdates || ReactDOM.deferredUpdates
+
 export const Container = ContainerFactory(React)
 export const StateContainer = StateContainerFactory(React)
-export const connect = connectFactory(HocFactory(React))
-export const decorator = decoratorFactory(HocFactory(React))
+export const connect = connectFactory(HocFactory(React, deferredUpdates ? deferredUpdates.bind(ReactDOM) : null))
+export const decorator = decoratorFactory(HocFactory(React, deferredUpdates ? deferredUpdates.bind(ReactDOM) : null))

--- a/packages/function-tree/src/index.js
+++ b/packages/function-tree/src/index.js
@@ -46,6 +46,7 @@ class FunctionTreeExecution extends EventEmitter {
     this.functionTree = functionTree
     this.datetime = Date.now()
     this.errorCallback = errorCallback
+    this.isAsync = false
 
     this.runFunction = this.runFunction.bind(this)
   }
@@ -80,6 +81,7 @@ class FunctionTreeExecution extends EventEmitter {
     */
     if (isPromise(result)) {
       functionTree.emit('asyncFunction', execution, funcDetails, payload, result)
+      this.isAsync = true
       result
         .then(function (result) {
           if (result instanceof Abort) {


### PR DESCRIPTION
It was actually super easy to create fiber support. It is just a function that might or might not be there, with some intelligent logic to ensure that it does not fail, runs when it is not supposed to etc... 

The way it optimises is that any state mutation that happens after an async function is triggered uses the "requestIdleCallback" thingy. That means you do not have to think about this really. It also means that you might have some sync signal that is not high priority, but this is a balance. I do not see any reason to do low level optimisations by introducing new API. Lets us try fiber first and get this stuff for free :) Will create a video explaining a bit more.

1. Follow this guide to build fiber: https://gist.github.com/duivvv/2ba00d413b8ff7bc1fa5a2e51c61ba43
2. copy react.js and react-dom-fiber.js to your project. 
3. Configure webpack alias to point to these files as:

```js
{
  resolve: {
    alias: {
      'react': path.resolve('someFolder', 'react.js'),
      'react-dom': path.resolve('someFolder', 'react-dom-fiber.js')
    }
  }
}
```

Then it works :)