### PR TITLE
feat(Providers): add provide factory to simplify concept of providers

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -2,7 +2,7 @@
 
 Providers are functions that runs before any action in any signal. Their purpose is to define and sometimes manipulate the context passed into every action. The providers run before every action, meaning that each action has a unique context object.
 
-To add something to the context you create a provider:
+Providers are created with a function:
 
 ```js
 function MyProvider (context, functionDetails, payload, prevPayload) {
@@ -23,10 +23,28 @@ function MyProvider (context, functionDetails, payload, prevPayload) {
 }
 ```
 
+This function needs to be listed in the **providers** property of the controller to be registered:
+
+```js
+Controller({
+  providers: [MyProvider]
+})
+```
+
+Ability to add a single provider is also available in modules:
+
+```js
+{
+  state: {},
+  signals: {},
+  provider: MyProvider
+}
+```
+
 There are a few things already available on the context when your provider runs:
 
 ```js
-function MyProvider(context) {
+function MyProvider (context) {
   context.execution // Information on the function tree execution
   context.controller // The Cerebral controller
   context.debugger // If devtools is added, you can send messages to the debugger
@@ -37,4 +55,50 @@ function MyProvider(context) {
 
   return context
 }
+```
+
+## Example provider
+
+```js
+// We create a factory, allowing you to pass in options to it
+function GreetProviderFactory (options = {}) {
+  // We use a variable to cache the created provider
+  let cachedProvider = null
+
+  // Just some custom code to handle an option
+  let exclamationMarks = ''
+
+  for (let x = 0; x < options.numberOfExclamationMarks || 0; x++) {
+    exclamationMarks += '!'
+  }
+
+  // This is the function that creates the provider,
+  // typically just an object with some methods
+  function createProvider (context) {
+    return {
+      hello (name) {
+        return `Hello, ${name}${exclamationMarks}`
+      }
+    }
+  }
+
+  // The function that is run by Cerebral, providing the context
+  // for you to attach your provider to
+  function GreetProvider (context) => {
+    context.greet = cachedProvider = (cachedProvider || createProvider(context))
+
+    // You can wrap the provider with the debugger
+    // to show information about its usage in the debugger
+    if (context.debugger) {
+      context.debugger.wrapProvider('greet')
+    }
+
+    // Always return the context after mutating it
+    return context
+  }
+
+  return GreetProvider
+}
+
+export default GreetProviderFactory
 ```

--- a/docs/developer_guide/providers.md
+++ b/docs/developer_guide/providers.md
@@ -1,18 +1,20 @@
 # Providers
 
-Providers are added to the context of every action executed by a signal. Providers can be everything from a tool you are already using, to something Cerebral specific. The point of providers is to separate side effects from execution. That means you can create all the logic you want with chains and actions without creating any dependencies to other tools. This makes them highly testable and generally gives you more flexibility.
+Providers are added to the context of every action executed by a signal. Providers can be everything from a tool you are already using, to something Cerebral specific. The point of providers is to separate side effects from execution. That means you can create all the logic you want in actions without creating any dependencies to other tools. This makes them highly testable and generally gives you more flexibility.
 
 ## Just add a tool
 If you are using libraries where you want access to everything they provide you can simply add them as a provider using an object:
 
 ```js
-import {Controller} from 'cerebral'
-import {ContextProvider} from 'cerebral/providers'
+import {Controller, provide} from 'cerebral'
 import axios from 'axios'
 import uuid from 'uuid'
 
 const controller = Controller({
-  providers: [{axios, uuid}]
+  providers: [
+    provide('http', axios),
+    provide('id', uuid.v4)
+  ]
 })
 ```
 
