### PR TITLE
test(forms): add more tests for code coverage and some changes

### DIFF
--- a/packages/cerebral-provider-forms/src/field.test.js
+++ b/packages/cerebral-provider-forms/src/field.test.js
@@ -21,7 +21,6 @@ describe('field', () => {
     assert.equal(nameField.isValid, false)
     assert.equal(nameField.hasValue, false)
   })
-
   it('should  be a valid field', () => {
     let compute = {
       state: {
@@ -37,5 +36,22 @@ describe('field', () => {
     assert.equal(nameField.isValid, true)
     assert.equal(nameField.value, 'Some name')
     assert.ok(nameField instanceof Field)
+  })
+  it('should warn when field value did not resolve to an object', () => {
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      assert.equal(args[0], 'Cerebral Forms - Field value: state`form.name` did not resolve to an object')
+      originWarn.apply(this, args)
+      console.warn = originWarn
+    }
+    let compute = {
+      state: {
+        form: {
+          name: 'Some name'
+        }
+      }
+    }
+    const nameField = runCompute(field(state`form.name`), compute)
+    assert.deepEqual(nameField, {})
   })
 })

--- a/packages/cerebral-provider-forms/src/form.js
+++ b/packages/cerebral-provider-forms/src/form.js
@@ -88,7 +88,7 @@ export default function computedForm (formValueTag) {
     formValueTag,
     (formValue) => {
       if (!formValue || typeof formValue !== 'object') {
-        console.warn('Cerebral Forms - Form value did not resolve to an object')
+        console.warn(`Cerebral Forms - Form value: ${formValueTag} did not resolve to an object`)
         return {}
       }
       return new Form(formValue)

--- a/packages/cerebral-provider-forms/src/form.test.js
+++ b/packages/cerebral-provider-forms/src/form.test.js
@@ -1,37 +1,43 @@
 /* eslint-env mocha */
-import {Controller} from 'cerebral'
-import FormsProvider from '.'
 import assert from 'assert'
-import {Form, Field} from './form'
+import {runCompute} from 'cerebral/test'
+import {state} from 'cerebral/tags'
+import computedForm, {Form, Field} from './form'
 
 describe('form', () => {
   it('should create fields with default state', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           name: {
             value: 'Ben'
           }
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            assert.ok(form instanceof Form)
-            assert.ok(form.name instanceof Field)
-            assert.equal(form.name.value, 'Ben')
-            assert.equal(form.name.isValid, true)
-          }
-        ]
       }
-    })
-    controller.getSignal('test')()
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.ok(form instanceof Form)
+    assert.ok(form.name instanceof Field)
+    assert.equal(form.name.value, 'Ben')
+    assert.equal(form.name.isValid, true)
+  })
+  it('should warn when form value did not resolve to an object', () => {
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      assert.equal(args[0], 'Cerebral Forms - Form value: state`form` did not resolve to an object')
+      originWarn.apply(this, args)
+      console.warn = originWarn
+    }
+    let compute = {
+      state: {
+        form: 'Ben'
+      }
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.deepEqual(form, {})
   })
   it('should validate initial form state', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           name: {
@@ -40,30 +46,22 @@ describe('form', () => {
             validationRules: ['minLength:4']
           }
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            assert.ok(form instanceof Form)
-            assert.ok(form.name instanceof Field)
-            assert.equal(form.name.value, 'Ben')
-            assert.equal(form.name.isValid, false)
-            assert.deepEqual(form.name.validationRules, ['minLength:4'])
-            assert.equal(form.name.requiredMessage, null)
-            assert.equal(form.name.hasValue, true)
-            assert.equal(form.name.isPristine, true)
-            assert.equal(form.name.failedRule.name, 'minLength')
-            assert.equal(form.name.failedRule.arg, 4)
-          }
-        ]
       }
