### PR TITLE
feat(Devtools): change to host prop and warn use of frozen objects in props

### DIFF
--- a/docs/api/devtools.md
+++ b/docs/api/devtools.md
@@ -9,7 +9,7 @@ const controller = Controller({
   devtools: process.env.NODE_ENV === 'production' ? null : Devtools({
     // Connect to Electron debugger (external debugger). It will
     // fall back to chrome extension if unable to connect
-    remoteDebugger: 'localhost:8585',
+    host: 'localhost:8585',
 
     // By default the devtools tries to reconnect
     // to debugger when it can not be reached, but

--- a/docs/get_started/todomvc.md
+++ b/docs/get_started/todomvc.md
@@ -19,7 +19,7 @@ import toggleAllChecked from './actions/toggleAllChecked'
 import clearCompletedTodos from './actions/clearCompletedTodos'
 
 const controller = Controller({
-  devtools: Devtools({ remoteDebugger: 'localhost:8787' }),
+  devtools: Devtools({ host: 'localhost:8787' }),
   // The router maps urls to signal execution
   router: Router({
     onlyHash: true,

--- a/docs/introduction/debugger.md
+++ b/docs/introduction/debugger.md
@@ -27,7 +27,7 @@ const controller = Controller({
       Devtools({
         // If running standalone debugger. Some environments
         // might require 127.0.0.1 or computer IP address
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
 
         // By default the devtools tries to reconnect
         // to debugger when it can not be reached, but

--- a/docs/introduction/organize.md
+++ b/docs/introduction/organize.md
@@ -164,7 +164,7 @@ import repos from './modules/repos'
 
 const controller = Controller({
   devtools: Devtools({
-    remoteDebugger: '127.0.0.1:8585'
+    host: '127.0.0.1:8585'
   }),
   modules: {
     app,

--- a/docs/introduction/signals.md
+++ b/docs/introduction/signals.md
@@ -126,7 +126,7 @@ function updateSubtitle ({state}) {
 
 const controller = Controller({
   devtools:  Devtools({
-    remoteDebugger: '127.0.0.1:8585'
+    host: '127.0.0.1:8585'
   }),
   state: {
     title: 'Hello from Cerebral!',

--- a/docs/introduction/state.md
+++ b/docs/introduction/state.md
@@ -28,7 +28,7 @@ import Devtools from 'cerebral/devtools'
 
 const controller = Controller({
   devtools: Devtools({
-    remoteDebugger: '127.0.0.1:8585'
+    host: '127.0.0.1:8585'
   }),
   state: {
     title: 'Cerebral Tutorial'

--- a/packages/demos/todomvc/src/controller.js
+++ b/packages/demos/todomvc/src/controller.js
@@ -11,7 +11,7 @@ import toggleAllChecked from './actions/toggleAllChecked'
 import clearCompletedTodos from './actions/clearCompletedTodos'
 
 const controller = Controller({
-  devtools: Devtools({ remoteDebugger: 'localhost:8787' }),
+  devtools: Devtools({ host: 'localhost:8787' }),
   providers: [
     provide('uuid', uuid),
     StorageProvider({

--- a/packages/node_modules/cerebral/src/Model.js
+++ b/packages/node_modules/cerebral/src/Model.js
@@ -34,21 +34,17 @@ class Model {
     Freezes objects and arrays recursively to avoid unwanted mutation
   */
   freezeObject(object) {
-    if (
-      (!Array.isArray(object) && !isObject(object)) | Object.isFrozen(object)
-    ) {
-      return object
-    }
+    if (!Object.isFrozen(object) && isComplexObject(object)) {
+      for (const key in object) {
+        // Properties might not be writable, but then there
+        // is not reason to freeze its value either
+        try {
+          object[key] = this.freezeObject(object[key])
+        } catch (e) {}
+      }
 
-    for (const key in object) {
-      // Properties might not be writable, but then there
-      // is not reason to freeze its value either
-      try {
-        object[key] = this.freezeObject(object[key])
-      } catch (e) {}
+      Object.freeze(object)
     }
-
-    Object.freeze(object)
 
     return object
   }
@@ -71,6 +67,9 @@ class Model {
   updateIn(path, cb, forceChildPathUpdates = false) {
     if (!path.length) {
       cb(this.state, this, 'state')
+      this.state = this.preventExternalMutations
+        ? this.freezeObject(this.state)
+        : this.state
 
       return
     }

--- a/packages/node_modules/cerebral/src/devtools/index.js
+++ b/packages/node_modules/cerebral/src/devtools/index.js
@@ -17,6 +17,7 @@ export class Devtools extends DevtoolsBase {
       preventPropsReplacement = false,
       bigComponentsWarning = 10,
       remoteDebugger = null,
+      host = null,
       reconnect = true,
       reconnectInterval = 5000,
       allowedTypes = [],
@@ -24,6 +25,7 @@ export class Devtools extends DevtoolsBase {
   ) {
     super({
       remoteDebugger,
+      host,
       reconnect,
       reconnectInterval,
     })
@@ -64,7 +66,7 @@ export class Devtools extends DevtoolsBase {
     prevent any new signals firing off when in "remember state"
   */
   remember(index) {
-    this.controller.model.state = JSON.parse(this.initialModelString)
+    this.controller.model.set([], JSON.parse(this.initialModelString))
 
     if (index === 0) {
       this.controller.run = this.originalRunTreeFunction
@@ -91,13 +93,13 @@ export class Devtools extends DevtoolsBase {
 
   */
   reset() {
-    this.controller.model.state = JSON.parse(this.initialModelString)
+    this.controller.model.set([], JSON.parse(this.initialModelString))
     this.backlog = []
     this.mutations = []
     this.controller.flush(true)
   }
   createSocket() {
-    this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+    this.ws = new WebSocket(`ws://${this.host}`)
   }
   onMessage(event) {
     const message = JSON.parse(event.data)

--- a/packages/node_modules/cerebral/src/devtools/index.test.js
+++ b/packages/node_modules/cerebral/src/devtools/index.test.js
@@ -14,11 +14,11 @@ import { FunctionTreeExecutionError } from 'function-tree/lib/errors'
 const version = VERSION
 
 Devtools.prototype.createSocket = function() {
-  this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+  this.ws = new WebSocket(`ws://${this.host}`)
 }
 
 describe('Devtools', () => {
-  it('should throw when remoteDebugger is not set', () => {
+  it('should throw when host is not set', () => {
     assert.throws(
       () => {
         new Devtools() // eslint-disable-line no-new
@@ -26,8 +26,7 @@ describe('Devtools', () => {
       err => {
         if (err instanceof Error) {
           return (
-            err.message ===
-            'Devtools: You have to pass in the "remoteDebugger" option'
+            err.message === 'Devtools: You have to pass in the "host" option'
           )
         }
       }
@@ -52,7 +51,7 @@ describe('Devtools', () => {
     })
     const controller = new Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
         reconnect: true,
       }),
     })
@@ -85,7 +84,7 @@ describe('Devtools', () => {
   /* it.only('should work when Debugger is opened after app load', (done) => {
     let messages = []
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnectInterval: 800
     })
     setTimeout(() => {
@@ -124,7 +123,7 @@ describe('Devtools', () => {
     }
     const controller = new Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
         reconnectInterval: 500,
       }),
     })
@@ -200,7 +199,7 @@ describe('Devtools', () => {
 
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',
@@ -368,7 +367,7 @@ describe('Devtools', () => {
     let errorCount = 0
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',
@@ -465,7 +464,7 @@ describe('Devtools', () => {
 
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',
@@ -576,7 +575,7 @@ describe('Devtools', () => {
     })
     const controller = new Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
         reconnect: true,
         storeMutations: false,
       }),
@@ -621,7 +620,7 @@ describe('Devtools', () => {
 
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',
@@ -752,7 +751,7 @@ describe('Devtools', () => {
 
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',
@@ -856,7 +855,7 @@ describe('Devtools', () => {
 
     const controller = Controller({
       devtools: new Devtools({
-        remoteDebugger: 'localhost:8585',
+        host: 'localhost:8585',
       }),
       state: {
         foo: 'bar',

--- a/packages/node_modules/cerebral/src/utils.js
+++ b/packages/node_modules/cerebral/src/utils.js
@@ -275,3 +275,13 @@ export function createDummyController(state = {}, signals = {}) {
     },
   }
 }
+
+export function getStateTreeProp(props = {}) {
+  return Object.keys(props).reduce((prop, key) => {
+    if (prop || (isComplexObject(props[key]) && Object.isFrozen(props[key]))) {
+      return key
+    }
+
+    return prop
+  }, null)
+}

--- a/packages/node_modules/cerebral/src/views/View.js
+++ b/packages/node_modules/cerebral/src/views/View.js
@@ -5,6 +5,7 @@ import {
   throwError,
   ensureStrictPath,
   createResolver,
+  getStateTreeProp,
 } from './../utils'
 
 class View {
@@ -23,6 +24,11 @@ class View {
     this._displayName = displayName
     this._hasWarnedBigComponent = false
     this.onUpdate = onUpdate
+
+    if (this.controller.devtools) {
+      this.verifyProps(props)
+    }
+
     /*
       First we find any dependency functions to convert to DependencyTrackers.
       They are instantly run to produce their value and map of state
@@ -45,6 +51,17 @@ class View {
       props
     )
     this.tagsDependencyMap = this.getTagsDependencyMap(props)
+  }
+  /*
+    A method to ensure objects and arrays from state tree are not passed as props
+  */
+  verifyProps(props) {
+    const key = getStateTreeProp(props)
+    if (key) {
+      console.warn(
+        `You are passing an ${Array.isArray(props[key]) ? 'array' : 'object'} to the component "${this._displayName}" on prop "${key}" which is from the Cerebral state tree. You should not do this, but rather connect it directly to this component. This will optimize the component and avoid any rerender issues.`
+      )
+    }
   }
   /*
     A getter for StateTracker and tags to grab state from Cerebral
@@ -84,6 +101,10 @@ class View {
     }
   }
   onPropsUpdate(props, nextProps) {
+    if (this.controller.devtools) {
+      this.verifyProps(nextProps)
+    }
+
     const propsChanges = getChangedProps(props, nextProps)
     if (propsChanges.length) {
       this.updateFromProps(propsChanges, nextProps)

--- a/packages/node_modules/cerebral/src/views/react/react.test.js
+++ b/packages/node_modules/cerebral/src/views/react/react.test.js
@@ -383,6 +383,7 @@ describe('React', () => {
         true
       )
       assert.equal(warnCount, 1)
+      console.warn = originWarn
     })
     it('should throw an error if no container component provided', () => {
       const TestComponent = connect(
@@ -1452,6 +1453,45 @@ describe('React', () => {
           TestUtils.findRenderedDOMComponentWithTag(tree, 'h1').innerHTML,
           'foo'
         )
+      })
+      it('should handle props composition updating value', () => {
+        let warnCount = 0
+        const originWarn = console.warn
+        console.warn = function(...args) {
+          warnCount++
+          assert.equal(
+            args[0],
+            'You are passing an array to the component "Test" on prop "list" which is from the Cerebral state tree. You should not do this, but rather connect it directly to this component. This will optimize the component and avoid any rerender issues.'
+          )
+          originWarn.apply(this, args)
+        }
+        const controller = Controller({
+          devtools: {
+            preventExternalMutations: true,
+            init() {},
+            send() {},
+            updateComponentsMap() {},
+          },
+          state: {
+            foo: 'bar',
+            list: [],
+          },
+        })
+        const TestComponent = connect(
+          {
+            foo: state`foo`,
+          },
+          function Test(props) {
+            return <div>{props.foo}</div>
+          }
+        )
+        TestUtils.renderIntoDocument(
+          <Container controller={controller}>
+            <TestComponent list={controller.getState('list')} />
+          </Container>
+        )
+        assert.equal(warnCount, 1)
+        console.warn = originWarn
       })
     })
   })

--- a/packages/node_modules/function-tree/src/devtools/base.js
+++ b/packages/node_modules/function-tree/src/devtools/base.js
@@ -2,14 +2,22 @@ import Path from '../Path'
 
 export class DevtoolsBase {
   constructor(
-    { remoteDebugger = null, reconnect = true, reconnectInterval = 10000 } = {}
+    {
+      host = null,
+      remoteDebugger = null,
+      reconnect = true,
+      reconnectInterval = 10000,
+    } = {}
   ) {
-    this.remoteDebugger = remoteDebugger
-    this.version = 0
-    if (!this.remoteDebugger) {
-      throw new Error(
-        `Devtools: You have to pass in the "remoteDebugger" option`
+    if (remoteDebugger) {
+      console.warn(
+        'The "remoteDebugger" property is DEPRECATED, please use "host" instead'
       )
+    }
+    this.host = host || remoteDebugger
+    this.version = 0
+    if (!this.host) {
+      throw new Error(`Devtools: You have to pass in the "host" option`)
     }
     this.backlog = []
     this.isConnected = false

--- a/packages/node_modules/function-tree/src/devtools/index.js
+++ b/packages/node_modules/function-tree/src/devtools/index.js
@@ -11,7 +11,7 @@ export class Devtools extends DevtoolsBase {
     this.init()
   }
   createSocket() {
-    this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+    this.ws = new WebSocket(`ws://${this.host}`)
   }
   onMessage(event) {
     const message = JSON.parse(event.data)

--- a/packages/node_modules/function-tree/src/devtools/index.test.js
+++ b/packages/node_modules/function-tree/src/devtools/index.test.js
@@ -5,12 +5,12 @@ import assert from 'assert'
 import { FunctionTree } from '../FunctionTree'
 
 Devtools.prototype.createSocket = function() {
-  this.ws = new WebSocket(`ws://${this.remoteDebugger}`)
+  this.ws = new WebSocket(`ws://${this.host}`)
 }
 
 describe('Devtools', () => {
   describe('DevtoolsBase', () => {
-    it('should throw when remoteDebugger is not set', () => {
+    it('should throw when host is not set', () => {
       assert.throws(
         () => {
           new Devtools() // eslint-disable-line no-new
@@ -18,8 +18,7 @@ describe('Devtools', () => {
         err => {
           if (err instanceof Error) {
             return (
-              err.message ===
-              'Devtools: You have to pass in the "remoteDebugger" option'
+              err.message === 'Devtools: You have to pass in the "host" option'
             )
           }
         }
@@ -38,7 +37,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     setTimeout(() => {
@@ -67,7 +66,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     setTimeout(() => {
@@ -81,7 +80,7 @@ describe('Devtools', () => {
     let messages = []
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnectInterval: 800
     })
     setTimeout(() => {
@@ -120,7 +119,7 @@ describe('Devtools', () => {
       originWarn.apply(this, args)
     }
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnectInterval: 500,
     })
     let mockServer
@@ -168,7 +167,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
 
@@ -200,7 +199,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
 
@@ -231,7 +230,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
 
@@ -277,7 +276,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     const ft = new FunctionTree([])
@@ -360,7 +359,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     const ft = new FunctionTree([])
@@ -441,7 +440,7 @@ describe('Devtools', () => {
     })
 
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     const ft = new FunctionTree([])
@@ -568,7 +567,7 @@ describe('Devtools', () => {
       }
     }
     const devtools = new Devtools({
-      remoteDebugger: 'localhost:8585',
+      host: 'localhost:8585',
       reconnect: true,
     })
     const ft = new FunctionTree([MyProvider()])


### PR DESCRIPTION
- Now using `host` instead of `remoteDebugger`... it has been DEPRECATED
- The `View` will now verify the props passed into it. It checks if any of the props are complex objects and if they are frozen. If this is the case it is coming from the Cerebral state tree and should not be there, it should be connected directly. It gives a warning when this occurs
- Fixed issue where root state update was not frozen
- Fixed issue where devtools would replace state and not freeze on `remember` and `reset`
- Updated docs to reflect new `host` prop