### PR TITLE
feat(Views): Expose cerebral controller in Angular.js service

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -235,9 +235,15 @@ angular.component('myComponent', {
   controller: connect({
     foo: state`foo`,
     click: signal`clicked`
-  }, 'myComponent', function MyController () {
+  }, 'MyComponent', ['cerebral', function MyController (cerebral) {
+
+    // In some cases you might need access to cerebral's controller.
+    // You can inject the cerebral angular service and
+    // access it's controller property anywhere in your app
+    cerebral.controller.getSignal('mySignal')()
+
     // Optionally add custom behaviour to controller
-  })
+  }])
 })
 ```
 Since angular doesn't expose the component name,

--- a/packages/node_modules/cerebral/src/views/angularjs/module.js
+++ b/packages/node_modules/cerebral/src/views/angularjs/module.js
@@ -88,6 +88,7 @@ export default angular => {
               displayName
             )
           },
+          controller,
         }
       },
     ]


### PR DESCRIPTION
Having direct access to cerebral's controller is crucial for many use cases within Angular. This PR exposes it as a `controller` property on the `cerebral` service.

Also updated docs with an example.