-    })
-    controller.getSignal('test')()
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.ok(form instanceof Form)
+    assert.ok(form.name instanceof Field)
+    assert.equal(form.name.value, 'Ben')
+    assert.equal(form.name.isValid, false)
+    assert.deepEqual(form.name.validationRules, ['minLength:4'])
+    assert.equal(form.name.requiredMessage, null)
+    assert.equal(form.name.hasValue, true)
+    assert.equal(form.name.isPristine, true)
+    assert.equal(form.name.failedRule.name, 'minLength')
+    assert.equal(form.name.failedRule.arg, 4)
   })
   it('should allow nested fields', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           address: {
@@ -75,25 +73,17 @@ describe('form', () => {
             }
           }
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            assert.ok(form.address.street instanceof Field)
-            assert.ok(form.address.zipCode instanceof Field)
-            assert.equal(form.isValid, true)
-            assert.equal(form.address.street.isValid, true)
-            assert.equal(form.address.zipCode.isValid, true)
-          }
-        ]
       }
-    })
-    controller.getSignal('test')()
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.ok(form.address.street instanceof Field)
+    assert.ok(form.address.zipCode instanceof Field)
+    assert.equal(form.isValid, true)
+    assert.equal(form.address.street.isValid, true)
+    assert.equal(form.address.zipCode.isValid, true)
   })
   it('should allow list of fields', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           users: [{
@@ -102,25 +92,17 @@ describe('form', () => {
             value: ''
           }]
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            assert.ok(form.users[0] instanceof Field)
-            assert.ok(form.users[1] instanceof Field)
-            assert.equal(form.isValid, true)
-            assert.equal(form.users[0].isValid, true)
-            assert.equal(form.users[1].isValid, true)
-          }
-        ]
       }
-    })
-    controller.getSignal('test')()
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.ok(form.users[0] instanceof Field)
+    assert.ok(form.users[1] instanceof Field)
+    assert.equal(form.isValid, true)
+    assert.equal(form.users[0].isValid, true)
+    assert.equal(form.users[1].isValid, true)
   })
   it('should convert to json', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           users: [{
@@ -129,23 +111,15 @@ describe('form', () => {
             value: 'Dopey'
           }]
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            assert.deepEqual(form.toJSON(), {
-              users: ['Ben', 'Dopey']
-            })
-          }
-        ]
       }
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.deepEqual(form.toJSON(), {
+      users: ['Ben', 'Dopey']
     })
-    controller.getSignal('test')()
   })
   it('should get invalid fields', () => {
-    const controller = Controller({
-      providers: [FormsProvider()],
+    let compute = {
       state: {
         form: {
           users: [{
@@ -155,50 +129,51 @@ describe('form', () => {
             value: 'Dopey'
           }]
         }
-      },
-      signals: {
-        test: [
-          ({forms}) => {
-            const form = forms.get('form')
-            const invalidFields = form.getInvalidFields()
-
-            assert.equal(Object.keys(invalidFields)[0], 'users.0')
-            assert.equal(invalidFields['users.0'].value, 'Ben')
-          }
-        ]
       }
-    })
-    controller.getSignal('test')()
-    it('should work with global props', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
-        state: {
-          form: {
-            name: {
-              value: 'Ben'
-            },
-            showErrors: false,
-            validationError: null
-          }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.ok(form instanceof Form)
-              assert.equal(form.showErrors, false)
-              assert.equal(form.validationError, null)
-            }
-          ]
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    const invalidFields = form.getInvalidFields()
+    assert.equal(Object.keys(invalidFields)[0], 'users.0')
+    assert.equal(invalidFields['users.0'].value, 'Ben')
+  })
+  it('should work with global props', () => {
+    let compute = {
+      state: {
+        form: {
+          name: {
+            value: 'Ben'
+          },
+          showErrors: false,
+          validationError: null
         }
-      })
-      controller.getSignal('test')()
-    })
+      }
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    assert.ok(form instanceof Form)
+    assert.equal(form.showErrors, false)
+    assert.equal(form.validationError, null)
+  })
+  it('should return all fields', () => {
+    let compute = {
+      state: {
+        form: {
+          someField: {
+            value: 'some field value'
+          },
+          otherField: {
+            value: 'some other field'
+          }
+        }
+      }
+    }
+    const form = runCompute(computedForm(state`form`), compute)
+    const fields = form.getFields()
+    assert.equal(fields.someField.value, 'some field value')
+    assert.equal(Object.keys(fields).length, 2)
   })
   describe('validate', () => {
     it('should validate using validationRules', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             name: {
@@ -206,21 +181,13 @@ describe('form', () => {
               validationRules: ['isNumeric']
             }
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, false)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, false)
     })
     it('should validate with multiple rules', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             name: {
@@ -228,23 +195,15 @@ describe('form', () => {
               validationRules: ['minLength:2', 'isNumeric']
             }
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, false)
-              assert.equal(form.name.failedRule.name, 'isNumeric')
-              assert.equal(form.name.failedRule.arg, undefined)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, false)
+      assert.equal(form.name.failedRule.name, 'isNumeric')
+      assert.equal(form.name.failedRule.arg, undefined)
     })
     it('should validate required value', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             name: {
@@ -252,21 +211,13 @@ describe('form', () => {
               isRequired: true
             }
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, false)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, false)
     })
     it('should validate required value using custom isValue rule', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             someField: {
@@ -275,21 +226,13 @@ describe('form', () => {
               isValueRules: ['minLength:1']
             }
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, false)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, false)
     })
     it('should validate using regexp', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             someField: {
@@ -297,47 +240,13 @@ describe('form', () => {
               isValueRules: [/foo/]
             }
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, true)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
-    })
-    it('should return all fields', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
-        state: {
-          form: {
-            someField: {
-              value: 'some field value'
-            },
-            otherField: {
-              value: 'some other field'
-            }
-          }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              let fields = form.getFields()
-              assert.equal(fields.someField.value, 'some field value')
-              assert.equal(Object.keys(fields).length, 2)
-            }
-          ]
-        }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, true)
     })
     it('should validate with global props', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
+      let compute = {
         state: {
           form: {
             name: {
@@ -347,41 +256,10 @@ describe('form', () => {
             showErrors: false,
             validationError: null
           }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, true)
-            }
-          ]
         }
-      })
-      controller.getSignal('test')()
-    })
-    it('should not validate with global props', () => {
-      const controller = Controller({
-        providers: [FormsProvider()],
-        state: {
-          form: {
-            name: {
-              value: 'Ben',
-              validationRules: ['isNumeric']
-            },
-            showErrors: false,
-            validationError: null
-          }
-        },
-        signals: {
-          test: [
-            ({forms}) => {
-              const form = forms.get('form')
-              assert.equal(form.isValid, false)
-            }
-          ]
-        }
-      })
-      controller.getSignal('test')()
+      }
+      const form = runCompute(computedForm(state`form`), compute)
+      assert.equal(form.isValid, true)
     })
   })
 })

