### PR TITLE
fix(http): fix error indexOf of undefined, if there are no headers

### DIFF
--- a/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
+++ b/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
@@ -32,7 +32,8 @@ export default {
 
     if (
       result &&
-      xhr.getResponseHeader('Content-Type').indexOf('application/json') >= 0
+      (xhr.getResponseHeader('Content-Type') || '')
+        .indexOf('application/json') >= 0
     ) {
       result = JSON.parse(xhr.responseText)
     }


### PR DESCRIPTION
The error occurs when there are no headers in the server response settings. We get "Uncaught TypeError: Can not read property" indexOf "undefined"