@@ -28,68 +30,33 @@ const controller = Controller({
   providers: [
     StorageProvider(),
     HttpProvider(),
-    FirebaseProvider(),
+    FirebaseProvider()
+  ]
+})
+```
 
-    // Let us create this
-    GreetProvider({
-      numberOfExclamationMarks: 3
+The **provide** factory helps you add your own providers in a simple way:
+
+```js
+import {Controller, provide} from 'cerebral'
+
+const controller = Controller({
+  providers: [
+    provide('someProvider', {
+      foo: 'bar'
     })
   ]
 })
 ```
 
-The convention on creating a provider looks like this:
-
-```js
-// We create a factory, allowing you to pass in options to it
-function GreetProviderFactory (options = {}) {
-  // We use a variable to cache the created provider
-  let cachedProvider = null
-
-  // Just some custom code to handle an option
-  let exclamationMarks = ''
-
-  for (let x = 0; x < options.numberOfExclamationMarks || 0; x++) {
-    exclamationMarks += '!'
-  }
-
-  // This is the function that creates the provider,
-  // typically just an object with some methods
-  function createProvider (context) {
-    return {
-      hello (name) {
-        return `Hello, ${name}${exclamationMarks}`
-      }
-    }
-  }
-
-  // The function that is run by Cerebral, providing the context
-  // for you to attach your provider to
-  function GreetProvider (context) => {
-    context.greet = cachedProvider = (cachedProvider || createProvider(context))
-
-    // You can wrap the provider with the debugger
-    // to show information about its usage in the debugger
-    if (context.debugger) {
-      context.debugger.wrapProvider('greet')
-    }
-
-    // Always return the context after mutating it
-    return context
-  }
-
-  return GreetProvider
-}
-
-export default GreetProviderFactory
-```
+When using the **provide** factory the provider will automatically be wrapped by the Cerebral devtools, to track its usage in the debugger.
 
 Now this provider is available to any action:
 
 ```js
-function myAction ({greet}) {
-  greet.hello('Thor') // "Hello Thor!!!"
+function myAction ({someProvider}) {
+  someProvider.foo // "bar"
 }
 ```
 
-As mentioned above we use providers to separate side effects from execution, allowing us to provider our own custom API to our application.
+As mentioned above we use providers to separate side effects from execution, allowing us to provide our own custom API to our application. The **provide** factory simplifies adding a provider, you can get more control by defining your own provider function. Look at the API docs for more information.

--- a/packages/cerebral/src/Provide.js
+++ b/packages/cerebral/src/Provide.js
@@ -1,0 +1,11 @@
+export default function Provide (name, provider) {
+  return function (context) {
+    context[name] = provider
+
+    if (context.debugger) {
+      context.debugger.wrapProvider(name)
+    }
+
+    return context
+  }
+}

--- a/packages/cerebral/src/Provide.test.js
+++ b/packages/cerebral/src/Provide.test.js
@@ -1,0 +1,23 @@
+/* eslint-env mocha */
+import Controller from './Controller'
+import provide from './Provide'
+import assert from 'assert'
+
+describe('Provide', () => {
+  it('should create a provider', (done) => {
+    const controller = new Controller({
+      providers: [
+        provide('test', {foo: 'bar'})
+      ],
+      signals: {
+        test: [
+          ({test}) => {
+            assert.deepEqual(test, {foo: 'bar'})
+            done()
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
+  })
+})

--- a/packages/cerebral/src/index.js
+++ b/packages/cerebral/src/index.js
@@ -1,3 +1,4 @@
 export {default as Controller} from './Controller'
 export {default as compute} from './Compute'
+export {default as provide} from './Provide'
 export {sequence, parallel} from 'function-tree'


### PR DESCRIPTION
Okay, so I woke up this night with an idea to a different approach making providers concept easier to understand.

So basically I have made some docs updates and added a `provide` helper. It looks like this:

```js
import {Controller, provide} from 'cerebral'
import axios from 'axios'

Controller({
  providers: [
    provide('http', axios)
  ]
})
```

The API makes it very explicit what you do, you "provide axios to Cerebral named http" . This just makes a lot more sense than some magical object in the providers array:

```js
Controller({
  providers: [{
    http: axios
  }]
})
```

This API is flawed cause it is not explicit, what about multiple objects etc.?

There is nothing breaking about this :)