--- a/packages/cerebral-provider-forms/src/index.test.js
+++ b/packages/cerebral-provider-forms/src/index.test.js
@@ -185,4 +185,36 @@ describe('provider', () => {
     })
     controller.getSignal('test')()
   })
+  it('should be able to work with DebuggerProvider', () => {
+    const DebuggerProviderFactory = () => {
+      function DebuggerProvider (context, functionDetails, payload, prevPayload) {
+        context.debugger = {
+          wrapProvider (providerKey) {
+            assert.equal(providerKey, 'forms')
+          }
+        }
+        return context
+      }
+      return DebuggerProvider
+    }
+    const controller = Controller({
+      providers: [DebuggerProviderFactory(), FormsProvider()],
+      state: {
+        form: {
+          name: {
+            value: 'Ben'
+          }
+        }
+      },
+      signals: {
+        test: [
+          ({forms}) => {
+            const form = forms.get('form')
+            assert.equal(form.name.value, 'Ben')
+          }
+        ]
+      }
+    })
+    controller.getSignal('test')()
+  })
 })

--- a/packages/cerebral-provider-forms/src/operators/resetForm.js
+++ b/packages/cerebral-provider-forms/src/operators/resetForm.js
@@ -3,7 +3,7 @@ import resetFormHelper from '../helpers/resetForm'
 function resetFormFactory (formPath) {
   function resetForm ({state, resolve}) {
     if (!resolve.isTag(formPath, 'state')) {
-      throw new Error('Cerebral Forms - resetForm factory requires a STATE TAG')
+      throw new Error('Cerebral-Provider-Forms operator.resetForm: You have to use the STATE TAG as an argument')
     }
 
     const path = resolve.path(formPath)

--- a/packages/cerebral-provider-forms/src/operators/resetForm.js
+++ b/packages/cerebral-provider-forms/src/operators/resetForm.js
@@ -3,7 +3,7 @@ import resetFormHelper from '../helpers/resetForm'
 function resetFormFactory (formPath) {
   function resetForm ({state, resolve}) {
     if (!resolve.isTag(formPath, 'state')) {
-      throw new Error('Cerebral-Provider-Forms operator.resetForm: You have to use the STATE TAG as an argument')
+      throw new Error('Cerebral Forms - operator.resetForm: You have to use the STATE TAG as an argument')
     }
 
     const path = resolve.path(formPath)

--- a/packages/cerebral-provider-forms/src/operators/resetForm.test.js
+++ b/packages/cerebral-provider-forms/src/operators/resetForm.test.js
@@ -107,7 +107,7 @@ describe('resetForm', () => {
               ({props}) => {
                 errorCount++
                 assert.equal(props.error.name, 'Error')
-                assert.equal(props.error.message, 'Cerebral-Provider-Forms operator.resetForm: You have to use the STATE TAG as an argument')
+                assert.equal(props.error.message, 'Cerebral Forms - operator.resetForm: You have to use the STATE TAG as an argument')
               }
             ]]
           ])

--- a/packages/cerebral-provider-forms/src/operators/resetForm.test.js
+++ b/packages/cerebral-provider-forms/src/operators/resetForm.test.js
@@ -30,7 +30,7 @@ describe('resetForm', () => {
     })
     controller.getSignal('test')()
   })
