### PR TITLE
feat(debugger): add several fixes

### DIFF
--- a/debugger/connector/index.js
+++ b/debugger/connector/index.js
@@ -33,6 +33,9 @@ const connector = {
         connector.sendEvent(port, 'ping')
       }
     })
+    ipcRenderer.on('port:exists', function onPortExists () {
+      eventCallback(new Error('Something running on this port already'))
+    })
     ipcRenderer.send('port:add', port)
   },
   onPortFocus (cb) {

--- a/debugger/electron/main.js
+++ b/debugger/electron/main.js
@@ -57,6 +57,9 @@ function createWindow () {
         }
       })
     })
+    clients[port].wss.on('error', function (ws) {
+      mainWindow.webContents.send('port:exists', port)
+    })
     mainWindow.webContents.send('port:added', port)
   })
 

--- a/debugger/src/components/Debugger/App/styles.css
+++ b/debugger/src/components/Debugger/App/styles.css
@@ -85,3 +85,19 @@
 .execution-led--executing {
   background-color: #dbb427;
 }
+
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: calc(100vh - 81px);
+  font-size: 32px;
+}
+
+.error-title {
+  color: #eb1e1e;
+  font-size: 80px;
+  font-weight: bold;
+  margin-bottom: 30px;
+}

--- a/debugger/src/components/Debugger/Inspector/index.js
+++ b/debugger/src/components/Debugger/Inspector/index.js
@@ -279,6 +279,13 @@ class Value extends Inferno.Component {
   onBlur () {
     this.setState({isEditing: false})
   }
+  shortenString (string) {
+    if (string.length > 50) {
+      return string.substr(0, 47) + '...'
+    }
+
+    return string
+  }
   renderValue (value, hasNext) {
     const isExactHighlightPath = this.props.highlightPath && String(this.props.highlightPath) === String(this.props.path)
 
@@ -299,7 +306,7 @@ class Value extends Inferno.Component {
       return (
         <div className={isExactHighlightPath ? 'inspector-highlight' : null}>
           {this.props.propertyKey ? this.props.propertyKey + ': ' : <span />}
-          <span onClick={this.onClick}>{isString(value) ? '"' + value + '"' : String(value)}</span>
+          <span onClick={this.onClick}>{isString(value) ? '"' + this.shortenString(value) + '"' : String(value)}</span>
           {hasNext ? ',' : null}
         </div>
       )

--- a/debugger/src/components/Debugger/Signals/Signal/Action/index.js
+++ b/debugger/src/components/Debugger/Signals/Signal/Action/index.js
@@ -60,6 +60,10 @@ function Action ({action, faded, execution, children, onMutationClick, onActionC
       </div>
       {error ? (
         <div className='action-error'>
+          <div className='action-actionInput'>
+            <div className='action-inputLabel'>props:</div>
+            <div className='action-inputValue'><Inspector value={execution.payload} /></div>
+          </div>
           <strong>{error.name}</strong> : {error.message}
           <pre data-line={getLineNumber(error)}>
             <code className='language-javascript' dangerouslySetInnerHTML={{__html: renderCode(error)}} />

--- a/debugger/src/components/Debugger/Signals/styles.css
+++ b/debugger/src/components/Debugger/Signals/styles.css
@@ -6,13 +6,13 @@
 }
 
 .signals-list {
-  flex: 2;
+  flex: 1;
   min-width: 200px;
 }
 
 .signals-signal {
   margin-left: 10px;
-  flex: 4;
+  flex: 3;
   overflow: auto;
 }
 

--- a/debugger/src/components/Debugger/Toolbar/index.js
+++ b/debugger/src/components/Debugger/Toolbar/index.js
@@ -34,6 +34,11 @@ export default connect({
               {
                 this.props.type === 'c' || this.props.type === 'cft' ? [
                   <li
+                    className={classNames('toolbar-tab', {'toolbar-tab--active': this.props.currentPage === 'model'})}
+                    onClick={() => this.props.pageChanged({page: 'model'})}>
+                    <i className='icon icon-model' /> STATE-TREE
+                  </li>,
+                  <li
                     className={classNames('toolbar-tab', {'toolbar-tab--active': this.props.currentPage === 'mutations'})}
                     onClick={() => this.props.pageChanged({page: 'mutations'})}>
                     <i className='icon icon-mutation' /> MUTATIONS
@@ -42,11 +47,6 @@ export default connect({
                     className={classNames('toolbar-tab', {'toolbar-tab--active': this.props.currentPage === 'components'})}
                     onClick={() => this.props.pageChanged({page: 'components'})}>
                     <i className='icon icon-components' /> COMPONENTS
-                  </li>,
-                  <li
-                    className={classNames('toolbar-tabOnSmall', 'toolbar-tab', {'toolbar-tab--active': this.props.currentPage === 'model'})}
-                    onClick={() => this.props.pageChanged({page: 'model'})}>
-                    <i className='icon icon-model' /> STATE-TREE
                   </li>,
                   <li className='toolbar-search'>
                     <input

--- a/debugger/src/components/Debugger/index.js
+++ b/debugger/src/components/Debugger/index.js
@@ -40,7 +40,8 @@ class Debugger extends Inferno.Component {
             controller: Controller({
               state: {
                 port,
-                type: storedApps[port].type
+                type: storedApps[port].type,
+                error: null
               },
               modules: {
                 debugger: DebuggerModule(),

--- a/debugger/src/modules/Debugger/index.js
+++ b/debugger/src/modules/Debugger/index.js
@@ -8,6 +8,7 @@ import resetClicked from './signals/resetClicked'
 import modelClicked from './signals/modelClicked'
 import searchValueChanged from './signals/searchValueChanged'
 import escPressed from './signals/escPressed'
+import addPortErrored from './signals/addPortErrored'
 
 export default () => ({
   state: {
@@ -39,6 +40,7 @@ export default () => ({
     mutationDoubleClicked,
     mutationClicked,
     resetClicked,
-    modelClicked
+    modelClicked,
+    addPortErrored
   }
 })

--- a/debugger/src/modules/Debugger/signals/addPortErrored.js
+++ b/debugger/src/modules/Debugger/signals/addPortErrored.js
@@ -1,0 +1,6 @@
+import {set} from 'cerebral/operators'
+import {state, props} from 'cerebral/tags'
+
+export default [
+  set(state`error`, props`error`)
+]

--- a/demos/todomvc/src/controller.js
+++ b/demos/todomvc/src/controller.js
@@ -76,7 +76,12 @@ const controller = Controller({
     clearCompletedClicked: [
       clearCompletedTodos
     ],
-    filterClicked: set(state`filter`, props`filter`)
+    filterClicked: [
+      set(state`filter`, props`filter`),
+      function Test () {
+        throw new Error('Wuuut?')
+      }
+    ]
   }
 })
 


### PR DESCRIPTION
- Shows warning when the selected PORT is in use
- Removed auto inline state tree on signals and mutations tab. It has been confusing to people and when signals becomes rather complex you want to separate them anyways
- Now errored actions shows the props passed to them
- Long strings are now ellipsed... when editing a long string in state tree you get the full string