### PR TITLE
fix(function-tree): errors should not be rethrown in promise catch

### DIFF
--- a/packages/node_modules/function-tree/src/FunctionTree.js
+++ b/packages/node_modules/function-tree/src/FunctionTree.js
@@ -182,6 +182,10 @@ class FunctionTreeExecution {
           }
         })
         .catch(function(result) {
+          if (execution.hasThrown) {
+            return
+          }
+
           if (result instanceof Error) {
             execution.hasThrown = true
             errorCallback(


### PR DESCRIPTION
Fixes https://github.com/cerebral/cerebral/issues/984