### PR TITLE
fix(Devtools): fix error handling on connection issues

### DIFF
--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -155,6 +155,7 @@ class Devtools {
     this.ws.onopen = () => {
       this.ws.send(JSON.stringify({type: 'ping'}))
     }
+    this.ws.onerror = () => {}
     this.ws.onclose = () => {
       console.warn('Could not connect to the debugger, please make sure it is running... automatically retrying in the background')
       this.reconnect()


### PR DESCRIPTION
Same fix for Cerebral devtools as function-tree.. need to swallow errors or it will be party time in console every 5 seconds :)