### PR TITLE
feat(router): add additional methods for grabbin parts of url

### DIFF
--- a/packages/cerebral-router/README.md
+++ b/packages/cerebral-router/README.md
@@ -74,8 +74,24 @@ const controller = Controller({
 ### getUrl
 ```js
 function myAction({router}) {
-  // Get current url, example: "/items"
+  // If url is "http://localhost:3000/items?foo=bar", returns "/items?foo=bar"
   router.getUrl()
+}
+```
+
+### getUrlBase
+```js
+function myAction({router}) {
+  // If url is "http://localhost:3000/items?foo=bar", returns "/items"
+  router.getUrlBase()
+}
+```
+
+### getUrlQuery
+```js
+function myAction({router}) {
+  // If url is "http://localhost:3000/items?foo=bar", returns "foo=bar"
+  router.getUrlQuery()
 }
 ```
 

--- a/packages/cerebral-router/src/index.js
+++ b/packages/cerebral-router/src/index.js
@@ -90,6 +90,12 @@ export default function Router (options = {}) {
       getUrl () {
         return addressbar.value.replace(addressbar.origin + options.baseUrl, '')
       },
+      getUrlBase () {
+        return addressbar.value.replace(addressbar.origin + options.baseUrl, '').split('?')[0]
+      },
+      getUrlQuery () {
+        return addressbar.value.replace(addressbar.origin + options.baseUrl, '').split('?')[1]
+      },
       goTo (url) {
         addressbar.value = options.baseUrl + url
         onUrlChange()


### PR DESCRIPTION
Being able to grab certain parts of url is useful to track state changes in url. For example in Ducky app we do not care if the query has changed, but we care if the base url has changed. In @great router I suggest we add state for this:

```js
{
  router: {
    url: 'http://localhost:3000/items?foo=bar',
    query: {foo: 'bar'},
    origin: 'localhost',
    port: 3000,
    path: '/items'
  }
}
```

Something like that... anyways, these methods are good enough for current router I think