### PR TITLE
fix(Controller): throw correct errors related to state updates

### DIFF
--- a/packages/cerebral/src/Model.js
+++ b/packages/cerebral/src/Model.js
@@ -139,7 +139,7 @@ class Model {
       this.devtools &&
       !isSerializable(value, this.devtools.allowedTypes)
     ) {
-      throwError(`You are passing a non serializable value into the state tree on path ${path.join('.')}`)
+      throwError(`You are passing a non serializable value into the state tree on path "${path.join('.')}"`)
     }
     if (this.devtools) {
       forceSerializable(value)

--- a/packages/cerebral/src/providers/State.js
+++ b/packages/cerebral/src/providers/State.js
@@ -35,7 +35,7 @@ function StateProviderFactory () {
     }, {})
   }
 
-  function StateProvider (context) {
+  function StateProvider (context, functionDetails) {
     context.state = provider = provider || createProvider(context)
 
     if (context.debugger) {
@@ -60,10 +60,8 @@ function StateProviderFactory () {
             try {
               originFunc.apply(context.controller.model, args)
             } catch (e) {
-              const path = args[0]
-              const type = typeof args[1]
               const signalName = context.execution.name
-              throwError(`The Signal '${signalName}' passed an invalid value of type '${type}' to the state tree at path: '${path}'`)
+              throwError(`The Signal "${signalName}" with action "${functionDetails.name}" has an error: ${e.message}`)
             }
           }
         }


### PR DESCRIPTION
There was only one error thrown here, making it super confusing. Now it throws these two errors:

### Wrong state path
Cerebral - The Signal "newTodoTitleChanged" with action "operator.set(state`newTodoTitle.mip`, props`title`)" has an error: The path "newTodoTitle.mip" is invalid, can not update state. Does the path "newTodoTitle" exist?

### Wrong state value
Cerebral - The Signal "newTodoTitleChanged" with action "operator.set(state`newTodoTitle`, props`title.foo`)" has an error: You are passing a non serializable value into the state tree on path "newTodoTitle"