### PR TITLE
feat(Views): warn when using objects and arrays on connected component

### DIFF
--- a/packages/node_modules/cerebral/src/utils.js
+++ b/packages/node_modules/cerebral/src/utils.js
@@ -275,3 +275,17 @@ export function createDummyController(state = {}, signals = {}) {
     },
   }
 }
+
+export function verifyPlainProps(props, componentName) {
+  if (!props) {
+    return
+  }
+
+  Object.keys(props).forEach(prop => {
+    if (typeof props[prop] === 'object' && props[prop] !== null) {
+      console.warn(
+        `You are passing an ${Array.isArray(props[prop]) ? 'array' : 'object'} on the prop "${prop}" into the connected component "${componentName}". If this value is from Cerebrals state tree, please connect it directly to the component instead`
+      )
+    }
+  })
+}

--- a/packages/node_modules/cerebral/src/views/View.js
+++ b/packages/node_modules/cerebral/src/views/View.js
@@ -5,6 +5,7 @@ import {
   throwError,
   ensureStrictPath,
   createResolver,
+  verifyPlainProps,
 } from './../utils'
 
 class View {
@@ -45,6 +46,10 @@ class View {
       props
     )
     this.tagsDependencyMap = this.getTagsDependencyMap(props)
+
+    if (this.controller.devtools) {
+      verifyPlainProps(props, displayName)
+    }
   }
   /*
     A getter for StateTracker and tags to grab state from Cerebral
@@ -84,6 +89,10 @@ class View {
     }
   }
   onPropsUpdate(props, nextProps) {
+    if (this.controller.devtools) {
+      verifyPlainProps(nextProps, this._displayName)
+    }
+
     const propsChanges = getChangedProps(props, nextProps)
     if (propsChanges.length) {
       this.updateFromProps(propsChanges, nextProps)

--- a/packages/node_modules/cerebral/src/views/react/react.test.js
+++ b/packages/node_modules/cerebral/src/views/react/react.test.js
@@ -383,6 +383,7 @@ describe('React', () => {
         true
       )
       assert.equal(warnCount, 1)
+      console.warn = originWarn
     })
     it('should throw an error if no container component provided', () => {
       const TestComponent = connect(
@@ -1452,6 +1453,40 @@ describe('React', () => {
           TestUtils.findRenderedDOMComponentWithTag(tree, 'h1').innerHTML,
           'foo'
         )
+      })
+      it('should warn when passing objects or arrays to connected component', () => {
+        let warnCount = 0
+        const originWarn = console.warn
+        console.warn = function(...args) {
+          warnCount++
+          assert.equal(
+            args[0],
+            'You are passing an array on the prop "foo" into the connected component "Test". If this value is from Cerebrals state tree, please connect it directly to the component instead'
+          )
+          originWarn.apply(this, args)
+        }
+        const controller = Controller({
+          devtools: { init() {}, send() {}, updateComponentsMap() {} },
+          state: {
+            foo: 'bar',
+          },
+        })
+        const TestComponent = connect(
+          {
+            foo: state`foo`,
+          },
+          function Test(props) {
+            return <div>{props.foo}</div>
+          }
+        )
+        // eslint-disable-next-line no-unused-vars
+        const tree = TestUtils.renderIntoDocument(
+          <Container controller={controller}>
+            <TestComponent foo={[]} />
+          </Container>
+        )
+        assert.equal(warnCount, 1)
+        console.warn = originWarn
       })
     })
   })


### PR DESCRIPTION
Connected components should not have objects and arrays passed as props:

```js
export default connect({
  foo: state`foo`
},
  function Comp ({foo}) {
    return <div>{foo}</div>
  }
)

// Some other component
<div>
  <Comp obj={{}} array={[]} />
</div>
```

The reason is that connected components has `return false` on `shouldComponentUpdate` and strict equality check on the props to optimize. Which means if one of these objects are mutated it will not update itself. BUT! Passing objects and arrays to connected components should not happen, cause:

1. They are very likely from the state tree, so should rather be connected directly
2. Generally you should not pass mutable objects and arrays as props, because it prevents render optimizations in general