### PR TITLE
feat(forms): use get from computed instead of form in rules

### DIFF
--- a/packages/demos/forms-demo/src/index.js
+++ b/packages/demos/forms-demo/src/index.js
@@ -10,17 +10,17 @@ import App from './components/App'
 import FormsProvider from '@cerebral/forms'
 
 const controller = Controller({
-  router: Router({
-    routes: {
-      '/': 'app.routed',
-      '/simple': 'simple.routed',
-    },
-    onlyHash: true,
-  }),
-  devtools: Devtools({ remoteDebugger: 'localhost:8787' }),
+  devtools: Devtools({ host: 'localhost:8787' }),
   modules: {
     app,
     simple,
+    router: Router({
+      routes: {
+        '/': 'app.routed',
+        '/simple': 'simple.routed',
+      },
+      onlyHash: true,
+    }),
   },
   providers: [FormsProvider()],
 })

--- a/packages/node_modules/@cerebral/forms/README.md
+++ b/packages/node_modules/@cerebral/forms/README.md
@@ -23,10 +23,15 @@ const controller = Controller({
     FormsProvider({
       // Add additional rules
       rules: {
-        myAddedRule (value, form, arg) {
-          value // value of the field
-          form // the form field is attached to
-          arg // arg passed to the rule
+        myAddedRule (value, arg, get) {
+          // value of the field
+          value
+          // arg passed to the rule
+          arg
+          // The "get" argument from computed. Use it to grab
+          // state or props passed to component. The component
+          // will track use of these dependencies for rerender
+          get
 
           return true
         }
@@ -119,7 +124,7 @@ export default connect({
 )
 ```
 
-You can also use the **field** computed, pointing to the field.
+You can also use the **field** computed, pointing to the field. This will optimize rendering as only the field will render on change.
 
 ```js
 import React from 'react'

--- a/packages/node_modules/@cerebral/forms/src/field.test.js
+++ b/packages/node_modules/@cerebral/forms/src/field.test.js
@@ -2,7 +2,7 @@
 import { field } from '.'
 import assert from 'assert'
 import { runCompute } from 'cerebral/test'
-import { state, props } from 'cerebral/tags'
+import { state } from 'cerebral/tags'
 import { Field } from './form'
 
 describe('field', () => {
@@ -56,44 +56,5 @@ describe('field', () => {
     }
     const nameField = runCompute(field(state`form.name`), compute)
     assert.deepEqual(nameField, {})
-  })
-  it('should have form as a form object', () => {
-    let compute = {
-      state: {
-        form: {
-          name: {
-            value: 'Ben',
-          },
-          name2: {
-            value: 'Ben2',
-          },
-        },
-      },
-    }
-    const nameField = runCompute(field(state`form.name`), compute)
-    assert.deepEqual(nameField._form, compute.state.form)
-  })
-  it('should have form when field computed has state and props dependency', () => {
-    let compute = {
-      state: {
-        form: {
-          name: {
-            value: 'Ben',
-          },
-          name2: {
-            value: 'Ben2',
-          },
-        },
-        field: 'name',
-      },
-      props: {
-        form: 'form',
-      },
-    }
-    const nameField = runCompute(
-      field(state`${props`form`}.${state`field`}`),
-      compute
-    )
-    assert.deepEqual(nameField._form, compute.state.form)
   })
 })

--- a/packages/node_modules/@cerebral/forms/src/form.js
+++ b/packages/node_modules/@cerebral/forms/src/form.js
@@ -3,7 +3,6 @@ import runValidation from './utils/runValidation'
 import formToJSON from './helpers/formToJSON'
 import getInvalidFormFields from './helpers/getInvalidFormFields'
 import getFormFields from './helpers/getFormFields'
-import { state, props } from 'cerebral/tags'
 
 function createFields(form) {
   return Object.keys(form).reduce((fields, key) => {
@@ -22,29 +21,28 @@ function createFields(form) {
 }
 
 export class Field {
-  constructor(field, form) {
-    this._form = form
+  constructor(field) {
     Object.assign(this, field, {
       isPristine: typeof field.isPristine === 'undefined'
         ? true
         : field.isPristine,
     })
   }
-  _validate() {
-    return Object.assign(this, runValidation(this, this._form)).isValid
+  _validate(get) {
+    return Object.assign(this, runValidation(this, get)).isValid
   }
 }
 
 export class Form {
-  constructor(form) {
+  constructor(form, get) {
     Object.assign(this, createFields(form))
-    this.isValid = this._validate()
+    this.isValid = this._validate(get)
   }
-  _validate() {
+  _validate(get) {
     function validate(obj) {
       return Object.keys(obj).reduce((isValid, field) => {
         if (obj[field] instanceof Field) {
-          const isFieldValid = obj[field]._validate()
+          const isFieldValid = obj[field]._validate(get)
 
           return isValid ? isFieldValid : false
         } else if (obj[field] === Object(obj[field])) {
@@ -78,31 +76,21 @@ export function computedField(fieldValueTag) {
       )
       return {}
     }
-    const formPath = fieldValueTag.getPath({
-      state(path) {
-        return get(state`${path}`)
-      },
-      props(path) {
-        return get(props`${path}`)
-      },
-    })
-    const formPathArray = formPath.split('.')
-    formPathArray.pop()
-    const form = get(state`${formPathArray.join('.')}`)
-    const field = new Field(fieldValue, form)
-    field._validate()
+    const field = new Field(fieldValue)
+    field._validate(get)
     return field
   })
 }
 
 export default function computedForm(formValueTag) {
-  return compute(formValueTag, formValue => {
+  return compute(formValueTag, (formValue, get) => {
     if (!formValue || typeof formValue !== 'object') {
       console.warn(
         `Cerebral Forms - Form value: ${formValueTag} did not resolve to an object`
       )
       return {}
     }
-    return new Form(formValue)
+
+    return new Form(formValue, get)
   })
 }

--- a/packages/node_modules/@cerebral/forms/src/index.test.js
+++ b/packages/node_modules/@cerebral/forms/src/index.test.js
@@ -224,17 +224,16 @@ describe('provider', () => {
     })
     controller.getSignal('test')()
   })
-  it('should be able to pass form into rules', () => {
+  it('should expose getter from computed', () => {
     const controller = Controller({
       providers: [
         FormsProvider({
           rules: {
-            isEqualField(value, form, field) {
-              assert.ok(form)
-              assert.equal(field, 'name2')
+            isEqualField(value, field, get) {
+              assert.ok(get)
+              assert.equal(field, 'form.name2')
               assert.equal(value, 'Ben')
-              assert.equal(form[field].value, 'Ben')
-              return form[field].value === value
+              return value === get(state`${field}.value`)
             },
           },
         }),
@@ -243,45 +242,7 @@ describe('provider', () => {
         form: {
           name: {
             value: 'Ben',
-            validationRules: ['isEqualField:name2'],
-          },
-          name2: {
-            value: 'Ben',
-          },
-        },
-      },
-      signals: {
-        test: [
-          ({ forms }) => {
-            const form = forms.get('form')
-            assert.equal(form.name.value, 'Ben')
-            assert.equal(form.name.isValid, true)
-          },
-        ],
-      },
-    })
-    controller.getSignal('test')()
-  })
-  it('should be able to use field computed with rules depending on form', () => {
-    const controller = Controller({
-      providers: [
-        FormsProvider({
-          rules: {
-            isEqualField(value, form, field) {
-              assert.ok(form)
-              assert.equal(field, 'name2')
-              assert.equal(value, 'Ben')
-              assert.equal(form[field].value, 'Ben2')
-              return form[field].value === value
-            },
-          },
-        }),
-      ],
-      state: {
-        form: {
-          name: {
-            value: 'Ben',
-            validationRules: ['isEqualField:name2'],
+            validationRules: ['isEqualField:form.name2'],
           },
           name2: {
             value: 'Ben2',

--- a/packages/node_modules/@cerebral/forms/src/rules.js
+++ b/packages/node_modules/@cerebral/forms/src/rules.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-useless-escape, no-control-regex */
+import { state } from 'cerebral/tags'
+
 const rules = {
   _errorMessages: {},
   isExisty(value) {
@@ -7,7 +9,7 @@ const rules = {
   isEmpty(value) {
     return value === ''
   },
-  regexp(value, _, regexp) {
+  regexp(value, regexp) {
     return !rules.isExisty(value) || rules.isEmpty(value) || regexp.test(value)
   },
   isValue(value) {
@@ -25,14 +27,12 @@ const rules = {
   isEmail(value) {
     return rules.regexp(
       value,
-      null,
       /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i
     )
   },
   isUrl(value) {
     return rules.regexp(
       value,
-      null,
       /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i
     )
   },
@@ -47,43 +47,42 @@ const rules = {
       return true
     }
 
-    return rules.regexp(value, null, /^[-+]?(?:\d*[.])?\d+$/)
+    return rules.regexp(value, /^[-+]?(?:\d*[.])?\d+$/)
   },
   isAlpha(value) {
-    return rules.regexp(value, null, /^[A-Z]+$/i)
+    return rules.regexp(value, /^[A-Z]+$/i)
   },
   isAlphanumeric(value) {
-    return rules.regexp(value, null, /^[0-9A-Z]+$/i)
+    return rules.regexp(value, /^[0-9A-Z]+$/i)
   },
   isInt(value) {
-    return rules.regexp(value, null, /^(?:[-+]?(?:0|[1-9]\d*))$/)
+    return rules.regexp(value, /^(?:[-+]?(?:0|[1-9]\d*))$/)
   },
   isFloat(value) {
     return rules.regexp(
       value,
-      null,
       /^(?:[-+]?(?:\d+))?(?:\.\d*)?(?:[eE][\+\-]?(?:\d+))?$/
     )
   },
   isWords(value) {
-    return rules.regexp(value, null, /^[A-Z\s]+$/i)
+    return rules.regexp(value, /^[A-Z\s]+$/i)
   },
   isSpecialWords(value) {
-    return rules.regexp(value, null, /^[A-Z\s\u00C0-\u017F]+$/i)
+    return rules.regexp(value, /^[A-Z\s\u00C0-\u017F]+$/i)
   },
-  isLength(value, form, length) {
+  isLength(value, length) {
     return value.length === length
   },
-  equals(value, form, eql) {
+  equals(value, eql) {
     return value === eql
   },
-  equalsField(value, form, field) {
-    return value === form[field].value
+  equalsField(value, field, get) {
+    return value === get(state`${field}.value`)
   },
-  maxLength(value, form, length) {
+  maxLength(value, length) {
     return value.length <= length
   },
-  minLength(value, form, length) {
+  minLength(value, length) {
     return (
       !rules.isExisty(value) || rules.isEmpty(value) || value.length >= length
     )

--- a/packages/node_modules/@cerebral/forms/src/rules.test.js
+++ b/packages/node_modules/@cerebral/forms/src/rules.test.js
@@ -271,77 +271,77 @@ describe('rules', () => {
 
   describe('isLength', () => {
     it('should return true due to length 4', () => {
-      assert.equal(rules.isLength('some', null, 4), true)
+      assert.equal(rules.isLength('some', 4), true)
     })
 
     it('should return false due to length 5', () => {
-      assert.equal(rules.isLength('some1', null, 4), false)
+      assert.equal(rules.isLength('some1', 4), false)
     })
   })
 
   describe('equals', () => {
     it('should return true due to same string', () => {
-      assert.equal(rules.equals('some', null, 'some'), true)
+      assert.equal(rules.equals('some', 'some'), true)
     })
 
     it('should return false due to not same string', () => {
-      assert.equal(rules.equals('some1', null, 'some'), false)
+      assert.equal(rules.equals('some1', 'some'), false)
     })
 
     it('should return true due to empty strings', () => {
-      assert.equal(rules.equals('', null, ''), true)
+      assert.equal(rules.equals('', ''), true)
     })
   })
 
   describe('equalsField', () => {
     it('should return true due to same value', () => {
-      const form = {
-        firstname: {
-          value: 'Bob',
-        },
-      }
-      assert.equal(rules.equalsField('Bob', form, 'firstname'), true)
+      assert.equal(
+        rules.equalsField('Bob', 'form.firstname', () => {
+          return 'Bob'
+        }),
+        true
+      )
     })
 
     it('should return false due to not same value', () => {
-      const form = {
-        firstname: {
-          value: 'Bob',
-        },
-      }
-      assert.equal(rules.equalsField('Bobby', form, 'firstname'), false)
+      assert.equal(
+        rules.equalsField('Bobby', 'form.firstname', () => {
+          return 'Bo'
+        }),
+        false
+      )
     })
   })
 
   describe('maxLength', () => {
     it('should return true due to length < 5', () => {
-      assert.equal(rules.maxLength('some', null, 5), true)
+      assert.equal(rules.maxLength('some', 5), true)
     })
 
     it('should return true due to length === 4', () => {
-      assert.equal(rules.maxLength('some', null, 4), true)
+      assert.equal(rules.maxLength('some', 4), true)
     })
 
     it('should return false due to length > 4', () => {
-      assert.equal(rules.maxLength('some1', null, 4), false)
+      assert.equal(rules.maxLength('some1', 4), false)
     })
   })
 
   describe('minLength', () => {
     it('should return false due to length < 5', () => {
-      assert.equal(rules.minLength('some', null, 5), false)
+      assert.equal(rules.minLength('some', 5), false)
     })
 
     it('should return true due to length === 4', () => {
-      assert.equal(rules.minLength('some', null, 4), true)
+      assert.equal(rules.minLength('some', 4), true)
     })
 
     it('should return true due to length > 4', () => {
-      assert.equal(rules.minLength('some1', null, 4), true)
+      assert.equal(rules.minLength('some1', 4), true)
     })
 
     it('should return true due to empty field', () => {
-      assert.equal(rules.minLength('', null, 4), true)
+      assert.equal(rules.minLength('', 4), true)
     })
   })
 })

--- a/packages/node_modules/@cerebral/forms/src/util.test.js
+++ b/packages/node_modules/@cerebral/forms/src/util.test.js
@@ -4,19 +4,19 @@ import checkHasValue from './utils/checkHasValue'
 
 describe('utils', () => {
   it('should return false due to not having a value', () => {
-    const hasValue = checkHasValue(null, '', ['isValue'])
+    const hasValue = checkHasValue('', ['isValue'])
     assert.equal(hasValue, false)
   })
 
   it('should return false due to non-numeric a value', () => {
-    const hasValue = checkHasValue(null, '123a', ['isValue', 'isNumeric'])
+    const hasValue = checkHasValue('123a', ['isValue', 'isNumeric'])
     assert.equal(hasValue, false)
   })
 
   it('should throw error for undefined validationRule', () => {
     assert.throws(
       () => {
-        checkHasValue(null, ' ', ['someValidationRule'])
+        checkHasValue(' ', ['someValidationRule'])
       },
       Error,
       'Rule someValidationRule is not found'
@@ -24,7 +24,7 @@ describe('utils', () => {
   })
 
   it('should return true due to having a value', () => {
-    const hasValue = checkHasValue(null, ' ', ['isValue'])
+    const hasValue = checkHasValue(' ', ['isValue'])
     assert.equal(hasValue, true)
   })
 })

--- a/packages/node_modules/@cerebral/forms/src/utils/checkHasValue.js
+++ b/packages/node_modules/@cerebral/forms/src/utils/checkHasValue.js
@@ -1,6 +1,6 @@
 import validate from './validate'
 
-export default function checkHasValue(form, value, isValueRules) {
-  const result = validate(form, value, isValueRules)
+export default function checkHasValue(value, isValueRules, get) {
+  const result = validate(value, isValueRules, get)
   return result.isValid
 }

--- a/packages/node_modules/@cerebral/forms/src/utils/runValidation.js
+++ b/packages/node_modules/@cerebral/forms/src/utils/runValidation.js
@@ -1,16 +1,16 @@
 import checkHasValue from './checkHasValue'
 import validate from './validate'
 
-export default function runValidation(field, form) {
+export default function runValidation(field, get) {
   const isValueRules = field.isValueRules || ['isValue']
-  const hasValue = checkHasValue(form, field.value, isValueRules)
-  const result = validate(form, field.value, field.validationRules)
+  const hasValue = checkHasValue(field.value, isValueRules, get)
+  const result = validate(field.value, field.validationRules, get)
   const isValid =
     result.isValid && ((field.isRequired && hasValue) || !field.isRequired)
 
   const validationResult = {
     isValid,
-    hasValue: checkHasValue(form, field.value, isValueRules),
+    hasValue: checkHasValue(field.value, isValueRules, get),
     failedRule: result.failedRule,
   }
 

--- a/packages/node_modules/@cerebral/forms/src/utils/validate.js
+++ b/packages/node_modules/@cerebral/forms/src/utils/validate.js
@@ -1,6 +1,6 @@
 import rules from '../rules.js'
 
-export default function validate(form, value, validationRules = []) {
+export default function validate(value, validationRules = [], get) {
   const initialValidation = {
     isValid: true,
   }
@@ -33,7 +33,7 @@ export default function validate(form, value, validationRules = []) {
       arg = undefined
     }
 
-    const isValid = rule(value, form, arg)
+    const isValid = rule(value, arg, get)
 
     return isValid
       ? initialValidation

--- a/packages/node_modules/@cerebral/forms/src/utils/validate.test.js
+++ b/packages/node_modules/@cerebral/forms/src/utils/validate.test.js
@@ -4,29 +4,29 @@ import assert from 'assert'
 
 describe('validate', () => {
   it('should return initialValidation when there is no validationRules', () => {
-    const result = validate(null, 'Ben')
+    const result = validate('Ben')
     assert.deepEqual(result, {
       isValid: true,
     })
   })
   it('should validate using validationRules', () => {
-    const result = validate(null, 'Ben', ['isNumeric'])
+    const result = validate('Ben', ['isNumeric'])
     assert.equal(result.isValid, false)
     assert.equal(result.failedRule.name, 'isNumeric')
   })
   it('should validate with multiple rules', () => {
-    const result = validate(null, 'Ben', ['isNumeric', 'minLength:2'])
+    const result = validate('Ben', ['isNumeric', 'minLength:2'])
     assert.equal(result.isValid, false)
     assert.equal(result.failedRule.name, 'isNumeric')
   })
   it('should return initialValidation when there is no failed rules', () => {
-    const result = validate(null, 'Ben', ['isValue', 'minLength:2'])
+    const result = validate('Ben', ['isValue', 'minLength:2'])
     assert.deepEqual(result, {
       isValid: true,
     })
   })
   it('should validate when validationRule arg is not JSON parsable', () => {
-    const result = validate(null, 'Ben', ['equals:Ben'])
+    const result = validate('Ben', ['equals:Ben'])
     assert.deepEqual(result, {
       isValid: true,
     })


### PR DESCRIPTION
This change is breaking IF you have created custom rules using the second/third argument. Now the args to rules are: `value`, `arg` and `get`. The `get` is from the computed allowing a rule to depend on any state or props passed to component, also tracking changes to it for rerender. This fixes issues where one field depends on an other etc.