### PR TITLE
fix(Devtools): fix error catching on function-tree devtools

### DIFF
--- a/packages/function-tree/src/devtools/index.js
+++ b/packages/function-tree/src/devtools/index.js
@@ -60,6 +60,7 @@ class DevtoolsClass {
     this.ws.onopen = () => {
       this.ws.send(JSON.stringify({type: 'ping'}))
     }
+    this.ws.onerror = () => {}
     this.ws.onclose = () => {
       console.warn('Debugger application is not running on selected port... will reconnect automatically behind the scenes')
       this.reconnect()


### PR DESCRIPTION
No need to to anything... it is just Node that totally breaks on any error throwing. It is closing of connection that handles reconnect.