### PR TITLE
feat(Devtools): make devtools instance based and flexible

### DIFF
--- a/docs/api/devtools.md
+++ b/docs/api/devtools.md
@@ -11,6 +11,11 @@ const controller = Controller({
     // fall back to chrome extension if unable to connect
     remoteDebugger: 'localhost:8585',
 
+    // By default the devtools tries to reconnect
+    // to debugger when it can not be reached, but
+    // you can turn it off
+    reconnect: true,
+
     // Time travel
     storeMutations: true,
 

--- a/docs/get_started/debugger.md
+++ b/docs/get_started/debugger.md
@@ -27,7 +27,12 @@ const controller = Controller({
       Devtools({
         // If running standalone debugger. Some environments
         // might require 127.0.0.1 or computer IP address
-        remoteDebugger: 'localhost:8585'
+        remoteDebugger: 'localhost:8585',
+
+        // By default the devtools tries to reconnect
+        // to debugger when it can not be reached, but
+        // you can turn it off
+        reconnect: true
       })
   )
 })

--- a/packages/function-tree/README.md
+++ b/packages/function-tree/README.md
@@ -99,15 +99,23 @@ import Devtools from 'function-tree/devtools'
 // const FunctionTree = require('function-tree').FunctionTree
 // const Devtools = require('function-tree/devtools').Devtools
 
+const devtools = new Devtools({
+  // Set url of remote debugger
+  remoteDebugger: 'localhost:8585',
+
+  // By default debugger tries to reconnect when it is not active
+  reconnect: true
+})
 const ft = new FunctionTree([])
 
-// Pass the instance of function-tree to debug. You can
-// optionally pass an array of function-trees
-if (process.env.NODE_ENV !== 'production') {
-  Devtools(ft, {
-    remoteDebugger: 'localhost:8585'
-  })  
-}
+// Add your function tree to the debugger
+devtools.add(ft)
+
+// If you are not going to use it anymore, remove it
+devtools.remove(ft)
+
+// Remove all function trees from debugger
+devtools.destroy()
 ```
 
 You can use it when creating providers to easily wrap their usage:


### PR DESCRIPTION
Makes function-tree devtools flexible:

```js
const devtools = new Devtools({
  remoteDebugger: 'localhost:8585',
  reconnect: true // Can turn off automatic reconnect
})

devtools.add(functionTreeInstance)
devtools.remove(functionTreeInstance)
devtools.destroy() // removes all instances
```