### PR TITLE
feat(cerebral): Immutable model

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/eventemitter3": "1.2.0",
     "addressbar": "1.0.3",
     "aphrodite": "1.2.0",
+    "baobab": "^2.4.3",
     "bulma": "0.2.3",
     "chalk": "1.1.3",
     "classnames": "2.2.5",

--- a/packages/node_modules/cerebral/src/Controller.js
+++ b/packages/node_modules/cerebral/src/Controller.js
@@ -1,7 +1,7 @@
 import DependencyStore from './DependencyStore'
 import FunctionTree from 'function-tree'
 import Module from './Module'
-import Model from './Model'
+import DefaultModel from './Model'
 import {
   ensurePath,
   isDeveloping,
@@ -50,6 +50,7 @@ class Controller extends FunctionTree {
       router,
       devtools = null,
       options = {},
+      Model = DefaultModel,
     } = config
     const getSignal = this.getSignal
 

--- a/packages/node_modules/cerebral/src/ImmutableModel.js
+++ b/packages/node_modules/cerebral/src/ImmutableModel.js
@@ -1,0 +1,92 @@
+import Baobab from 'baobab'
+
+class ImmutableModel {
+  constructor(initialState = {}, devtools = null) {
+    this.devtools = devtools
+
+    this.state = new Baobab(initialState)
+    this.changedPaths = []
+  }
+  /*
+    Returns array of changes
+  */
+  flush() {
+    const changes = this.changedPaths.slice()
+
+    this.changedPaths = []
+
+    return changes
+  }
+  get(path = []) {
+    return this.state.get(path)
+  }
+  set(path, value) {
+    this.state.set(path, value)
+    this.changedPaths.push({
+      forceChildPathUpdates: true,
+      path,
+    })
+  }
+  toggle(path) {
+    this.state.set(path, !this.state.get(path))
+    this.changedPaths.push({
+      path,
+    })
+  }
+  push(path, value) {
+    this.state.push(path, value)
+    this.changedPaths.push({
+      path,
+    })
+  }
+  merge(path, ...values) {
+    values.forEach(value => {
+      this.state.merge(path, value)
+      for (let prop in value) {
+        this.changedPaths.push({
+          forceChildPathUpdates: true,
+          path: path.concat(prop),
+        })
+      }
+    })
+  }
+  pop(path) {
+    this.state.pop(path)
+    this.changedPaths.push({
+      path,
+    })
+  }
+  shift(path) {
+    this.state.shift(path)
+    this.changedPaths.push({
+      path,
+    })
+  }
+  unshift(path, value) {
+    this.state.unshift(path, value)
+    this.changedPaths.push({
+      path,
+    })
+  }
+  splice(path, ...args) {
+    this.state.splice(path, args)
+    this.changedPaths.push({
+      path,
+    })
+  }
+  unset(path) {
+    this.state.unset(path)
+    this.changedPaths.push({
+      forceChildPathUpdates: true,
+      path,
+    })
+  }
+  concat(path, value) {
+    this.state.concat(path, value)
+    this.changedPaths.push({
+      path,
+    })
+  }
+}
+
+export default ImmutableModel

--- a/packages/node_modules/cerebral/src/ImmutableModel.test.js
+++ b/packages/node_modules/cerebral/src/ImmutableModel.test.js
@@ -1,0 +1,251 @@
+/* eslint-env mocha */
+import Model from './ImmutableModel'
+import assert from 'assert'
+
+describe('Model', () => {
+  it('should instantiate with initial state', () => {
+    const model = new Model({
+      foo: 'bar',
+    })
+    assert.equal(model.get(['foo']), 'bar')
+  })
+  it('should instantiate with initial state', () => {
+    const model = new Model({
+      foo: 'bar',
+    })
+    assert.equal(model.get(['foo']), 'bar')
+  })
+  it('should grab nested state', () => {
+    const model = new Model({
+      foo: {
+        bar: 'value',
+      },
+    })
+    assert.equal(model.get(['foo', 'bar']), 'value')
+  })
+  it('should be able to flush changed paths', () => {
+    const model = new Model({
+      foo: {
+        bar: 'value',
+      },
+    })
+    model.set(['foo', 'bar'], 'value2')
+    assert.deepEqual(model.flush(), [
+      {
+        path: ['foo', 'bar'],
+        forceChildPathUpdates: true,
+      },
+    ])
+  })
+  it('should flush same path changes correctly', () => {
+    const model = new Model({
+      foo: {
+        bar: 'value',
+      },
+    })
+    model.set(['foo', 'bar'], 'value2')
+    model.set(['foo', 'bar'], 'value3')
+    assert.deepEqual(model.flush(), [
+      {
+        path: ['foo', 'bar'],
+        forceChildPathUpdates: true,
+      },
+      {
+        path: ['foo', 'bar'],
+        forceChildPathUpdates: true,
+      },
+    ])
+  })
+  // it('should throw when updating invalid path', () => {
+  //   const model = new Model({
+  //     foo: 'bar',
+  //   })
+  //   assert.throws(() => {
+  //     model.set(['foo', 'bar'], 'baz2')
+  //   })
+  // })
+  // it('should throw when updating invalid nested path', () => {
+  //   const model = new Model({
+  //     foo: 'bar',
+  //   })
+  //   assert.throws(() => {
+  //     model.set(['foo', 'bar', 'baz'], 'baz2')
+  //   })
+  // })
+
+  describe('SET', () => {
+    it('should be able to set state', () => {
+      const model = new Model({})
+      model.set(['foo'], 'bar')
+      assert.deepEqual(model.get(), { foo: 'bar' })
+    })
+  })
+  describe('TOGGLE', () => {
+    it('should be able to toggle value', () => {
+      const model = new Model({
+        foo: true,
+      })
+      model.toggle(['foo'])
+      assert.deepEqual(model.get(), { foo: false })
+    })
+  })
+  describe('PUSH', () => {
+    it('should be able to push to array', () => {
+      const model = new Model({
+        list: [],
+      })
+      model.push(['list'], 'bar')
+      assert.deepEqual(model.get(), { list: ['bar'] })
+    })
+  })
+  describe('MERGE', () => {
+    it('should be able to merge objects', () => {
+      const model = new Model({
+        foo: {
+          valA: 'foo',
+        },
+      })
+      model.merge(['foo'], { valB: 'bar' })
+      assert.deepEqual(model.get(), { foo: { valA: 'foo', valB: 'bar' } })
+    })
+    it('should flush changes to merged keys when object exists', () => {
+      const model = new Model({
+        foo: {
+          valA: 'foo',
+        },
+      })
+      model.merge(['foo'], { valB: 'bar' })
+      assert.deepEqual(model.flush(), [
+        {
+          path: ['foo', 'valB'],
+          forceChildPathUpdates: true,
+        },
+      ])
+    })
+    // it('should flush change on object only if no existing object', () => {
+    //   const model = new Model({
+    //     foo: null,
+    //   })
+    //   model.merge(['foo'], { valB: 'bar' })
+    //   assert.deepEqual(model.flush(), [
+    //     {
+    //       path: ['foo'],
+    //       forceChildPathUpdates: true,
+    //     },
+    //   ])
+    // })
+  })
+  describe('POP', () => {
+    it('should be able to pop arrays', () => {
+      const model = new Model({
+        list: ['foo', 'bar'],
+      })
+      model.pop(['list'])
+      assert.deepEqual(model.get(), { list: ['foo'] })
+    })
+  })
+  describe('SHIFT', () => {
+    it('should be able to shift arrays', () => {
+      const model = new Model({
+        list: ['foo', 'bar'],
+      })
+      model.shift(['list'])
+      assert.deepEqual(model.get(), { list: ['bar'] })
+    })
+  })
+  describe('UNSHIFT', () => {
+    it('should be able to unshift arrays', () => {
+      const model = new Model({
+        list: ['foo'],
+      })
+      model.unshift(['list'], 'bar')
+      assert.deepEqual(model.get(), { list: ['bar', 'foo'] })
+    })
+  })
+  describe('SPLICE', () => {
+    it('should be able to splice arrays', () => {
+      const model = new Model({
+        list: ['foo', 'bar'],
+      })
+      model.splice(['list'], 1, 1, 'bar2')
+      assert.deepEqual(model.get(), { list: ['foo', 'bar2'] })
+    })
+  })
+  describe('UNSET', () => {
+    it('should be able to unset keys', () => {
+      const model = new Model({
+        foo: 'bar',
+      })
+      model.unset(['foo'])
+      assert.deepEqual(model.get(), {})
+    })
+    it('should flush unset paths', () => {
+      const model = new Model({
+        foo: {
+          bar: 'value',
+        },
+      })
+      model.unset(['foo', 'bar'])
+      assert.deepEqual(model.flush(), [
+        {
+          path: ['foo', 'bar'],
+          forceChildPathUpdates: true,
+        },
+      ])
+    })
+  })
+  describe('CONCAT', () => {
+    it('should be able to concat array', () => {
+      const model = new Model({
+        foo: ['foo'],
+      })
+      model.concat(['foo'], ['bar'])
+      assert.deepEqual(model.get(), { foo: ['foo', 'bar'] })
+    })
+  })
+  describe('Serializable', () => {
+    // it('should make value forceSerializable when devtools are attached', () => {
+    //   const model = new Model(
+    //     {
+    //       foo: 'bar',
+    //     },
+    //     { allowedTypes: [Date] }
+    //   )
+    //   model.set(['foo'], new Date())
+    //   assert.equal(model.state.foo.toJSON(), '[Date]')
+    // })
+    // it('should throw error if value inserted is not serializable', () => {
+    //   const model = new Model(
+    //     {
+    //       foo: 'bar',
+    //     },
+    //     {}
+    //   )
+    //   assert.throws(() => {
+    //     model.set(['foo'], new Date())
+    //   })
+    // })
+    it('should NOT throw error if value inserted is serializable', () => {
+      const model = new Model(
+        {
+          foo: 'bar',
+        },
+        {}
+      )
+      assert.doesNotThrow(() => {
+        model.set(['foo'], [])
+      })
+    })
+    it('should NOT throw error if passing allowed type in devtools', () => {
+      const model = new Model(
+        {
+          foo: 'bar',
+        },
+        { allowedTypes: [Date] }
+      )
+      assert.doesNotThrow(() => {
+        model.set(['foo'], new Date())
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add support for overriding the default Cerebral model and include an alternative based on Baobab.

```js
import { Controller } from 'cerebral';
import ImmutableModel from 'cerebral/lib/ImmutableModel';

export default Controller({
    Model: ImmutableModel, // replaces the default
    state: {},
    modules: {}
});
```

This makes is possible for complex projects to move from Cerebral 1.0, which was immutable by default, without having to make a complete rewrite. It's also a safer alternative to the default store for projects who appreciate the benefits of immutability and can accept the performance overhead.