### PR TITLE
Fix typo in variable name.

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -71,7 +71,7 @@ import {connect} from 'cerebral/react'
 import {state} from 'cerebral/tags'
 
 export default connect({
-  array: state`app.array.*`,
+  list: state`app.array.*`,
   map: state`app.map.*`,
 },
   function App (props) {


### PR DESCRIPTION
I chose list to show that you can name props however you want.