### PR TITLE
test(function-tree): add more tests and some fixes

### DIFF
--- a/packages/function-tree/package.json
+++ b/packages/function-tree/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha --compilers js:babel-register 'src/**/*.test.js'",
+    "test:watch": "npm run test -- --watch",
     "build": "cross-env BABEL_ENV=production babel src/ --out-dir=lib/ -s",
     "coverage": "nyc --reporter=lcov --reporter=json npm run test",
     "prepublish": "npm run build"

--- a/packages/function-tree/src/FunctionTree.js
+++ b/packages/function-tree/src/FunctionTree.js
@@ -35,7 +35,7 @@ function isValidResult (result) {
   Create an error with execution details
 */
 function createErrorObject (error, execution, functionDetails, payload) {
-  const errorToReturn = error || new Error()
+  const errorToReturn = error
 
   errorToReturn.execution = execution
   errorToReturn.functionDetails = functionDetails
@@ -106,7 +106,7 @@ class FunctionTreeExecution {
         .then(function (result) {
           if (result instanceof Path) {
             functionTree.emit('functionEnd', execution, funcDetails, payload, result)
-            next(result.toJS())
+            next(result.toJSON())
           } else if (funcDetails.outputs) {
             functionTree.emit('functionEnd', execution, funcDetails, payload, result)
             throw new FunctionTreeExecutionError(execution, funcDetails, payload, new Error('The result ' + JSON.stringify(result) + ' from function ' + funcDetails.name + ' needs to be a path of either ' + Object.keys(funcDetails.outputs)))
@@ -126,7 +126,7 @@ class FunctionTreeExecution {
             errorCallback(createErrorObject(result, execution, funcDetails, payload), execution, funcDetails, payload)
           } else if (result instanceof Path) {
             functionTree.emit('functionEnd', execution, funcDetails, payload, result)
-            next(result.toJS())
+            next(result.toJSON())
           } else if (funcDetails.outputs) {
             let error = new FunctionTreeExecutionError(execution, funcDetails, payload, new Error('The result ' + JSON.stringify(result) + ' from function ' + funcDetails.name + ' needs to be a path of either ' + Object.keys(funcDetails.outputs)))
 
@@ -146,7 +146,7 @@ class FunctionTreeExecution {
         })
     } else if (result instanceof Path) {
       functionTree.emit('functionEnd', execution, funcDetails, payload, result)
-      next(result.toJS())
+      next(result.toJSON())
     } else if (funcDetails.outputs) {
       let error = new FunctionTreeExecutionError(execution, funcDetails, payload, new Error('The result ' + JSON.stringify(result) + ' from function ' + funcDetails.name + ' needs to be a path of either ' + Object.keys(funcDetails.outputs)))
 
@@ -174,7 +174,7 @@ class FunctionTreeExecution {
       PropsProvider(),
       PathProvider()
     ].concat(this.functionTree.contextProviders).reduce(function (currentContext, contextProvider) {
-      var newContext = (
+      const newContext = (
         typeof contextProvider === 'function'
           ? contextProvider(currentContext, funcDetails, payload, prevPayload)
           : ContextProvider(contextProvider)(currentContext, funcDetails, payload, prevPayload)

--- a/packages/function-tree/src/Path.js
+++ b/packages/function-tree/src/Path.js
@@ -3,7 +3,7 @@ class Path {
     this.path = path
     this.payload = payload
   }
-  toJS () {
+  toJSON () {
     return {
       path: this.path,
       payload: this.payload

--- a/packages/function-tree/src/Path.test.js
+++ b/packages/function-tree/src/Path.test.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+import Path from './Path'
+import assert from 'assert'
+
+describe('primitives', () => {
+  it('should initiate correctly', () => {
+    const payload = {
+      foo: 'bar'
+    }
+    const path = new Path('path', payload)
+
+    assert.ok(path instanceof Path)
+    assert.equal(path.path, 'path')
+    assert.deepEqual(path.payload, payload)
+    assert.equal(path.toJSON().path, 'path')
+    assert.deepEqual(path.toJSON().payload, payload)
+  })
+})

--- a/packages/function-tree/src/errors.js
+++ b/packages/function-tree/src/errors.js
@@ -1,6 +1,6 @@
 export class FunctionTreeError extends Error {
   constructor (error) {
-    super(error.message)
+    super(error.message || error)
     this.name = 'FunctionTreeError'
   }
   toJSON () {

--- a/packages/function-tree/src/primitives.test.js
+++ b/packages/function-tree/src/primitives.test.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+import {Primitive, Sequence, Parallel} from './primitives'
+import assert from 'assert'
+
+describe('primitives', () => {
+  it('should correctly initiate primitive', () => {
+    const items = [
+      function a () {}
+    ]
+    const primitive = new Primitive('primitive', 'test', items)
+
+    assert.ok(primitive instanceof Primitive)
+    assert.equal(primitive.type, 'primitive')
+    assert.equal(primitive.name, 'test')
+    assert.deepEqual(primitive.items, items)
+    assert.equal(primitive.toJSON().name, 'test')
+    assert.equal(primitive.toJSON()._functionTreePrimitive, true)
+    assert.equal(primitive.toJSON().type, 'primitive')
+    assert.deepEqual(primitive.toJSON().items, items)
+  })
+  it('should throw when items is not array', () => {
+    const items = function a () {}
+    assert.throws(() => {
+      new Primitive('primitive', items) // eslint-disable-line no-new
+    }, (err) => {
+      if ((err instanceof Error) && err.name === 'FunctionTreeError' && err.toJSON) {
+        return err.toJSON().message === 'You have not passed an array of functions to primitive'
+      }
+    })
+  })
+  describe('sequence', () => {
+    it('should have extended Primitive', () => {
+      const items = [
+        function a () {}
+      ]
+      const sequence = new Sequence(items)
+
+      assert.ok(sequence instanceof Primitive)
+      assert.equal(sequence.type, 'sequence')
+      assert.equal(sequence.name, null)
+      assert.deepEqual(sequence.items, items)
+      assert.equal(sequence.toJSON().name, null)
+      assert.equal(sequence.toJSON()._functionTreePrimitive, true)
+      assert.equal(sequence.toJSON().type, 'sequence')
+      assert.deepEqual(sequence.toJSON().items, items)
+    })
+    it('should set name of sequence', () => {
+      const items = [
+        function a () {}
+      ]
+      const sequence = new Sequence('test', items)
+
+      assert.ok(sequence instanceof Primitive)
+      assert.equal(sequence.type, 'sequence')
+      assert.equal(sequence.name, 'test')
+      assert.deepEqual(sequence.items, items)
+      assert.equal(sequence.toJSON().name, 'test')
+      assert.equal(sequence.toJSON()._functionTreePrimitive, true)
+      assert.equal(sequence.toJSON().type, 'sequence')
+      assert.deepEqual(sequence.toJSON().items, items)
+    })
+  })
+  describe('parallel', () => {
+    it('should have extended Primitive', () => {
+      const items = [
+        function a () {}
+      ]
+      const parallel = new Parallel(items)
+
+      assert.ok(parallel instanceof Primitive)
+      assert.equal(parallel.type, 'parallel')
+      assert.equal(parallel.name, null)
+      assert.deepEqual(parallel.items, items)
+      assert.equal(parallel.toJSON().name, null)
+      assert.equal(parallel.toJSON()._functionTreePrimitive, true)
+      assert.equal(parallel.toJSON().type, 'parallel')
+      assert.deepEqual(parallel.toJSON().items, items)
+    })
+    it('should set name of parallel', () => {
+      const items = [
+        function a () {}
+      ]
+      const parallel = new Parallel('test', items)
+
+      assert.ok(parallel instanceof Primitive)
+      assert.equal(parallel.type, 'parallel')
+      assert.equal(parallel.name, 'test')
+      assert.deepEqual(parallel.items, items)
+      assert.equal(parallel.toJSON().name, 'test')
+      assert.equal(parallel.toJSON()._functionTreePrimitive, true)
+      assert.equal(parallel.toJSON().type, 'parallel')
+      assert.deepEqual(parallel.toJSON().items, items)
+    })
+  })
+})

--- a/packages/function-tree/src/providers/Context.js
+++ b/packages/function-tree/src/providers/Context.js
@@ -25,7 +25,7 @@ export default function ContextProvider (extendedContext) {
         /*
           Wraps methods and sends their payload through the debugger
         */
-        const proxy = (sourceKeys, source, target) => {
+        const proxy = (sourceKeys, target) => {
           return sourceKeys.reduce(function (obj, objKey) {
             if (typeof contextValue[objKey] === 'function') {
               obj[objKey] = (...args) => {
@@ -67,9 +67,9 @@ export default function ContextProvider (extendedContext) {
         }
 
         // Go through keys original value and wrap any attached methods
-        context[key] = proxy(Object.keys(contextValue), contextValue, context[key])// Object.keys(contextValue).reduce(proxy, context[key])
+        context[key] = proxy(Object.keys(contextValue), context[key])// Object.keys(contextValue).reduce(proxy, context[key])
         // Go through proto
-        context[key] = proto ? proxy(Object.getOwnPropertyNames(proto), proto, context[key]) : context[key]
+        context[key] = proto ? proxy(Object.getOwnPropertyNames(proto), context[key]) : context[key]
       } else {
         context[key] = extendedContext[key]
       }

--- a/packages/function-tree/src/providers/Context.test.js
+++ b/packages/function-tree/src/providers/Context.test.js
@@ -17,4 +17,93 @@ describe('ContextProvider', () => {
       }
     ])
   })
+  it('should run with DebuggerProvider', () => {
+    const DebuggerProvider = () => {
+      function provider (context, functionDetails, payload) {
+        context.debugger = {
+          send (data) {
+            assert.ok(data)
+          }
+        }
+
+        return context
+      }
+
+      return provider
+    }
+    const ft = new FunctionTree([
+      DebuggerProvider(),
+      ContextProvider({
+        foo: 'bar'
+      })
+    ])
+
+    ft.run([
+      ({foo}) => {
+        assert.equal(foo, 'bar')
+        assert.equal(foo.length, 3)
+      }
+    ])
+  })
+  it('should run with DebuggerProvider when passed value is function', () => {
+    const DebuggerProvider = () => {
+      function provider (context, functionDetails, payload) {
+        context.debugger = {
+          send (data) {
+            assert.ok(data)
+          }
+        }
+
+        return context
+      }
+
+      return provider
+    }
+    const ft = new FunctionTree([
+      DebuggerProvider(),
+      ContextProvider({
+        foo: (baz) => { return 'bar' + baz }
+      })
+    ])
+
+    ft.run([
+      ({foo}) => {
+        assert.equal(foo('baz'), 'barbaz')
+      }
+    ])
+  })
+  it('should run with DebuggerProvider when passed value is function instance', () => {
+    const Test = function (foo) {
+      this.foo = foo
+      this.getFoo = function () { return this.foo }
+      this.setFoo = function (value) { this.foo = value }
+    }
+    const DebuggerProvider = () => {
+      function provider (context, functionDetails, payload) {
+        context.debugger = {
+          send (data) {
+            assert.ok(data)
+          }
+        }
+
+        return context
+      }
+
+      return provider
+    }
+    const ft = new FunctionTree([
+      DebuggerProvider(),
+      ContextProvider({
+        test: new Test('foo')
+      })
+    ])
+
+    ft.run([
+      ({test}) => {
+        assert.equal(test.foo, 'foo')
+        test.setFoo('bar')
+        assert.equal(test.getFoo(), 'bar')
+      }
+    ])
+  })
 })

--- a/packages/function-tree/src/providers/StopExecution.test.js
+++ b/packages/function-tree/src/providers/StopExecution.test.js
@@ -4,7 +4,7 @@ import StopExecution from './StopExecution'
 import assert from 'assert'
 
 describe('StopExecutionProvider', () => {
-  it('should throw error when conditions are not met', (done) => {
+  it('should throw error when conditions return true', (done) => {
     const ft = new FunctionTree([
       StopExecution({
         test (context) { return context.props.doStop }
@@ -22,5 +22,39 @@ describe('StopExecutionProvider', () => {
         assert.ok(error instanceof FunctionTreeExecutionError)
         done()
       })
+  })
+  it('should continue when conditions return false', (done) => {
+    const ft = new FunctionTree([
+      StopExecution({
+        test (context) { return context.props.doStop }
+      })
+    ])
+
+    ft.run('test', {
+      doStop: false
+    }, [
+      ({props}) => {
+        assert.deepEqual(props, {
+          doStop: false
+        })
+        done()
+      }
+    ])
+  })
+  it('should continue when using without conditions', (done) => {
+    const ft = new FunctionTree([
+      StopExecution()
+    ])
+
+    ft.run('test', {
+      doStop: false
+    }, [
+      ({props}) => {
+        assert.deepEqual(props, {
+          doStop: false
+        })
+        done()
+      }
+    ])
   })
 })

--- a/packages/function-tree/src/staticTree.test.js
+++ b/packages/function-tree/src/staticTree.test.js
@@ -28,6 +28,25 @@ describe('StaticTree', () => {
     assert.equal(tree.items[0].functionIndex, 0)
     assert.ok(tree.items[0].function)
   })
+  it('should throw when unexpected entry in tree', () => {
+    assert.throws(() => {
+      staticTree([
+        function a () {},
+        1
+      ])
+    }, (err) => {
+      if ((err instanceof Error) && err.name === 'FunctionTreeError' && err.toJSON) {
+        return err.toJSON().message === 'Unexpected entry in tree'
+      }
+    })
+    assert.throws(() => {
+      staticTree(1)
+    }, (err) => {
+      if ((err instanceof Error) && err.name === 'FunctionTreeError' && err.toJSON) {
+        return err.toJSON().message === 'Unexpected entry in tree'
+      }
+    })
+  })
   it('should handle paths', () => {
     const tree = staticTree([
       function a () {}, {


### PR DESCRIPTION
Hi,
again more tests :)

- fix errors. Error classes should be able to work with string or error instance.
- add primitives and path test file
- change Path.toJS method to Path.toJSON (like other classes)
- fix some typo mistakes