### PR TITLE
feat(UniversalController): allow multiple runs of Signals.

### DIFF
--- a/packages/node_modules/cerebral/src/UniversalController.js
+++ b/packages/node_modules/cerebral/src/UniversalController.js
@@ -1,5 +1,4 @@
 import Controller from './Controller'
-import { throwError } from './utils'
 
 class UniversalController extends Controller {
   constructor(controllerOptions) {
@@ -22,16 +21,10 @@ class UniversalController extends Controller {
       }, {})
     )
 
+    this.hasRun = true
     return `<script>window.CEREBRAL_STATE = ${state}</script>`
   }
   run(sequence, payload) {
-    if (this.hasRun) {
-      throwError(
-        'You can not run the universal controller more than once, create a new one'
-      )
-    }
-    this.hasRun = true
-
     return super.run('UniversalController.run', sequence, payload)
   }
 }

--- a/packages/node_modules/cerebral/src/UniversalController.test.js
+++ b/packages/node_modules/cerebral/src/UniversalController.test.js
@@ -35,7 +35,14 @@ describe('UniversalController', () => {
       '<script>window.CEREBRAL_STATE = {"foo":"bar2"}</script>'
     )
   })
-  it('should throw error when using run twice', () => {
+  it('sets its hasRun flag to true in getScript()', () => {
+    const controller = new UniversalController({})
+    controller.run([function dummy() {}])
+    assert.equal(controller.hasRun, false)
+    controller.getScript()
+    assert.equal(controller.hasRun, true)
+  })
+  it('should allow multiple runs', () => {
     const controller = new UniversalController({
       state: {
         foo: 'bar',
@@ -43,15 +50,18 @@ describe('UniversalController', () => {
     })
     controller.run([
       function stateUpdate({ state }) {
-        state.set('foo', state.get('foo') + '!')
+        state.set('foo', 'bar1')
       },
     ])
-    assert.throws(() => {
-      controller.run([
-        function stateUpdate({ state }) {
-          state.set('foo', state.get('foo') + '!')
-        },
-      ])
-    })
+    controller.run([
+      function stateUpdate({ state }) {
+        state.set('foo', 'bar2')
+      },
+    ])
+    assert.deepEqual(controller.getState(), { foo: 'bar2' })
+    assert.deepEqual(controller.changes, [
+      { path: ['foo'], forceChildPathUpdates: true },
+      { path: ['foo'], forceChildPathUpdates: true },
+    ])
   })
 })


### PR DESCRIPTION
Add an option to skip runOnce check in UniversalController.