### PR TITLE
test(cerebral): Failing test for setting paths with an array index

### DIFF
--- a/packages/cerebral/src/providers/State.test.js
+++ b/packages/cerebral/src/providers/State.test.js
@@ -26,6 +26,16 @@ describe('State', () => {
     controller.getSignal('foo')()
     assert.deepEqual(controller.getState(), {foo: 'bar2'})
   })
+  it('should be able to SET state with an array in the path', () => {
+    const controller = new Controller({
+      state: {foo: ['bar']},
+      signals: {
+        foo: [({state}) => state.set('foo.0', 'baz')]
+      }
+    })
+    controller.getSignal('foo')()
+    assert.deepEqual(controller.getState(), {foo: ['baz']})
+  })
   it('should be able to PUSH state', () => {
     const controller = new Controller({
       state: {


### PR DESCRIPTION
Seems to pass when the array is not at the end.