### PR TITLE
Refactor devtools

### DIFF
--- a/packages/cerebral/package.json
+++ b/packages/cerebral/package.json
@@ -35,5 +35,8 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
+  },
+  "devDependencies": {
+    "mock-socket": "^6.0.4"
   }
 }

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -160,10 +160,11 @@ export class Devtools extends DevtoolsBase {
 
     this.isResettingDebugger = true
     this.sendMessage(message)
-    this.sendBulkMessage(this.backlog, 'c')
+    if (this.backlog.length) {
+      this.sendBulkMessage(this.backlog, 'c')
+      this.backlog = []
+    }
     this.isResettingDebugger = false
-
-    this.backlog = []
 
     this.isConnected = true
 

--- a/packages/cerebral/src/devtools/index.js
+++ b/packages/cerebral/src/devtools/index.js
@@ -1,6 +1,6 @@
 /* global WebSocket File FileList Blob ImageData */
-import {delay, throwError} from '../utils'
-import Path from 'function-tree/lib/Path'
+import {delay} from '../utils'
+import DevtoolsBase from 'function-tree/lib/devtools/base'
 const PLACEHOLDER_INITIAL_MODEL = 'PLACEHOLDER_INITIAL_MODEL'
 const PLACEHOLDER_DEBUGGING_DATA = '$$DEBUGGING_DATA$$'
 
@@ -9,37 +9,34 @@ const PLACEHOLDER_DEBUGGING_DATA = '$$DEBUGGING_DATA$$'
   - Triggers events with information from function tree execution
   - Stores data related to time travel, if activated
 */
-class Devtools {
-  constructor (options = {
-    storeMutations: true,
-    preventExternalMutations: true,
-    preventPropsReplacement: false,
-    bigComponentsWarning: 10,
-    remoteDebugger: null,
-    allowedTypes: [],
-    doReconnect: true
-  }) {
+export class Devtools extends DevtoolsBase {
+  constructor ({
+    storeMutations = true,
+    preventExternalMutations = true,
+    preventPropsReplacement = false,
+    bigComponentsWarning = 10,
+    remoteDebugger = null,
+    reconnect = true,
+    reconnectInterval = 5000,
+    allowedTypes = []
+  } = {}) {
+    super({
+      remoteDebugger,
+      reconnect,
+      reconnectInterval
+    })
+    this.version = VERSION // eslint-disable-line
     this.debuggerComponentsMap = {}
     this.debuggerComponentDetailsId = 1
-    this.storeMutations = typeof options.storeMutations === 'undefined' ? true : options.storeMutations
-    this.preventExternalMutations = typeof options.preventExternalMutations === 'undefined' ? true : options.preventExternalMutations
-    this.doReconnect = typeof options.reconnect === 'undefined' ? true : options.reconnect
-    this.preventPropsReplacement = options.preventPropsReplacement || false
-    this.bigComponentsWarning = options.bigComponentsWarning || 10
-    this.remoteDebugger = options.remoteDebugger || null
+    this.storeMutations = storeMutations
+    this.preventExternalMutations = preventExternalMutations
+    this.preventPropsReplacement = preventPropsReplacement
+    this.bigComponentsWarning = bigComponentsWarning
 
-    if (!this.remoteDebugger) {
-      throwError('You have to pass "remoteDebugger" property')
-    }
-
-    this.backlog = []
     this.mutations = []
     this.initialModelString = null
-    this.isConnected = false
     this.controller = null
     this.originalRunTreeFunction = null
-    this.reconnectInterval = 5000
-    this.ws = null
     this.isResettingDebugger = false
     this.allowedTypes = []
       .concat(typeof File === 'undefined' ? [] : File)
@@ -47,7 +44,7 @@ class Devtools {
       .concat(typeof Blob === 'undefined' ? [] : Blob)
       .concat(typeof ImageData === 'undefined' ? [] : ImageData)
       .concat(typeof RegExp === 'undefined' ? [] : RegExp)
-      .concat(options.allowedTypes || [])
+      .concat(allowedTypes || [])
 
     this.sendInitial = this.sendInitial.bind(this)
     this.sendComponentsMap = delay(this.sendComponentsMap, 50)
@@ -92,44 +89,33 @@ class Devtools {
     this.mutations = []
     this.controller.flush(true)
   }
-  /*
-    Sets up the listeners to Chrome Extension or remote debugger
-  */
-  addListeners () {
+  createSocket () {
     this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
-    this.ws.onmessage = (event) => {
-      const message = JSON.parse(event.data)
-      switch (message.type) {
-        case 'changeModel':
-          this.controller.model.set(message.data.path, message.data.value)
-          this.controller.flush()
-          break
-        case 'remember':
-          if (!this.storeMutations) {
-            console.warn('Cerebral Devtools - You tried to time travel, but you have turned of storing of mutations')
-          }
-          this.remember(message.data)
-          break
-        case 'reset':
-          this.reset()
-          break
-        case 'pong':
-          this.sendInitial()
-          break
-        case 'ping':
-          this.sendInitial()
-          break
-      }
-    }
   }
-  reconnect () {
-    setTimeout(() => {
-      this.init(this.controller)
-      this.ws.onclose = () => {
-        this.isConnected = false
-        this.reconnect()
-      }
-    }, this.reconnectInterval)
+  onMessage (event) {
+    const message = JSON.parse(event.data)
+    switch (message.type) {
+      case 'changeModel':
+        this.controller.model.set(message.data.path, message.data.value)
+        this.controller.flush()
+        break
+      case 'remember':
+        if (!this.storeMutations) {
+          console.warn('Cerebral Devtools - You tried to time travel, but you have turned of storing of mutations')
+        } else {
+          this.remember(message.data)
+        }
+        break
+      case 'reset':
+        this.reset()
+        break
+      case 'pong':
+        this.sendInitial()
+        break
+      case 'ping':
+        this.sendInitial()
+        break
+    }
   }
   /*
     The debugger might be ready or it might not. The initial communication
@@ -144,183 +130,18 @@ class Devtools {
       - Devtools sends "init"
   */
   init (controller) {
-    this.controller = controller
-    this.originalRunTreeFunction = controller.run
+    this.controller = controller || this.controller
+    this.originalRunTreeFunction = this.controller.run
 
     if (this.storeMutations) {
-      this.initialModelString = JSON.stringify(controller.model.get())
+      this.initialModelString = JSON.stringify(this.controller.model.get())
     }
 
-    this.addListeners()
+    super.init()
 
-    this.ws.onopen = () => {
-      this.ws.send(JSON.stringify({type: 'ping'}))
+    if (controller) {
+      this.watchExecution(this.controller, 'c')
     }
-    this.ws.onerror = () => {}
-    this.ws.onclose = () => {
-      this.isConnected = false
-      if (this.doReconnect) {
-        console.warn('Could not connect to the debugger, please make sure it is running... automatically retrying in the background')
-        this.reconnect()
-      }
-    }
-
-    this.watchExecution()
-  }
-  /*
-    Sends message to chrome extension or remote debugger
-  */
-  sendMessage (stringifiedMessage) {
-    this.ws.send(stringifiedMessage)
-  }
-  /*
-    Watches function tree for execution of signals. This is passed to
-    debugger to prevent time travelling when executing. It also tracks
-    latest executed signal for "remember" to know when signals can be
-    called again
-  */
-  watchExecution () {
-    this.controller.on('start', (execution, payload) => {
-      const message = JSON.stringify({
-        type: 'executionStart',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id,
-            name: execution.name,
-            staticTree: execution.staticTree,
-            datetime: execution.datetime,
-            executedBy: (payload && payload._execution) ? payload._execution : null
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    this.controller.on('end', (execution) => {
-      const message = JSON.stringify({
-        type: 'executionEnd',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id
-          }
-        }
-      })
-      this.latestExecutionId = execution.id
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    this.controller.on('pathStart', (path, execution, funcDetails) => {
-      const message = JSON.stringify({
-        type: 'executionPathStart',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            path
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    this.controller.on('functionStart', (execution, funcDetails, payload) => {
-      const message = JSON.stringify({
-        type: 'execution',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            payload,
-            data: null
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    this.controller.on('functionEnd', (execution, funcDetails, payload, result) => {
-      if (!result || (result instanceof Path && !result.payload)) {
-        return
-      }
-
-      const message = JSON.stringify({
-        type: 'executionFunctionEnd',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            output: result instanceof Path ? result.payload : result
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    this.controller.on('error', (error, execution, funcDetails) => {
-      const message = JSON.stringify({
-        type: 'executionFunctionError',
-        source: 'c',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            error: {
-              name: error.name,
-              message: error.message,
-              stack: error.stack,
-              func: funcDetails.function.toString()
-            }
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-  }
-  /*
-    Sends multiple message in one batch to debugger, causing debugger
-    also to synchronously run all updates before rendering
-  */
-  sendBulkMessage (messages) {
-    const message = JSON.stringify({
-      type: 'bulk',
-      source: 'c',
-      version: VERSION, // eslint-disable-line
-      data: {
-        messages
-      }
-    })
-
-    this.sendMessage(message)
   }
   /*
     Send initial model. If model has already been stringified we reuse it. Any
@@ -331,7 +152,7 @@ class Devtools {
     const message = JSON.stringify({
       type: 'init',
       source: 'c',
-      version: VERSION, // eslint-disable-line
+      version: this.version,
       data: {
         initialModel: this.initialModelString ? PLACEHOLDER_INITIAL_MODEL : initialModel
       }
@@ -339,7 +160,7 @@ class Devtools {
 
     this.isResettingDebugger = true
     this.sendMessage(message)
-    this.sendBulkMessage(this.backlog)
+    this.sendBulkMessage(this.backlog, 'c')
     this.isResettingDebugger = false
 
     this.backlog = []
@@ -349,6 +170,7 @@ class Devtools {
     this.sendMessage(JSON.stringify({
       type: 'components',
       source: 'c',
+      version: this.version,
       data: {
         map: this.debuggerComponentsMap,
         render: {
@@ -391,24 +213,9 @@ class Devtools {
     return JSON.stringify({
       type: type,
       source: 'c',
-      version: VERSION, // eslint-disable-line
+      version: this.version,
       data: data
     }).replace(`"${PLACEHOLDER_DEBUGGING_DATA}"`, mutationString)
-  }
-  /*
-    Sends execution data to the debugger. Whenever a signal starts
-    it will send a message to the debugger, but any functions in the
-    function tree might also use this to send debugging data. Like when
-    mutations are done or any wrapped methods run.
-  */
-  sendExecutionData (debuggingData, context, functionDetails, payload) {
-    const message = this.createExecutionMessage(debuggingData, context, functionDetails, payload)
-
-    if (this.isConnected) {
-      this.sendMessage(message)
-    } else {
-      this.backlog.push(message)
-    }
   }
   /*
     The container will listen to "flush" events from the controller
@@ -419,7 +226,7 @@ class Devtools {
   }
   /*
     Updates the map the represents what active state paths and
-    components are in your app. Used by the debugger
+    components are in your app.Called from Controller. Used by the debugger
   */
   updateComponentsMap (component, nextDeps, prevDeps) {
     const componentDetails = {
@@ -472,6 +279,7 @@ class Devtools {
       this.sendMessage(JSON.stringify({
         type: 'components',
         source: 'c',
+        version: this.version,
         data: {
           map: this.debuggerComponentsMap,
           render: {

--- a/packages/cerebral/src/devtools/index.test.js
+++ b/packages/cerebral/src/devtools/index.test.js
@@ -51,7 +51,7 @@ describe('Devtools', () => {
     })
     assert.equal(controller.devtools.isConnected, false)
     setTimeout(() => {
-      assert.deepEqual(messages, ['ping', 'init', 'bulk', 'components'])
+      assert.deepEqual(messages, ['ping', 'init', 'components'])
       assert.equal(controller.devtools.isConnected, true)
       assert.equal(controller.devtools.reconnectInterval, 5000)
       assert.equal(controller.devtools.doReconnect, true)
@@ -137,7 +137,7 @@ describe('Devtools', () => {
     }, 400)
 
     setTimeout(() => {
-      assert.deepEqual(messages, ['ping', 'init', 'bulk', 'components'])
+      assert.deepEqual(messages, ['ping', 'init', 'components'])
       assert.equal(warnCount, 1)
       assert.equal(controller.devtools.isConnected, true)
       console.warn = originWarn
@@ -221,7 +221,7 @@ describe('Devtools', () => {
     assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
 
     setTimeout(() => {
-      assert.deepEqual(messageTypes, ['bulk', 'components'])
+      assert.deepEqual(messageTypes, ['components'])
       assert.equal(controller.devtools.isConnected, true)
 
       assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
@@ -233,10 +233,6 @@ describe('Devtools', () => {
       assert.deepEqual(messages.components.data.map.bar, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
       assert.deepEqual(messages.components.data.render, { components: [] })
 
-      assert.equal(messages.bulk.source, 'c')
-      assert.equal(messages.bulk.version, version)
-      assert.deepEqual(messages.bulk.data.messages, [])
-
       controller.getSignal('test')({
         foo: 'bar'
       })
@@ -245,7 +241,7 @@ describe('Devtools', () => {
       assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 1, id: 1 }])
       assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
 
-      assert.deepEqual(messageTypes, ['bulk', 'components', 'executionStart', 'execution', 'execution', 'executionPathStart', 'execution', 'executionFunctionEnd', 'executionEnd'])
+      assert.deepEqual(messageTypes, ['components', 'executionStart', 'execution', 'execution', 'executionPathStart', 'execution', 'executionFunctionEnd', 'executionEnd'])
       assert.ok(messages.executionStart.data.execution)
       assert.equal(messages.executionStart.source, 'c')
 
@@ -366,7 +362,7 @@ describe('Devtools', () => {
     setTimeout(() => {
       controller.getSignal('test')()
       assert.equal(errorCount, 1)
-      assert.deepEqual(messageTypes, ['bulk', 'components', 'components', 'executionStart', 'execution', 'executionFunctionError', 'executionStart', 'execution', 'executionEnd'])
+      assert.deepEqual(messageTypes, ['components', 'components', 'executionStart', 'execution', 'executionFunctionError', 'executionStart', 'execution', 'executionEnd'])
       mockServer.stop(done)
     }, 70)
   })

--- a/packages/cerebral/src/devtools/index.test.js
+++ b/packages/cerebral/src/devtools/index.test.js
@@ -1,0 +1,795 @@
+/* eslint-env mocha */
+'use strict'
+
+import assert from 'assert'
+import {state, signal} from '../tags'
+import {Container, connect} from '../viewFactories/react'
+import { WebSocket, Server } from 'mock-socket'
+import {Devtools} from './'
+import Controller from '../Controller'
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+const version = VERSION // eslint-disable-line
+import {FunctionTreeExecutionError} from 'function-tree/lib/errors'
+
+Devtools.prototype.createSocket = function () {
+  this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+}
+
+describe('Devtools', () => {
+  it('should throw when remoteDebugger is not set', () => {
+    assert.throws(() => {
+      new Devtools() // eslint-disable-line no-new
+    }, (err) => {
+      if (err instanceof Error) {
+        return err.message === 'Devtools: You have to pass in the "remoteDebugger" option'
+      }
+    })
+  })
+  it('should init correctly and work when debugger is open when app loads', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = []
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        messages.push(message.type)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+    })
+    const controller = new Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585',
+        reconnect: true
+      })
+    })
+    assert.equal(controller.devtools.isConnected, false)
+    setTimeout(() => {
+      assert.deepEqual(messages, ['ping', 'init', 'bulk', 'components'])
+      assert.equal(controller.devtools.isConnected, true)
+      assert.equal(controller.devtools.reconnectInterval, 5000)
+      assert.equal(controller.devtools.doReconnect, true)
+      assert.deepEqual(controller.devtools.debuggerComponentsMap, {})
+      assert.equal(controller.devtools.debuggerComponentDetailsId, 1)
+      assert.equal(controller.devtools.storeMutations, true)
+      assert.equal(controller.devtools.preventExternalMutations, true)
+      assert.equal(controller.devtools.preventPropsReplacement, false)
+      assert.equal(controller.devtools.bigComponentsWarning, 10)
+
+      assert.deepEqual(controller.devtools.controller, controller)
+      assert.deepEqual(controller.devtools.originalRunTreeFunction, controller.run)
+      assert.equal(controller.devtools.isResettingDebugger, false)
+      assert.equal(controller.devtools.initialModelString, JSON.stringify(controller.model.get()))
+      mockServer.stop(done)
+    }, 70)
+  })
+  /* it.only('should work when Debugger is opened after app load', (done) => {
+
+    let messages = []
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnectInterval: 800
+    })
+    setTimeout(() => {
+      const mockServer = new Server('ws://localhost:8585')
+      mockServer.on('connection', (server) => {
+        server.on('message', (event) => {
+          const message = JSON.parse(event)
+          messages.push(message.type)
+          switch (message.type) {
+            case 'pong':
+              server.send(JSON.stringify({type: 'ping'}))
+              break
+            case 'ping':
+              server.send(JSON.stringify({type: 'pong'}))
+              break
+          }
+        })
+      })
+    }, 10)
+
+    setTimeout(() => {
+      assert.deepEqual(messages, ['pong', 'init'])
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done);
+    }, 1500);
+  }) */
+  it('should warn and try to reconnect to Debugger', (done) => {
+    let warnCount = 0
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      warnCount++
+      assert.equal(args[0], 'Debugger application is not running on selected port... will reconnect automatically behind the scenes')
+      originWarn.apply(this, args)
+    }
+    const controller = new Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585',
+        reconnectInterval: 500
+      })
+    })
+    assert.equal(controller.devtools.isConnected, false)
+    let mockServer
+    let messages = []
+    setTimeout(() => {
+      mockServer = new Server('ws://localhost:8585')
+      mockServer.on('connection', (server) => {
+        server.on('message', (event) => {
+          const message = JSON.parse(event)
+          messages.push(message.type)
+          switch (message.type) {
+            case 'pong':
+              server.send(JSON.stringify({type: 'ping'}))
+              break
+            case 'ping':
+              server.send(JSON.stringify({type: 'pong'}))
+              break
+          }
+        })
+      })
+    }, 400)
+
+    setTimeout(() => {
+      assert.deepEqual(messages, ['ping', 'init', 'bulk', 'components'])
+      assert.equal(warnCount, 1)
+      assert.equal(controller.devtools.isConnected, true)
+      console.warn = originWarn
+      mockServer.stop(done)
+    }, 1050)
+  })
+  it('should set component details and watch executions', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    let messageTypes = []
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          case 'execution':
+            messageTypes.push(message.type)
+            if (Array.isArray(messages[message.type])) {
+              messages[message.type].push(message)
+            } else {
+              messages[message.type] = [message]
+            }
+            break
+          default:
+            messageTypes.push(message.type)
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+    function actionA ({path, state}) {
+      assert.ok(true)
+      state.set('foo', 'foo')
+      return path.success()
+    }
+    function actionB () {
+      assert.ok(true)
+      return { bar: 'baz' }
+    }
+
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      },
+      signals: {
+        test: [
+          actionA, {
+            success: [
+              actionB
+            ]
+          }
+        ]
+      }
+    })
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`,
+      test: signal`test`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      assert.deepEqual(messageTypes, ['bulk', 'components'])
+      assert.equal(controller.devtools.isConnected, true)
+
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+
+      assert.equal(messages.components.source, 'c')
+      assert.deepEqual(messages.components.data.map.foo, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.deepEqual(messages.components.data.map.bar, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.deepEqual(messages.components.data.render, { components: [] })
+
+      assert.equal(messages.bulk.source, 'c')
+      assert.equal(messages.bulk.version, version)
+      assert.deepEqual(messages.bulk.data.messages, [])
+
+      controller.getSignal('test')({
+        foo: 'bar'
+      })
+
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 1, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 1, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+
+      assert.deepEqual(messageTypes, ['bulk', 'components', 'executionStart', 'execution', 'execution', 'executionPathStart', 'execution', 'executionFunctionEnd', 'executionEnd'])
+      assert.ok(messages.executionStart.data.execution)
+      assert.equal(messages.executionStart.source, 'c')
+
+      assert.equal(messages.execution.length, 3)
+      assert.ok(messages.execution[0].data.execution)
+      assert.equal(messages.execution[0].source, 'c')
+      assert.equal(messages.execution[0].version, version)
+      assert.deepEqual(messages.execution[0].data.execution.payload, { foo: 'bar' })
+
+      assert.ok(messages.execution[1].data.execution)
+      assert.equal(messages.execution[1].source, 'c')
+      assert.equal(messages.execution[1].version, version)
+      assert.deepEqual(messages.execution[1].data.execution.payload, { foo: 'bar' })
+      assert.equal(messages.execution[1].data.execution.data.method, 'set')
+      assert.deepEqual(messages.execution[1].data.execution.data.args, [ [ 'foo' ], 'foo' ])
+      assert.equal(messages.execution[1].data.execution.data.type, 'mutation')
+      assert.equal(messages.execution[1].data.execution.data.color, '#333')
+
+      assert.ok(messages.executionPathStart.data.execution)
+      assert.equal(messages.executionPathStart.source, 'c')
+      assert.equal(messages.executionPathStart.version, version)
+      assert.equal(messages.executionPathStart.data.execution.path, 'success')
+
+      assert.ok(messages.execution[2].data.execution)
+      assert.equal(messages.execution[2].source, 'c')
+      assert.equal(messages.execution[2].version, version)
+      assert.deepEqual(messages.execution[2].data.execution.payload, { foo: 'bar' })
+
+      assert.ok(messages.executionFunctionEnd.data.execution)
+      assert.equal(messages.executionFunctionEnd.source, 'c')
+      assert.equal(messages.executionFunctionEnd.version, version)
+      assert.deepEqual(messages.executionFunctionEnd.data.execution.output, { bar: 'baz' })
+
+      assert.ok(messages.executionEnd.data.execution)
+      assert.equal(messages.executionEnd.version, version)
+      assert.equal(messages.executionEnd.source, 'c')
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should watch signal execution error', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    let messageTypes = []
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          case 'execution':
+            messageTypes.push(message.type)
+            if (Array.isArray(messages[message.type])) {
+              messages[message.type].push(message)
+            } else {
+              messages[message.type] = [message]
+            }
+            break
+          default:
+            messageTypes.push(message.type)
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+    function actionA () {
+      return {
+        foo: 'bar'
+      }
+    }
+    let errorCount = 0
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      },
+      signals: {
+        test: [
+          actionA, {
+            success: []
+          }
+        ]
+      },
+      catch: new Map([
+        [FunctionTreeExecutionError, [
+          ({props}) => {
+            errorCount++
+            assert.ok(props.error.message.match(/needs to be a path of either success/))
+          }
+        ]]
+      ])
+    })
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`,
+      test: signal`test`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      controller.getSignal('test')()
+      assert.equal(errorCount, 1)
+      assert.deepEqual(messageTypes, ['bulk', 'components', 'components', 'executionStart', 'execution', 'executionFunctionError', 'executionStart', 'execution', 'executionEnd'])
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should reset the state', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          default:
+            break
+        }
+      })
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'reset'}))
+      }, 150)
+    })
+    function actionA ({path, state}) {
+      state.set('foo', 'foo')
+      return path.success()
+    }
+    function actionB () {
+      return { bar: 'baz' }
+    }
+
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      },
+      signals: {
+        test: [
+          actionA, {
+            success: [
+              actionB
+            ]
+          }
+        ]
+      }
+    })
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`,
+      test: signal`test`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.isConnected, true)
+
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 0, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+
+      controller.getSignal('test')({
+        foo: 'bar'
+      })
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 1, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 1, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+    }, 70)
+
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, JSON.parse(controller.devtools.initialModelString))
+      assert.deepEqual(controller.devtools.backlog, [])
+      assert.deepEqual(controller.devtools.mutations, [])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+      mockServer.stop(done)
+    }, 300)
+  })
+  it('should warn when remember message sent if storeMutations option is false', (done) => {
+    let warnCount = 0
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      warnCount++
+      assert.equal(args[0], 'Cerebral Devtools - You tried to time travel, but you have turned of storing of mutations')
+      originWarn.apply(this, args)
+    }
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'remember', data: 0}))
+      }, 70)
+    })
+    const controller = new Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585',
+        reconnect: true,
+        storeMutations: false
+      })
+    })
+    setTimeout(() => {
+      assert.equal(warnCount, 1)
+      assert.equal(controller.devtools.storeMutations, false)
+      console.warn = originWarn
+      mockServer.stop(done)
+    }, 100)
+  })
+  it('should travel back in time', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'remember', data: 1}))
+      }, 200)
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'remember', data: 0}))
+      }, 400)
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'remember', data: 1}))
+      }, 600)
+    })
+    function actionA ({state}) {
+      state.set('foo', 'foo')
+    }
+    function actionB ({state}) {
+      state.set('bar', 'bar')
+    }
+
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      },
+      signals: {
+        testA: [
+          actionA
+        ],
+        testB: [
+          actionB
+        ]
+      }
+    })
+    let rememberCount = 0
+    controller.on('remember', (datetime) => {
+      rememberCount++
+    })
+
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.isConnected, true)
+
+      controller.getSignal('testA')()
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      controller.getSignal('testB')()
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'bar'
+      })
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 2, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 2, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+      assert.equal(controller.devtools.mutations.length, 2)
+      assert.equal(rememberCount, 0)
+    }, 70)
+
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.mutations.length, 2)
+      assert.equal(rememberCount, 1)
+    }, 300)
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'bar'
+      })
+      assert.equal(controller.devtools.mutations.length, 2)
+      assert.equal(rememberCount, 2)
+    }, 500)
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.mutations.length, 2)
+      assert.equal(rememberCount, 3)
+
+      mockServer.stop(done)
+    }, 800)
+  })
+  it('should warn when the signal fired while debugger is remembering state', (done) => {
+    let warnCount = 0
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      warnCount++
+      assert.equal(args[0], 'The signal "testB" fired while debugger is remembering state, it was ignored')
+      originWarn.apply(this, args)
+    }
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'remember', data: 1}))
+      }, 150)
+    })
+    function actionA ({state}) {
+      state.set('foo', 'foo')
+    }
+    function actionB ({state}) {
+      state.set('bar', 'bar')
+    }
+
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      },
+      signals: {
+        testA: [
+          actionA
+        ],
+        testB: [
+          actionB
+        ]
+      }
+    })
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.isConnected, true)
+
+      controller.getSignal('testA')()
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      controller.getSignal('testB')()
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'bar'
+      })
+      assert.deepEqual(JSON.parse(controller.devtools.initialModelString), {
+        foo: 'bar',
+        bar: 'foo'
+      })
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.foo, [{ name: 'TestComponent', renderCount: 2, id: 1 }])
+      assert.deepEqual(controller.devtools.debuggerComponentsMap.bar, [{ name: 'TestComponent', renderCount: 2, id: 1 }])
+      assert.equal(controller.devtools.debuggerComponentsMap.test, undefined)
+      assert.equal(controller.devtools.mutations.length, 2)
+    }, 70)
+
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+      assert.equal(controller.devtools.mutations.length, 2)
+      controller.getSignal('testB')()
+      assert.deepEqual(controller.model.state, {
+        foo: 'foo',
+        bar: 'foo'
+      })
+
+      assert.equal(warnCount, 1)
+      console.warn = originWarn
+      mockServer.stop(done)
+    }, 300)
+  })
+  it('should change model state when debugger model state changed', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+      setTimeout(() => {
+        server.send(JSON.stringify({type: 'changeModel', data: {path: [ 'foo' ], value: 'baz'}}))
+      }, 70)
+    })
+
+    const controller = Controller({
+      devtools: new Devtools({
+        remoteDebugger: 'localhost:8585'
+      }),
+      state: {
+        foo: 'bar',
+        bar: 'foo'
+      }
+    })
+    const TestComponent = connect({
+      foo: state`foo`,
+      bar: state`bar`
+    }, (props) => {
+      return (
+        <div>{props.foo}</div>
+      )
+    })
+    TestComponent.displayName = 'TestComponent'
+    const tree = TestUtils.renderIntoDocument((
+      <Container controller={controller}>
+        <TestComponent />
+      </Container>
+    ))
+    assert.equal(TestUtils.findRenderedDOMComponentWithTag(tree, 'div').innerHTML, 'bar')
+
+    setTimeout(() => {
+      assert.deepEqual(controller.model.state, {
+        foo: 'baz',
+        bar: 'foo'
+      })
+      mockServer.stop(done)
+    }, 100)
+  })
+})

--- a/packages/function-tree/package.json
+++ b/packages/function-tree/package.json
@@ -46,5 +46,8 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
+  },
+  "devDependencies": {
+    "mock-socket": "^6.0.4"
   }
 }

--- a/packages/function-tree/src/devtools/base.js
+++ b/packages/function-tree/src/devtools/base.js
@@ -1,0 +1,241 @@
+import Path from '../Path'
+
+export class DevtoolsBase {
+  constructor ({
+    remoteDebugger = null,
+    reconnect = true,
+    reconnectInterval = 10000
+  } = {}) {
+    this.remoteDebugger = remoteDebugger
+    this.version = 0
+    if (!this.remoteDebugger) {
+      throw new Error(`Devtools: You have to pass in the "remoteDebugger" option`)
+    }
+    this.backlog = []
+    this.isConnected = false
+    this.ws = null
+    this.reconnectInterval = reconnectInterval
+    this.doReconnect = reconnect
+
+    this.sendInitial = this.sendInitial.bind(this)
+  }
+  createSocket () { }
+  /*
+    Sets up the listeners to Chrome Extension or remote debugger
+  */
+  addListeners () {
+    this.createSocket()
+    this.ws.onmessage = this.onMessage.bind(this)
+  }
+  onMessage (event) { }
+  reconnect () {
+    setTimeout(() => {
+      this.init()
+    }, this.reconnectInterval)
+  }
+  /*
+    The debugger might be ready or it might not. The initial communication
+    with the debugger requires a "ping" -> "pong" to identify that it
+    is ready to receive messages.
+    1. Debugger is open when app loads
+      - Devtools sends "ping"
+      - Debugger sends "pong"
+      - Devtools sends "init"
+    2. Debugger is opened after app load
+      - Debugger sends "ping"
+      - Devtools sends "init"
+  */
+  init () {
+    this.addListeners()
+    this.ws.onopen = () => {
+      this.ws.send(JSON.stringify({type: 'ping'}))
+    }
+    this.ws.onerror = () => {}
+    this.ws.onclose = () => {
+      this.isConnected = false
+
+      if (this.doReconnect) {
+        console.warn('Debugger application is not running on selected port... will reconnect automatically behind the scenes')
+        this.reconnect()
+      }
+    }
+  }
+  /*
+    Sends message to chrome extension or remote debugger
+  */
+  sendMessage (stringifiedMessage) {
+    this.ws.send(stringifiedMessage)
+  }
+  /*
+    Sends multiple message in one batch to debugger, causing debugger
+    also to synchronously run all updates before rendering
+  */
+  sendBulkMessage (messages, source) {
+    const message = JSON.stringify({
+      type: 'bulk',
+      source,
+      version: this.version, // eslint-disable-line
+      data: {
+        messages
+      }
+    })
+
+    this.sendMessage(message)
+  }
+  /*
+    Watches function tree for execution of signals. This is passed to
+    debugger to prevent time travelling when executing. It also tracks
+    latest executed signal for "remember" to know when signals can be
+    called again
+  */
+  watchExecution (tree, source) {
+    tree.on('start', (execution, payload) => {
+      const message = JSON.stringify({
+        type: 'executionStart',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id,
+            name: execution.name,
+            staticTree: execution.staticTree,
+            datetime: execution.datetime,
+            executedBy: (payload && payload._execution) ? payload._execution : null
+          }
+        }
+      })
+
+      this.sendExecutionMessage(message)
+    })
+    tree.on('end', (execution) => {
+      const message = JSON.stringify({
+        type: 'executionEnd',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id
+          }
+        }
+      })
+      this.latestExecutionId = execution.id
+
+      this.sendExecutionMessage(message)
+    })
+    tree.on('pathStart', (path, execution, funcDetails) => {
+      const message = JSON.stringify({
+        type: 'executionPathStart',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id,
+            functionIndex: funcDetails.functionIndex,
+            path
+          }
+        }
+      })
+
+      this.sendExecutionMessage(message)
+    })
+    tree.on('functionStart', (execution, funcDetails, payload) => {
+      const message = this.safeStringify({
+        type: 'execution',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id,
+            functionIndex: funcDetails.functionIndex,
+            payload,
+            data: null
+          }
+        }
+      })
+
+      this.sendExecutionMessage(message)
+    })
+    tree.on('functionEnd', (execution, funcDetails, payload, result) => {
+      if (!result || (result instanceof Path && !result.payload)) {
+        return
+      }
+
+      const message = this.safeStringify({
+        type: 'executionFunctionEnd',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id,
+            functionIndex: funcDetails.functionIndex,
+            output: result instanceof Path ? result.payload : result
+          }
+        }
+      })
+
+      this.sendExecutionMessage(message)
+    })
+    tree.on('error', (error, execution, funcDetails) => {
+      const message = JSON.stringify({
+        type: 'executionFunctionError',
+        source: source,
+        version: this.version,
+        data: {
+          execution: {
+            executionId: execution.id,
+            functionIndex: funcDetails.functionIndex,
+            error: {
+              name: error.name,
+              message: error.message,
+              stack: error.stack,
+              func: funcDetails.function.toString()
+            }
+          }
+        }
+      })
+
+      this.sendExecutionMessage(message)
+    })
+  }
+  safeStringify (object) {
+    const refs = []
+
+    return JSON.stringify(object, (key, value) => {
+      const isObject = (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      )
+
+      if (isObject && refs.indexOf(value) > -1) {
+        return '[CIRCULAR]'
+      } else if (isObject) {
+        refs.push(value)
+      }
+
+      return value
+    })
+  }
+  sendExecutionMessage (message) {
+    if (this.isConnected) {
+      this.sendMessage(message)
+    } else {
+      this.backlog.push(message)
+    }
+  }
+  sendInitial () { }
+  createExecutionMessage (debuggingData, context, functionDetails, payload) { }
+  /*
+    Sends execution data to the debugger. Whenever a signal starts
+    it will send a message to the debugger, but any functions in the
+    function tree might also use this to send debugging data. Like when
+    mutations are done or any wrapped methods run.
+  */
+  sendExecutionData (debuggingData, context, functionDetails, payload) {
+    const message = this.createExecutionMessage(debuggingData, context, functionDetails, payload)
+
+    this.sendExecutionMessage(message)
+  }
+}
+
+export default DevtoolsBase

--- a/packages/function-tree/src/devtools/index.js
+++ b/packages/function-tree/src/devtools/index.js
@@ -1,75 +1,37 @@
+import DevtoolsBase from './base'
 import WebSocket from 'universal-websocket-client'
-import Path from '../Path'
 
-export class Devtools {
-  constructor (options = {
-    remoteDebugger: null,
-    reconnect: true
-  }) {
+export class Devtools extends DevtoolsBase {
+  constructor (options) {
+    super(options)
     this.trees = []
-    this.remoteDebugger = options.remoteDebugger || null
-    this.backlog = []
     this.latestExecutionId = null
-    this.isConnected = false
-    this.ws = null
-    this.reconnectInterval = 10000
-    this.doReconnect = typeof options.reconnect === 'undefined' ? true : options.reconnect
-    this.isResettingDebugger = false
-
-    if (!this.remoteDebugger) {
-      throw new Error('Function-tree Devtools: You have to pass in the "remoteDebugger" option')
-    }
-
-    this.sendInitial = this.sendInitial.bind(this)
-
+    this.version = VERSION // eslint-disable-line
     this.init()
   }
-
-  addListeners () {
+  createSocket () {
     this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
-    this.ws.onmessage = (event) => {
-      const message = JSON.parse(event.data)
-      switch (message.type) {
-        case 'pong':
-          this.sendInitial()
-          break
-        case 'ping':
-          this.sendInitial()
-          break
-      }
-    }
   }
-  reconnect () {
-    setTimeout(() => {
-      this.init()
-      this.ws.onclose = () => {
-        this.isConnected = false
-        this.reconnect()
-      }
-    }, this.reconnectInterval)
-  }
-  init () {
-    this.addListeners()
-    this.ws.onopen = () => {
-      this.ws.send(JSON.stringify({type: 'ping'}))
-    }
-    this.ws.onerror = () => {}
-    this.ws.onclose = () => {
-      this.isConnected = false
-
-      if (this.doReconnect) {
-        console.warn('Debugger application is not running on selected port... will reconnect automatically behind the scenes')
-        this.reconnect()
-      }
+  onMessage (event) {
+    const message = JSON.parse(event.data)
+    switch (message.type) {
+      case 'pong':
+        this.sendInitial()
+        break
+      case 'ping':
+        this.sendInitial()
+        break
     }
   }
   add (tree) {
     this.trees.push(tree)
     tree.contextProviders.unshift(this.Provider())
-    this.watchExecution(tree)
+    this.watchExecution(tree, 'ft')
   }
   remove (tree) {
     this.trees.splice(this.trees.indexOf(tree), 1)
+    tree.contextProviders.splice(0, 1)
+
     tree.removeAllListeners('start')
     tree.removeAllListeners('end')
     tree.removeAllListeners('pathStart')
@@ -77,171 +39,27 @@ export class Devtools {
     tree.removeAllListeners('functionEnd')
     tree.removeAllListeners('error')
   }
-  destroy () {
-    this.trees.forEach(this.remove.bind(this))
-  }
-  safeStringify (object) {
-    const refs = []
-
-    return JSON.stringify(object, (key, value) => {
-      const isObject = (
-        typeof value === 'object' &&
-        value !== null &&
-        !Array.isArray(value)
-      )
-
-      if (isObject && refs.indexOf(value) > -1) {
-        return '[CIRCULAR]'
-      } else if (isObject) {
-        refs.push(value)
-      }
-
-      return value
-    })
-  }
-  sendMessage (stringifiedMessage) {
-    this.ws.send(stringifiedMessage)
-  }
-  watchExecution (tree) {
-    tree.on('start', (execution, payload) => {
-      const message = JSON.stringify({
-        type: 'executionStart',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id,
-            name: execution.name,
-            staticTree: execution.staticTree,
-            datetime: execution.datetime,
-            executedBy: (payload && payload._execution) ? payload._execution : null
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    tree.on('end', (execution) => {
-      const message = JSON.stringify({
-        type: 'executionEnd',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id
-          }
-        }
-      })
-      this.latestExecutionId = execution.id
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    tree.on('pathStart', (path, execution, funcDetails) => {
-      const message = JSON.stringify({
-        type: 'executionPathStart',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            path
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    tree.on('functionStart', (execution, funcDetails, payload) => {
-      const message = this.safeStringify({
-        type: 'execution',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            payload,
-            data: null
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    tree.on('functionEnd', (execution, funcDetails, payload, result) => {
-      if (!result || (result instanceof Path && !result.payload)) {
-        return
-      }
-
-      const message = this.safeStringify({
-        type: 'executionFunctionEnd',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            output: result instanceof Path ? result.payload : result
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
-    })
-    tree.on('error', (error, execution, funcDetails) => {
-      const message = JSON.stringify({
-        type: 'executionFunctionError',
-        source: 'ft',
-        data: {
-          execution: {
-            executionId: execution.id,
-            functionIndex: funcDetails.functionIndex,
-            error: {
-              name: error.name,
-              message: error.message,
-              stack: error.stack,
-              func: funcDetails.function.toString()
-            }
-          }
-        }
-      })
-
-      if (this.isConnected) {
-        this.sendMessage(message)
-      } else {
-        this.backlog.push(message)
-      }
+  removeAll () {
+    const trees = this.trees.reduce((newTrees, tree) => {
+      newTrees.push(tree)
+      return newTrees
+    }, [])
+    trees.forEach((tree) => {
+      this.remove(tree)
     })
   }
   sendInitial () {
     const message = JSON.stringify({
       type: 'init',
       source: 'ft',
-      version: VERSION // eslint-disable-line
+      version: this.version
     })
 
     this.sendMessage(message)
-    this.backlog.forEach((backlogItem) => {
-      this.sendMessage(backlogItem)
-    })
-
-    this.backlog = []
+    if (this.backlog.length) {
+      this.sendBulkMessage(this.backlog, 'ft')
+      this.backlog = []
+    }
     this.isConnected = true
   }
   /*
@@ -265,18 +83,9 @@ export class Devtools {
     return this.safeStringify({
       type: type,
       source: 'ft',
-      version: VERSION, // eslint-disable-line
+      version: this.version,
       data: data
     })
-  }
-  sendExecutionData (debuggingData, context, functionDetails, payload) {
-    const message = this.createExecutionMessage(debuggingData, context, functionDetails, payload)
-
-    if (this.isConnected) {
-      this.sendMessage(message)
-    } else {
-      this.backlog.push(message)
-    }
   }
   Provider () {
     const sendExecutionData = this.sendExecutionData.bind(this)

--- a/packages/function-tree/src/devtools/index.test.js
+++ b/packages/function-tree/src/devtools/index.test.js
@@ -1,0 +1,565 @@
+/* eslint-env mocha */
+import { WebSocket, Server } from 'mock-socket'
+import Devtools from './'
+import assert from 'assert'
+import { FunctionTree } from '../FunctionTree'
+
+Devtools.prototype.createSocket = function () {
+  this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+}
+
+describe('Devtools', () => {
+  describe('DevtoolsBase', () => {
+    it('should throw when remoteDebugger is not set', () => {
+      assert.throws(() => {
+        new Devtools() // eslint-disable-line no-new
+      }, (err) => {
+        if (err instanceof Error) {
+          return err.message === 'Devtools: You have to pass in the "remoteDebugger" option'
+        }
+      })
+    })
+  })
+  it('should init correctly', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        // client send ping
+        assert.equal(message.type, 'ping')
+      })
+      assert.ok(server)
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    setTimeout(() => {
+      assert.equal(devtools.isConnected, false)
+      assert.equal(devtools.reconnectInterval, 10000)
+      assert.equal(devtools.doReconnect, true)
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should work when debugger is already opened', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = []
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        messages.push(message.type)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    setTimeout(() => {
+      assert.deepEqual(messages, ['ping', 'init'])
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done)
+    }, 70)
+  })
+  /* it.only('should work when Debugger is opened after app load', (done) => {
+
+    let messages = []
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnectInterval: 800
+    })
+    setTimeout(() => {
+      const mockServer = new Server('ws://localhost:8585')
+      mockServer.on('connection', (server) => {
+        server.on('message', (event) => {
+          const message = JSON.parse(event)
+          messages.push(message.type)
+          switch (message.type) {
+            case 'pong':
+              server.send(JSON.stringify({type: 'ping'}))
+              break
+            case 'ping':
+              server.send(JSON.stringify({type: 'pong'}))
+              break
+          }
+        })
+      })
+    }, 10)
+
+    setTimeout(() => {
+      assert.deepEqual(messages, ['pong', 'init'])
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done);
+    }, 1500);
+  }) */
+  it('should warn and reconnect to Debugger', (done) => {
+    let warnCount = 0
+    const originWarn = console.warn
+    console.warn = function (...args) {
+      warnCount++
+      assert.equal(args[0], 'Debugger application is not running on selected port... will reconnect automatically behind the scenes')
+      originWarn.apply(this, args)
+    }
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnectInterval: 500
+    })
+    let mockServer
+    let messages = []
+    setTimeout(() => {
+      mockServer = new Server('ws://localhost:8585')
+      mockServer.on('connection', (server) => {
+        server.on('message', (event) => {
+          const message = JSON.parse(event)
+          messages.push(message.type)
+          switch (message.type) {
+            case 'pong':
+              server.send(JSON.stringify({type: 'ping'}))
+              break
+            case 'ping':
+              server.send(JSON.stringify({type: 'pong'}))
+              break
+          }
+        })
+      })
+    }, 400)
+
+    setTimeout(() => {
+      assert.deepEqual(messages, ['ping', 'init'])
+      assert.equal(warnCount, 1)
+      assert.equal(devtools.isConnected, true)
+      console.warn = originWarn
+      mockServer.stop(done)
+    }, 1050)
+  })
+  it('should add function tree', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+
+    setTimeout(() => {
+      const ft = new FunctionTree([])
+      assert.equal(ft.contextProviders.length, 0)
+      devtools.add(ft)
+      assert.equal(ft.contextProviders.length, 1)
+      assert.equal(devtools.trees.length, 1)
+      assert.deepEqual(devtools.trees[0], ft)
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should remove function tree', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+
+    setTimeout(() => {
+      const ft = new FunctionTree([])
+      devtools.add(ft)
+      devtools.remove(ft)
+      assert.equal(ft.contextProviders.length, 0)
+      assert.equal(devtools.trees.length, 0)
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should remove all trees', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+
+    setTimeout(() => {
+      const ftA = new FunctionTree()
+      ftA.type = 'A'
+      devtools.add(ftA)
+      assert.equal(ftA.contextProviders.length, 1)
+      assert.equal(devtools.trees.length, 1)
+      const ftB = new FunctionTree()
+      ftB.type = 'B'
+      devtools.add(ftB)
+      assert.equal(ftB.contextProviders.length, 1)
+      assert.equal(devtools.trees.length, 2)
+      devtools.removeAll()
+      assert.equal(ftA.contextProviders.length, 0)
+      assert.equal(ftB.contextProviders.length, 0)
+      assert.equal(devtools.trees.length, 0)
+      assert.equal(devtools.isConnected, true)
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should watch function tree executions', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          default:
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    const ft = new FunctionTree([])
+    devtools.add(ft)
+
+    function actionA ({path}) {
+      assert.ok(true)
+      return path.success()
+    }
+    function actionB () {
+      assert.ok(true)
+      return { bar: 'baz' }
+    }
+
+    setTimeout(() => {
+      ft.run([
+        actionA, {
+          success: [
+            actionB
+          ]
+        }
+      ], {
+        foo: 'bar'
+      })
+
+      assert.deepEqual(Object.keys(messages), [ 'executionStart', 'execution', 'executionPathStart', 'executionFunctionEnd', 'executionEnd' ])
+      assert.ok(messages.executionStart.data.execution)
+      assert.equal(messages.executionStart.source, 'ft')
+
+      assert.ok(messages.execution.data.execution)
+      assert.equal(messages.execution.source, 'ft')
+      assert.deepEqual(messages.execution.data.execution.payload, { foo: 'bar' })
+
+      assert.ok(messages.executionPathStart.data.execution)
+      assert.equal(messages.executionPathStart.source, 'ft')
+      assert.equal(messages.executionPathStart.data.execution.path, 'success')
+
+      assert.ok(messages.executionFunctionEnd.data.execution)
+      assert.equal(messages.executionFunctionEnd.source, 'ft')
+      assert.deepEqual(messages.executionFunctionEnd.data.execution.output, { bar: 'baz' })
+
+      assert.ok(messages.executionEnd.data.execution)
+      assert.equal(messages.executionEnd.source, 'ft')
+
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should watch function tree execution error', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          default:
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    const ft = new FunctionTree([])
+    devtools.add(ft)
+
+    function actionA () {
+      return {
+        foo: 'bar'
+      }
+    }
+
+    ft.once('error', (error) => {
+      assert.ok(error.message.match(/needs to be a path of either success/))
+    })
+
+    setTimeout(() => {
+      ft.run([
+        actionA, {
+          success: []
+        }
+      ]).catch((error) => {
+        assert.ok(error.message.match(/needs to be a path of either success/))
+      })
+
+      assert.deepEqual(Object.keys(messages), [ 'executionStart', 'execution', 'executionFunctionError' ])
+      assert.ok(messages.executionStart.data.execution)
+      assert.equal(messages.executionStart.source, 'ft')
+
+      assert.ok(messages.execution.data.execution)
+      assert.equal(messages.execution.source, 'ft')
+
+      assert.ok(messages.executionFunctionError.data.execution)
+      assert.equal(messages.executionFunctionError.source, 'ft')
+      assert.equal(messages.executionFunctionError.data.execution.error.name, 'FunctionTreeExecutionError')
+      assert.equal(messages.executionFunctionError.data.execution.error.func, actionA.toString())
+      assert.ok(messages.executionFunctionError.data.execution.error.message.match(/needs to be a path of either success/))
+
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should keep execution messages when debugger is not ready and send bulk messages after debugger is ready', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          default:
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    const ft = new FunctionTree([])
+    devtools.add(ft)
+
+    function actionA ({path}) {
+      assert.ok(true)
+      return path.success()
+    }
+    function actionB () {
+      assert.ok(true)
+      return { bar: 'baz' }
+    }
+    ft.run([
+      actionA, {
+        success: [
+          actionB
+        ]
+      }
+    ], {
+      foo: 'bar'
+    })
+
+    setTimeout(() => {
+      assert.deepEqual(Object.keys(messages), [ 'bulk' ])
+      assert.equal(messages.bulk.data.messages.length, 6)
+
+      const executionStartMessage = JSON.parse(messages.bulk.data.messages[0])
+      assert.equal(executionStartMessage.type, 'executionStart')
+      assert.ok(executionStartMessage.data.execution)
+      assert.equal(executionStartMessage.source, 'ft')
+
+      let executionMessage = JSON.parse(messages.bulk.data.messages[1])
+      assert.equal(executionMessage.type, 'execution')
+      assert.ok(executionMessage.data.execution)
+      assert.equal(executionMessage.source, 'ft')
+      assert.deepEqual(executionMessage.data.execution.payload, { foo: 'bar' })
+
+      const executionPathStartMessage = JSON.parse(messages.bulk.data.messages[2])
+      assert.equal(executionPathStartMessage.type, 'executionPathStart')
+      assert.ok(executionPathStartMessage.data.execution)
+      assert.equal(executionPathStartMessage.source, 'ft')
+      assert.equal(executionPathStartMessage.data.execution.path, 'success')
+
+      executionMessage = JSON.parse(messages.bulk.data.messages[3])
+      assert.equal(executionMessage.type, 'execution')
+      assert.ok(executionMessage.data.execution)
+      assert.equal(executionMessage.source, 'ft')
+      assert.deepEqual(executionMessage.data.execution.payload, { foo: 'bar' })
+
+      const executionFunctionEndMessage = JSON.parse(messages.bulk.data.messages[4])
+      assert.equal(executionFunctionEndMessage.type, 'executionFunctionEnd')
+      assert.ok(executionFunctionEndMessage.data.execution)
+      assert.equal(executionFunctionEndMessage.source, 'ft')
+      assert.deepEqual(executionFunctionEndMessage.data.execution.output, { bar: 'baz' })
+
+      const executionEndMessage = JSON.parse(messages.bulk.data.messages[5])
+      assert.equal(executionEndMessage.type, 'executionEnd')
+      assert.ok(executionEndMessage.data.execution)
+      assert.equal(executionEndMessage.source, 'ft')
+
+      mockServer.stop(done)
+    }, 70)
+  })
+  it('should send provider data', (done) => {
+    const mockServer = new Server('ws://localhost:8585')
+    let messages = {}
+    let messageTypes = []
+    mockServer.on('connection', (server) => {
+      server.on('message', (event) => {
+        const message = JSON.parse(event)
+        switch (message.type) {
+          case 'pong':
+            server.send(JSON.stringify({type: 'ping'}))
+            break
+          case 'ping':
+            server.send(JSON.stringify({type: 'pong'}))
+            break
+          case 'init':
+            break
+          case 'execution':
+            messageTypes.push(message.type)
+            if (Array.isArray(messages[message.type])) {
+              messages[message.type].push(message)
+            } else {
+              messages[message.type] = [message]
+            }
+            break
+          default:
+            messageTypes.push(message.type)
+            messages[message.type] = message
+            break
+        }
+      })
+    })
+    const MyProvider = (options = {}) => {
+      let cachedProvider = null
+
+      function createProvider (context) {
+        return {
+          doSomething (value) {
+            return value
+          }
+        }
+      }
+
+      return (context) => {
+        context.myProvider = cachedProvider = (cachedProvider || createProvider(context))
+
+        if (context.debugger) {
+          context.debugger.wrapProvider('myProvider')
+        }
+
+        return context
+      }
+    }
+    const devtools = new Devtools({
+      remoteDebugger: 'localhost:8585',
+      reconnect: true
+    })
+    const ft = new FunctionTree([
+      MyProvider()
+    ])
+    devtools.add(ft)
+
+    function actionA ({myProvider}) {
+      assert.ok(true)
+      assert.equal(myProvider.doSomething('bar'), 'bar')
+    }
+
+    setTimeout(() => {
+      ft.run([
+        actionA
+      ], {
+        foo: 'bar'
+      })
+
+      assert.deepEqual(messageTypes, [ 'executionStart', 'execution', 'execution', 'executionEnd' ])
+      assert.ok(messages.executionStart.data.execution)
+      assert.equal(messages.executionStart.source, 'ft')
+
+      assert.equal(messages.execution.length, 2)
+      assert.ok(messages.execution[0].data.execution)
+      assert.equal(messages.execution[0].source, 'ft')
+      assert.deepEqual(messages.execution[0].data.execution.payload, { foo: 'bar' })
+
+      assert.ok(messages.execution[1].data.execution)
+      assert.equal(messages.execution[1].source, 'ft')
+      assert.deepEqual(messages.execution[1].data.execution.payload, { foo: 'bar' })
+      assert.equal(messages.execution[1].data.execution.data.method, 'myProvider.doSomething')
+      assert.deepEqual(messages.execution[1].data.execution.data.args, ['bar'])
+
+      assert.ok(messages.executionEnd.data.execution)
+      assert.equal(messages.executionEnd.source, 'ft')
+
+      mockServer.stop(done)
+    }, 70)
+  })
+})


### PR DESCRIPTION
Hi all,

PR includes:  
- create new DevtoolsBase class (get rid of code duplication)
- Cerebral Devtools and Function-tree Devtools extending from DevtoolsBase  
- new devtools tests using mock-socket

function-tree devtools
- change destroy method name to removeAll because it removes all trees but not destroy devtools
- fix remove tree should remove provider
- fix removeAll (destroy) .first copy trees then remove them safely
- fix reconnect. Before it listened onclose method two times.

cerebral devtools
- remove doReconnect from options
- fix init memory leak :) only call watchExecution if it is the first time.
- use safeStringify method for cerebral devtools.

I pushed also some fixes for debugger.  https://github.com/cerebral/cerebral-debugger/pull/3

I tested with my cerebral project. It seems OK. @christianalfoni can you please test it? I don't have any function-tree project yet :) 

By the way why do we have two different debuggers at webpage and where is the function-tree debugger source code? 