-  it('Should reset nested Form', () => {
+  it('should reset nested Form', () => {
     const controller = Controller({
       providers: [FormsProvider()],
       signals: {
@@ -58,7 +58,7 @@ describe('resetForm', () => {
     })
     controller.getSignal('test')()
   })
-  it('Should reset nested form arrays', () => {
+  it('should reset nested form arrays', () => {
     const controller = Controller({
       providers: [FormsProvider()],
       signals: {
@@ -92,5 +92,36 @@ describe('resetForm', () => {
       }
     })
     controller.getSignal('test')()
+  })
+  it('should throw when form path is not a state tag', () => {
+    let errorCount = 0
+    const controller = Controller({
+      providers: [FormsProvider()],
+      signals: {
+        test: {
+          signal: [
+            resetForm('form')
+          ],
+          catch: new Map([
+            [Error, [
+              ({props}) => {
+                errorCount++
+                assert.equal(props.error.name, 'Error')
+                assert.equal(props.error.message, 'Cerebral-Provider-Forms operator.resetForm: You have to use the STATE TAG as an argument')
+              }
+            ]]
+          ])
+        }
+      },
+      state: {
+        form: {
+          name: {
+            value: 'Ben'
+          }
+        }
+      }
+    })
+    controller.getSignal('test')()
+    assert.equal(errorCount, 1)
   })
 })

--- a/packages/cerebral-provider-forms/src/operators/setField.js
+++ b/packages/cerebral-provider-forms/src/operators/setField.js
@@ -1,7 +1,7 @@
 function setFieldFactory (fieldPath, fieldValue) {
   function setField ({state, resolve}) {
     if (!resolve.isTag(fieldPath, 'state')) {
-      throw new Error('cerebral-provider-forms operator.setField: You have to use the STATE TAG as first argument')
+      throw new Error('Cerebral-Provider-Forms operator.setField: You have to use the STATE TAG as first argument')
     }
 
     state.merge(resolve.path(fieldPath), {

--- a/packages/cerebral-provider-forms/src/operators/setField.js
+++ b/packages/cerebral-provider-forms/src/operators/setField.js
@@ -1,7 +1,7 @@
 function setFieldFactory (fieldPath, fieldValue) {
   function setField ({state, resolve}) {
     if (!resolve.isTag(fieldPath, 'state')) {
-      throw new Error('Cerebral-Provider-Forms operator.setField: You have to use the STATE TAG as first argument')
+      throw new Error('Cerebral Forms - operator.setField: You have to use the STATE TAG as first argument')
     }
 
     state.merge(resolve.path(fieldPath), {

--- a/packages/cerebral-provider-forms/src/operators/setField.test.js
+++ b/packages/cerebral-provider-forms/src/operators/setField.test.js
@@ -43,7 +43,7 @@ describe('setField', () => {
               ({props}) => {
                 errorCount++
                 assert.equal(props.error.name, 'Error')
-                assert.equal(props.error.message, 'Cerebral-Provider-Forms operator.setField: You have to use the STATE TAG as first argument')
+                assert.equal(props.error.message, 'Cerebral Forms - operator.setField: You have to use the STATE TAG as first argument')
               }
             ]]
           ])

--- a/packages/cerebral-provider-forms/src/operators/setField.test.js
+++ b/packages/cerebral-provider-forms/src/operators/setField.test.js
@@ -29,4 +29,35 @@ describe('setField', () => {
     })
     controller.getSignal('test')()
   })
+  it('should throw when field path is not a state tag', () => {
+    let errorCount = 0
+    const controller = Controller({
+      providers: [FormsProvider()],
+      signals: {
+        test: {
+          signal: [
+            setField('form.name', 'foo')
+          ],
+          catch: new Map([
+            [Error, [
+              ({props}) => {
+                errorCount++
+                assert.equal(props.error.name, 'Error')
+                assert.equal(props.error.message, 'Cerebral-Provider-Forms operator.setField: You have to use the STATE TAG as first argument')
+              }
+            ]]
+          ])
+        }
+      },
+      state: {
+        form: {
+          name: {
+            value: 'Ben'
+          }
+        }
+      }
+    })
+    controller.getSignal('test')()
+    assert.equal(errorCount, 1)
+  })
 })

--- a/packages/cerebral-provider-forms/src/utils/runValidation.js
+++ b/packages/cerebral-provider-forms/src/utils/runValidation.js
@@ -4,7 +4,7 @@ import validate from './validate'
 export default function runValidation (field, form) {
   const isValueRules = field.isValueRules || ['isValue']
   const hasValue = checkHasValue(form, field.value, isValueRules)
-  const result = validate(form, field.value, field.validationRules || [])
+  const result = validate(form, field.value, field.validationRules)
   const isValid = result.isValid && (
     (field.isRequired && hasValue) ||
     !field.isRequired

--- a/packages/cerebral-provider-forms/src/utils/validate.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.js
@@ -1,13 +1,9 @@
 import rules from '../rules.js'
 
-export default function validate (form, value, validationRules) {
+export default function validate (form, value, validationRules = []) {
   const initialValidation = {
     isValid: true,
     failedRule: null
-  }
-
-  if (!validationRules) {
-    return initialValidation
   }
 
   return validationRules.reduce((result, validationRule, index) => {
@@ -36,9 +32,9 @@ export default function validate (form, value, validationRules) {
 
     const isValid = rule(value, form, arg)
 
-    return {
+    return isValid ? initialValidation : {
       isValid,
-      failedRule: isValid ? null : {
+      failedRule: {
         name: ruleKey,
         arg
       },

--- a/packages/cerebral-provider-forms/src/utils/validate.test.js
+++ b/packages/cerebral-provider-forms/src/utils/validate.test.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+import validate from './validate'
+import assert from 'assert'
+
+describe('validate', () => {
+  it('should return initialValidation when there is no validationRules', () => {
+    const result = validate(null, 'Ben')
+    assert.deepEqual(result, {
+      isValid: true,
+      failedRule: null
+    })
+  })
+  it('should validate using validationRules', () => {
+    const result = validate(null, 'Ben', ['isNumeric'])
+    assert.equal(result.isValid, false)
+    assert.equal(result.failedRule.name, 'isNumeric')
+  })
+  it('should validate with multiple rules', () => {
+    const result = validate(null, 'Ben', ['isNumeric', 'minLength:2'])
+    assert.equal(result.isValid, false)
+    assert.equal(result.failedRule.name, 'isNumeric')
+  })
+  it('should return initialValidation when there is no failed rules', () => {
+    const result = validate(null, 'Ben', ['isValue', 'minLength:2'])
+    assert.deepEqual(result, {
+      isValid: true,
+      failedRule: null
+    })
+  })
+  it('should validate when validationRule arg is not JSON parsable', () => {
+    const result = validate(null, 'Ben', ['equals:Ben'])
+    assert.deepEqual(result, {
+      isValid: true,
+      failedRule: null
+    })
+  })
+})


### PR DESCRIPTION
Hi @christianalfoni ,
- use runCompute instead of controller in form.test.js
- catch errors using new cerebral error handling 
- fix field error message, if the field is valid. It should return initialValidation without any error message.

By the way why initialValidation has failedRule key?