### PR TITLE
feat(Controller): refactor to base controller and add mobx state tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "url-mapper": "1.1.1",
     "uuid": "2.0.3",
     "chokidar": "1.6.1",
-    "prism": "4.1.2"
+    "prism": "4.1.2",
+    "mobx": "3.2.0",
+    "mobx-state-tree": "0.9.1"
   },
   "lint-staged": {
     "*.js": [

--- a/packages/node_modules/cerebral-mobx/.babelrc
+++ b/packages/node_modules/cerebral-mobx/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["version-transform"],
+  "env": {
+    "production": {
+      "ignore": [
+        "**/*.test.js"
+      ]
+    }
+  }
+}

--- a/packages/node_modules/cerebral-mobx/README.md
+++ b/packages/node_modules/cerebral-mobx/README.md
@@ -1,0 +1,107 @@
+# cerebral-mobx
+
+Combine Cerebral with Mobx state-tree.
+
+## State and model
+
+With Mobx state tree you also define models, in addition to state. You do this directly in your modules:
+
+*modules/app.js*
+```js
+import { types } from 'mobx-state-tree'
+import {set} from 'cerebral/operators'
+import {state, props} from 'cerebral/tags'
+
+const Box = types.model('Box', {
+  id: types.identifier(),
+  name: '',
+  x: 0,
+  y: 0,
+  get width() {
+    return this.name.length * 15
+  }
+})
+
+export default {
+  model: {
+    boxes: types.map(Box),
+    selection: types.reference(Box)    
+  },
+  state: {
+    boxes: {},
+    selection: null
+  },
+  signals: {
+    boxSelected: set(state`app.selection`, state`app.boxes.${props`boxKey`}`)
+  }
+}
+```
+
+## Instantiate
+
+Instead of creating the controller from `cerebral`, you create it from this package:
+
+```js
+import {Controller} from 'cerebral-mobx'
+import app from './modules/app'
+
+export default Controller({
+  modules: {app}
+  // Other config options are the same
+})
+```
+
+## Accessing state and props in components
+
+For example using React you will need the package [mobx-react]() and use the **provide()** method of the controller:
+
+*main.js*
+```js
+import React from 'react'
+import {render} from 'react-dom'
+import controller from './controller'
+import {Provider} from 'mobx-react'
+import App from './components/App'
+
+render((
+  <Provider {...controller.provide()}>
+    <App />
+  </Provider>
+))
+```
+
+*App.js*
+```js
+import React from 'react'
+import {observer, inject} from 'mobx-react'
+
+@observer
+@inject('store', 'signals')
+class App extends React.Component {
+  renderBoxes () {
+    const {store, signals} = this.props
+
+    return Object.keys(store.app.boxes).map((boxKey) => {
+      return (
+        <li onClick={() => signals.app.boxSelected({boxKey})}>
+          {store.app.boxes[boxKey].name}
+        </li>
+      )
+    })
+  }
+  render () {
+    const {store} = this.props
+
+    return (
+      <div>
+        <h1>{store.app.selection && store.app.selection.name}</h1>
+        <ul>
+          {this.renderBoxes()}
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default App
+```

--- a/packages/node_modules/cerebral-mobx/index.js
+++ b/packages/node_modules/cerebral-mobx/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib')

--- a/packages/node_modules/cerebral-mobx/package.json
+++ b/packages/node_modules/cerebral-mobx/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "cerebral-mobx",
+  "version": "0.0.0-next",
+  "description": "Combine Cerebral with Mobx state tree",
+  "main": "index.js",
+  "author": "Christian Alfoni <christianalfoni@gmail.com>",
+  "contributors": [
+    "Aleksey Guryanov <gurianov@gmail.com>"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cerebral/cerebral.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cerebral/cerebral/issues"
+  },
+  "homepage": "http://cerebral.github.io/cerebral-website",
+  "peerDependencies": {
+    "cerebral": "^2.0.0-beta.3",
+    "mobx": "^3.2.0",
+    "mobx-state-tree": "^0.9.1"
+  },
+  "scripts": {
+    "build": "cross-env BABEL_ENV=production babel src/ --out-dir=lib/ -s",
+    "coverage": "nyc --reporter=lcov --reporter=json npm run test",
+    "prepublish": "npm run build"
+  },
+  "nyc": {
+    "exclude": [
+      "node_modules",
+      "lib",
+      "tests",
+      "**/*.test.js",
+      "**/testHelper.js"
+    ]
+  },
+  "devDependencies": {
+    "prop-types": "^15.5.10"
+  }
+}

--- a/packages/node_modules/cerebral-mobx/src/Model.js
+++ b/packages/node_modules/cerebral-mobx/src/Model.js
@@ -1,0 +1,151 @@
+import { unprotect, protect, types } from 'mobx-state-tree'
+import {
+  isSerializable,
+  throwError,
+  forceSerializable,
+  extractModulesProp,
+} from 'cerebral/lib/utils'
+import StateProvider from './StateProvider'
+
+class Model {
+  constructor(controller) {
+    const state = extractModulesProp('root', controller.module, 'state')
+    this.StateProvider = StateProvider
+    this.state = types
+      .model(
+        'Store',
+        extractModulesProp('root', controller.module, 'model', (key, model) => {
+          return types.model(key, model)
+        })
+      )
+      .create(state)
+  }
+  updateIn(path, cb, forceChildPathUpdates = false) {
+    if (!path.length) {
+      cb(this.state, this, 'state')
+
+      return
+    }
+
+    unprotect(this.state)
+    path.reduce((currentState, key, index) => {
+      if (index === path.length - 1) {
+        const currentValue = 'get' in currentState
+          ? currentState.get(key)
+          : currentState[key]
+
+        cb(currentValue, currentState, key)
+      } else if (
+        !('get' in currentState ? currentState.get(key) : currentState[key])
+      ) {
+        throwError(
+          `The path "${path.join(
+            '.'
+          )}" is invalid, can not update state. Does the path "${path
+            .splice(0, path.length - 1)
+            .join('.')}" exist?`
+        )
+      }
+
+      return 'get' in currentState ? currentState.get(key) : currentState[key]
+    }, this.state)
+    protect(this.state)
+  }
+  /*
+    Checks if value is serializable, if turned on
+  */
+  verifyValue(value, path) {
+    if (this.devtools && !isSerializable(value, this.devtools.allowedTypes)) {
+      throwError(
+        `You are passing a non serializable value into the state tree on path "${path.join(
+          '.'
+        )}"`
+      )
+    }
+    if (this.devtools) {
+      forceSerializable(value)
+    }
+  }
+  verifyValues(values, path) {
+    if (this.devtools) {
+      values.forEach(value => {
+        this.verifyValue(value, path)
+      })
+    }
+  }
+  get(path = []) {
+    return path.reduce((currentState, key) => {
+      return 'get' in currentState ? currentState.get(key) : currentState[key]
+    }, this.state)
+  }
+  set(path, value) {
+    this.verifyValue(value, path)
+    this.updateIn(
+      path,
+      (_, parent, key) => {
+        parent[key] = value
+      },
+      true
+    )
+  }
+  push(path, value) {
+    this.verifyValue(value, path)
+    this.updateIn(path, array => {
+      array.push(value)
+    })
+  }
+  merge(path, ...values) {
+    const value = Object.assign(...values)
+
+    // If we already have an object we make it behave
+    // like multiple sets, indicating a change to very key.
+    // If no value it should indicate that we are setting
+    // a new object
+    if (this.get(path)) {
+      for (let prop in value) {
+        this.set(path.concat(prop), value[prop])
+      }
+    } else {
+      this.set(path, value)
+    }
+  }
+  pop(path) {
+    this.updateIn(path, array => {
+      array.pop()
+    })
+  }
+  shift(path) {
+    this.updateIn(path, array => {
+      array.shift()
+    })
+  }
+  unshift(path, value) {
+    this.verifyValue(value, path)
+    this.updateIn(path, array => {
+      array.unshift(value)
+    })
+  }
+  splice(path, ...args) {
+    this.verifyValues(args, path)
+    this.updateIn(path, array => {
+      array.splice(...args)
+    })
+  }
+  unset(path) {
+    this.updateIn(
+      path,
+      (_, parent, key) => {
+        delete parent[key]
+      },
+      true
+    )
+  }
+  concat(path, value) {
+    this.verifyValue(value, path)
+    this.updateIn(path, (array, parent, key) => {
+      parent[key] = array.concat(value)
+    })
+  }
+}
+
+export default Model

--- a/packages/node_modules/cerebral-mobx/src/StateProvider.js
+++ b/packages/node_modules/cerebral-mobx/src/StateProvider.js
@@ -1,0 +1,80 @@
+import { ensurePath, cleanPath, throwError } from 'cerebral/lib/utils'
+
+function StateProviderFactory(devtools) {
+  const methods = [
+    'get',
+    'set',
+    'toggle',
+    'push',
+    'merge',
+    'pop',
+    'shift',
+    'unshift',
+    'splice',
+    'unset',
+    'concat',
+  ]
+  let provider = null
+
+  function createProvider(context) {
+    const model = context.controller.model
+
+    return methods.reduce((currentStateContext, methodKey) => {
+      currentStateContext[methodKey] = (...args) => {
+        const path = ensurePath(cleanPath(args.shift()))
+
+        if (methodKey === 'get') {
+          return model.get(path)
+        }
+
+        return model[methodKey].apply(model, [path].concat(args))
+      }
+
+      return currentStateContext
+    }, {})
+  }
+
+  function StateProvider(context, functionDetails) {
+    context.state = provider = provider || createProvider(context)
+
+    if (context.debugger) {
+      context.state = methods.reduce((currentState, methodKey) => {
+        if (methodKey === 'get' || methodKey === 'compute') {
+          currentState[methodKey] = provider[methodKey]
+        } else {
+          const originFunc = provider[methodKey]
+
+          currentState[methodKey] = (...args) => {
+            const argsCopy = args.slice()
+            const path = ensurePath(argsCopy.shift())
+
+            context.debugger.send({
+              datetime: Date.now(),
+              type: 'mutation',
+              color: '#333',
+              method: methodKey,
+              args: [path, ...argsCopy],
+            })
+
+            try {
+              originFunc.apply(context.controller.model, args)
+            } catch (e) {
+              const signalName = context.execution.name
+              throwError(
+                `The Signal "${signalName}" with action "${functionDetails.name}" has an error: ${e.message}`
+              )
+            }
+          }
+        }
+
+        return currentState
+      }, {})
+    }
+
+    return context
+  }
+
+  return StateProvider
+}
+
+export default StateProviderFactory

--- a/packages/node_modules/cerebral-mobx/src/index.js
+++ b/packages/node_modules/cerebral-mobx/src/index.js
@@ -1,0 +1,38 @@
+import { BaseController } from 'cerebral'
+import Model from './Model'
+import { extractModulesProp, throwError } from 'cerebral/lib/utils'
+
+class MobxController extends BaseController {
+  constructor(config) {
+    super(config)
+    this.provide = function() {
+      return {
+        store: this.model.state,
+        signals: extractModulesProp(
+          'root',
+          this.module,
+          'signals',
+          (key, signals) => {
+            return Object.keys(signals).reduce((runSignals, signalKey) => {
+              runSignals[signalKey] = signals[signalKey].run
+
+              return runSignals
+            }, {})
+          }
+        ),
+      }
+    }
+  }
+}
+
+export function Controller(config) {
+  if (config.state || config.signals || config.model) {
+    throwError(
+      'The Mobx Controller does not support root state, signals or model. Create a module'
+    )
+  }
+
+  config.Model = Model
+
+  return new MobxController(config)
+}

--- a/packages/node_modules/cerebral-mobx/src/index.test.js
+++ b/packages/node_modules/cerebral-mobx/src/index.test.js
@@ -1,0 +1,85 @@
+/* eslint-env mocha */
+import { Controller } from './'
+import { set } from 'cerebral/operators'
+import { state } from 'cerebral/tags'
+import { types } from 'mobx-state-tree'
+import assert from 'assert'
+
+describe('MobxController', () => {
+  it('should instantiate with initial state', () => {
+    const controller = Controller({
+      modules: {
+        app: {
+          model: {
+            foo: types.string,
+          },
+          state: {
+            foo: 'bar',
+          },
+        },
+      },
+    })
+
+    assert.deepEqual(controller.provide().store.toJSON(), {
+      app: { foo: 'bar' },
+    })
+  })
+  it('should throw when changing state directly', () => {
+    const controller = Controller({
+      modules: {
+        app: {
+          model: {
+            foo: types.string,
+          },
+          state: {
+            foo: 'bar',
+          },
+        },
+      },
+    })
+
+    assert.throws(() => {
+      controller.provide().store.app.foo = 'bar2'
+    })
+  })
+  it('should allow changing state through signals', () => {
+    const controller = Controller({
+      modules: {
+        app: {
+          model: {
+            foo: types.string,
+          },
+          state: {
+            foo: 'bar',
+          },
+          signals: {
+            test: set(state`app.foo`, 'bar2'),
+          },
+        },
+      },
+    })
+
+    controller.provide().signals.app.test()
+    assert.equal(controller.provide().store.app.foo, 'bar2')
+  })
+  it('should provide store and signals', () => {
+    const controller = Controller({
+      modules: {
+        app: {
+          model: {
+            foo: types.string,
+          },
+          state: {
+            foo: 'bar',
+          },
+          signals: {
+            test: set(state`app.foo`, 'bar2'),
+          },
+        },
+      },
+    })
+
+    assert.ok(typeof controller.provide().signals.app.test === 'function')
+    assert.equal(controller.provide().store.app.foo, 'bar')
+  })
+})

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -1,15 +1,19 @@
-import DependencyStore from './DependencyStore'
-import BaseController from './BaseController'
+import FunctionTree from 'function-tree'
 import Module from './Module'
-import Model from './Model'
 import {
   ensurePath,
+  isDeveloping,
+  throwError,
   isSerializable,
   forceSerializable,
   isObject,
-  cleanPath,
+  getProviders,
   getModule,
 } from './utils'
+import VerifyPropsProvider from './providers/VerifyProps'
+import DebuggerProvider from './providers/Debugger'
+import ControllerProvider from './providers/Controller'
+import ResolveProvider from './providers/Resolve'
 
 /*
   The controller is where everything is attached. The devtools
@@ -17,85 +21,67 @@ import {
   The controller creates the function tree that will run all signals,
   based on top level providers and providers defined in modules
 */
-class Controller extends BaseController {
+class BaseController extends FunctionTree {
   constructor(config) {
-    super(
-      Object.assign(
-        {
-          Model,
-        },
-        config
-      )
-    )
+    super()
+    const {
+      state = {},
+      signals = {},
+      providers = [],
+      modules = {},
+      devtools = null,
+      options = {},
+    } = config
+    const getSignal = this.getSignal
 
-    this.componentDependencyStore = new DependencyStore()
-    this.flush = this.flush.bind(this)
-
-    this.on('asyncFunction', (execution, funcDetails) => {
-      if (!funcDetails.isParallel) {
-        this.flush()
-      }
-    })
-    this.on('parallelStart', () => this.flush())
-    this.on(
-      'parallelProgress',
-      (execution, currentPayload, functionsResolving) => {
-        if (functionsResolving === 1) {
-          this.flush()
-        }
-      }
-    )
-    this.on('end', () => this.flush())
-  }
-  /*
-    Whenever components needs to be updated, this method
-    can be called
-  */
-  flush(force) {
-    const changes = this.model.flush()
-
-    if (!force && !Object.keys(changes).length) {
-      return
-    }
-
-    this.updateComponents(changes, force)
-    this.emit('flush', changes, Boolean(force))
-  }
-  updateComponents(changes, force) {
-    let componentsToRender = []
-
-    if (force) {
-      componentsToRender = this.componentDependencyStore.getAllUniqueEntities()
-    } else {
-      componentsToRender = this.componentDependencyStore.getUniqueEntities(
-        changes
+    this.getSignal = () => {
+      throwError(
+        'You are grabbing a signal before controller has initialized, please wait for "initialized" event'
       )
     }
 
-    const start = Date.now()
-    componentsToRender.forEach(component => {
-      if (this.devtools) {
-        this.devtools.updateComponentsMap(component)
-      }
-      component.onUpdate(changes, force)
+    this.options = options
+    this.catch = config.catch || null
+    this.devtools = devtools
+    this.module = new Module(this, [], {
+      state,
+      signals,
+      modules,
     })
-    const end = Date.now()
+    this.model = new config.Model(this)
 
-    if (this.devtools && componentsToRender.length) {
-      this.devtools.sendComponentsMap(componentsToRender, changes, start, end)
+    this.contextProviders = [ControllerProvider(this)]
+      .concat(this.devtools ? [DebuggerProvider()] : [])
+      .concat(isDeveloping() ? [VerifyPropsProvider] : [])
+      .concat(this.model.StateProvider(this.devtools), ResolveProvider())
+      .concat(providers.concat(getProviders(this.module)))
+
+    if (typeof window !== 'undefined' && window.CEREBRAL_STATE) {
+      Object.keys(window.CEREBRAL_STATE).forEach(statePath => {
+        this.model.set(ensurePath(statePath), window.CEREBRAL_STATE[statePath])
+      })
     }
-  }
-  /*
-    Conveniance method for grabbing the model
-  */
-  getModel() {
-    return this.model
-  }
-  /*
-    Method called by view to grab state
-  */
-  getState(path) {
-    return this.model.get(ensurePath(cleanPath(path)))
+
+    if (this.devtools) {
+      this.devtools.init(this)
+    }
+
+    if (
+      !this.devtools &&
+      isDeveloping() &&
+      typeof navigator !== 'undefined' &&
+      /Chrome/.test(navigator.userAgent)
+    ) {
+      console.warn(
+        'You are not using the Cerebral devtools. It is highly recommended to use it in combination with the debugger: http://cerebraljs.com/docs/get_started/debugger.html'
+      )
+    }
+
+    this.getSignal = getSignal
+
+    this.model.flush()
+
+    this.emit('initialized')
   }
   /*
     Uses function tree to run the array and optional
@@ -129,7 +115,7 @@ class Controller extends BaseController {
 
     this.run(name, signal, payload, error => {
       if (error) {
-        const signalPath = ensurePath(error.execution.name)
+        const signalPath = error.execution.name.split('.')
         let signalCatch = signalPath.reduce((currentModule, key, index) => {
           if (index === signalPath.length - 1 && currentModule.signals[key]) {
             return currentModule.signals[key].catch
@@ -177,18 +163,16 @@ class Controller extends BaseController {
     return signal && signal.run
   }
   addModule(path, module) {
-    const pathArray = ensurePath(path)
+    const pathArray = path.split('.')
     const moduleKey = pathArray.pop()
     const parentModule = getModule(pathArray, this.module)
-    parentModule.modules[moduleKey] = new Module(this, ensurePath(path), module)
+    parentModule.modules[moduleKey] = new Module(this, path.split('.'), module)
 
     if (module.provider) {
       this.contextProviders.push(module.provider)
     }
 
-    this.emit('moduleAdded', path.split('.'), module)
-
-    this.flush()
+    this.emit('moduleAdded', path, module)
   }
   removeModule(path) {
     if (!path) {
@@ -196,7 +180,7 @@ class Controller extends BaseController {
       return null
     }
 
-    const pathArray = ensurePath(path)
+    const pathArray = path.split('.')
     const moduleKey = pathArray.pop()
     const parentModule = getModule(pathArray, this.module)
 
@@ -211,10 +195,8 @@ class Controller extends BaseController {
 
     delete parentModule.modules[moduleKey]
 
-    this.emit('moduleRemoved', ensurePath(path), module)
-
-    this.flush()
+    this.emit('moduleRemoved', path, module)
   }
 }
 
-export default Controller
+export default BaseController

--- a/packages/node_modules/cerebral/src/Model.js
+++ b/packages/node_modules/cerebral/src/Model.js
@@ -5,16 +5,36 @@ import {
   throwError,
   forceSerializable,
   addCerebralStateKey,
+  extractModulesProp,
 } from './utils'
+import StateProvider from './providers/State'
 
 class Model {
-  constructor(initialState = {}, devtools = null) {
-    this.devtools = devtools
+  constructor(controller) {
+    const initialState = extractModulesProp('root', controller.module, 'state')
 
-    this.state = devtools && devtools.warnStateProps
+    this.controller = controller
+    this.StateProvider = StateProvider
+    this.devtools = controller.devtools
+    this.state = this.devtools && this.devtools.warnStateProps
       ? addCerebralStateKey(initialState)
       : initialState
     this.changedPaths = []
+
+    controller.on('moduleAdded', this.onModuleAdded.bind(this))
+    controller.on('moduleRemoved', this.onModuleRemoved.bind(this))
+
+    if (typeof window !== 'undefined' && window.CEREBRAL_STATE) {
+      Object.keys(window.CEREBRAL_STATE).forEach(statePath => {
+        this.set(statePath.split('.'), window.CEREBRAL_STATE[statePath])
+      })
+    }
+  }
+  onModuleAdded(path, module) {
+    this.set(path, module.state)
+  }
+  onModuleRemoved(path) {
+    this.unset(path)
   }
   /*
     Returns array of changes
@@ -71,7 +91,6 @@ class Model {
     }, this.state)
   }
   /*
-<<<<<<< HEAD
     Unfreezes on the way down. When done freezes state. It is optimized
     to not go down already frozen paths
   */

--- a/packages/node_modules/cerebral/src/Model.test.js
+++ b/packages/node_modules/cerebral/src/Model.test.js
@@ -1,34 +1,38 @@
 /* eslint-env mocha */
+import BaseController from './BaseController'
 import Model from './Model'
 import assert from 'assert'
 
 describe('Model', () => {
   it('should instantiate with initial state', () => {
-    const model = new Model({
-      foo: 'bar',
-    })
-    assert.equal(model.get(['foo']), 'bar')
-  })
-  it('should instantiate with initial state', () => {
-    const model = new Model({
-      foo: 'bar',
-    })
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: 'bar',
+      },
+    }).model
     assert.equal(model.get(['foo']), 'bar')
   })
   it('should grab nested state', () => {
-    const model = new Model({
-      foo: {
-        bar: 'value',
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: {
+          bar: 'value',
+        },
       },
-    })
+    }).model
     assert.equal(model.get(['foo', 'bar']), 'value')
   })
   it('should be able to flush changed paths', () => {
-    const model = new Model({
-      foo: {
-        bar: 'value',
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: {
+          bar: 'value',
+        },
       },
-    })
+    }).model
     model.set(['foo', 'bar'], 'value2')
     assert.deepEqual(model.flush(), [
       {
@@ -38,11 +42,14 @@ describe('Model', () => {
     ])
   })
   it('should flush same path changes correctly', () => {
-    const model = new Model({
-      foo: {
-        bar: 'value',
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: {
+          bar: 'value',
+        },
       },
-    })
+    }).model
     model.set(['foo', 'bar'], 'value2')
     model.set(['foo', 'bar'], 'value3')
     assert.deepEqual(model.flush(), [
@@ -57,17 +64,23 @@ describe('Model', () => {
     ])
   })
   it('should throw when updating invalid path', () => {
-    const model = new Model({
-      foo: 'bar',
-    })
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: 'bar',
+      },
+    }).model
     assert.throws(() => {
       model.set(['foo', 'bar'], 'baz2')
     })
   })
   it('should throw when updating invalid nested path', () => {
-    const model = new Model({
-      foo: 'bar',
-    })
+    const model = new BaseController({
+      Model,
+      state: {
+        foo: 'bar',
+      },
+    }).model
     assert.throws(() => {
       model.set(['foo', 'bar', 'baz'], 'baz2')
     })
@@ -75,45 +88,61 @@ describe('Model', () => {
 
   describe('SET', () => {
     it('should be able to set state', () => {
-      const model = new Model({})
+      const model = new BaseController({
+        Model,
+        state: {},
+      }).model
+
       model.set(['foo'], 'bar')
       assert.deepEqual(model.get(), { foo: 'bar' })
     })
   })
   describe('TOGGLE', () => {
     it('should be able to toggle value', () => {
-      const model = new Model({
-        foo: true,
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: true,
+        },
+      }).model
       model.toggle(['foo'])
       assert.deepEqual(model.get(), { foo: false })
     })
   })
   describe('PUSH', () => {
     it('should be able to push to array', () => {
-      const model = new Model({
-        list: [],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          list: [],
+        },
+      }).model
       model.push(['list'], 'bar')
       assert.deepEqual(model.get(), { list: ['bar'] })
     })
   })
   describe('MERGE', () => {
     it('should be able to merge objects', () => {
-      const model = new Model({
-        foo: {
-          valA: 'foo',
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: {
+            valA: 'foo',
+          },
         },
-      })
+      }).model
       model.merge(['foo'], { valB: 'bar' })
       assert.deepEqual(model.get(), { foo: { valA: 'foo', valB: 'bar' } })
     })
     it('should flush changes to merged keys when object exists', () => {
-      const model = new Model({
-        foo: {
-          valA: 'foo',
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: {
+            valA: 'foo',
+          },
         },
-      })
+      }).model
       model.merge(['foo'], { valB: 'bar' })
       assert.deepEqual(model.flush(), [
         {
@@ -123,9 +152,12 @@ describe('Model', () => {
       ])
     })
     it('should flush change on object only if no existing object', () => {
-      const model = new Model({
-        foo: null,
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: null,
+        },
+      }).model
       model.merge(['foo'], { valB: 'bar' })
       assert.deepEqual(model.flush(), [
         {
@@ -137,54 +169,72 @@ describe('Model', () => {
   })
   describe('POP', () => {
     it('should be able to pop arrays', () => {
-      const model = new Model({
-        list: ['foo', 'bar'],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          list: ['foo', 'bar'],
+        },
+      }).model
       model.pop(['list'])
       assert.deepEqual(model.get(), { list: ['foo'] })
     })
   })
   describe('SHIFT', () => {
     it('should be able to shift arrays', () => {
-      const model = new Model({
-        list: ['foo', 'bar'],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          list: ['foo', 'bar'],
+        },
+      }).model
       model.shift(['list'])
       assert.deepEqual(model.get(), { list: ['bar'] })
     })
   })
   describe('UNSHIFT', () => {
     it('should be able to unshift arrays', () => {
-      const model = new Model({
-        list: ['foo'],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          list: ['foo'],
+        },
+      }).model
       model.unshift(['list'], 'bar')
       assert.deepEqual(model.get(), { list: ['bar', 'foo'] })
     })
   })
   describe('SPLICE', () => {
     it('should be able to splice arrays', () => {
-      const model = new Model({
-        list: ['foo', 'bar'],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          list: ['foo', 'bar'],
+        },
+      }).model
       model.splice(['list'], 1, 1, 'bar2')
       assert.deepEqual(model.get(), { list: ['foo', 'bar2'] })
     })
   })
   describe('UNSET', () => {
     it('should be able to unset keys', () => {
-      const model = new Model({
-        foo: 'bar',
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: 'bar',
+        },
+      }).model
       model.unset(['foo'])
       assert.deepEqual(model.get(), {})
     })
     it('should flush unset paths', () => {
-      const model = new Model({
-        foo: {
-          bar: 'value',
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: {
+            bar: 'value',
+          },
         },
-      })
+      }).model
       model.unset(['foo', 'bar'])
       assert.deepEqual(model.flush(), [
         {
@@ -196,53 +246,63 @@ describe('Model', () => {
   })
   describe('CONCAT', () => {
     it('should be able to concat array', () => {
-      const model = new Model({
-        foo: ['foo'],
-      })
+      const model = new BaseController({
+        Model,
+        state: {
+          foo: ['foo'],
+        },
+      }).model
       model.concat(['foo'], ['bar'])
       assert.deepEqual(model.get(), { foo: ['foo', 'bar'] })
     })
   })
   describe('Serializable', () => {
     it('should make value forceSerializable when devtools are attached', () => {
-      const model = new Model(
-        {
+      const model = new BaseController({
+        Model,
+        state: {
           foo: 'bar',
         },
-        { allowedTypes: [Date] }
-      )
+        devtools: {
+          allowedTypes: [Date],
+          init() {},
+        },
+      }).model
       model.set(['foo'], new Date())
       assert.equal(model.state.foo.toJSON(), '[Date]')
     })
     it('should throw error if value inserted is not serializable', () => {
-      const model = new Model(
-        {
+      const model = new BaseController({
+        Model,
+        state: {
           foo: 'bar',
         },
-        {}
-      )
+        devtools: { init() {} },
+      }).model
       assert.throws(() => {
         model.set(['foo'], new Date())
       })
     })
     it('should NOT throw error if value inserted is serializable', () => {
-      const model = new Model(
-        {
+      const model = new BaseController({
+        Model,
+        state: {
           foo: 'bar',
         },
-        {}
-      )
+        devtools: { init() {} },
+      }).model
       assert.doesNotThrow(() => {
         model.set(['foo'], [])
       })
     })
     it('should NOT throw error if passing allowed type in devtools', () => {
-      const model = new Model(
-        {
+      const model = new BaseController({
+        Model,
+        state: {
           foo: 'bar',
         },
-        { allowedTypes: [Date] }
-      )
+        devtools: { allowedTypes: [Date], init() {} },
+      }).model
       assert.doesNotThrow(() => {
         model.set(['foo'], new Date())
       })

--- a/packages/node_modules/cerebral/src/Module.js
+++ b/packages/node_modules/cerebral/src/Module.js
@@ -13,8 +13,6 @@ class Module {
       ? moduleDescription(moduleStub)
       : moduleDescription
 
-    /* Set initial module state to model */
-    controller.getModel().set(path, module.state || {})
     /* Convert arrays to actually runable signals */
     module.signals = Object.keys(
       module.signals || {}

--- a/packages/node_modules/cerebral/src/index.js
+++ b/packages/node_modules/cerebral/src/index.js
@@ -1,5 +1,10 @@
+import BaseControllerClass from './BaseController'
 import ControllerClass from './Controller'
 import UniversalControllerClass from './UniversalController'
+
+export function BaseController(options) {
+  return new BaseControllerClass(options)
+}
 
 export function Controller(options) {
   return new ControllerClass(options)

--- a/packages/node_modules/cerebral/src/utils.js
+++ b/packages/node_modules/cerebral/src/utils.js
@@ -305,3 +305,42 @@ export function getStateTreeProp(props = {}) {
     return hit
   }, null)
 }
+
+export function getModule(path, modules) {
+  const pathArray = Array.isArray(path) ? path : ensurePath(path)
+  return pathArray.reduce((currentModule, key) => {
+    if (!currentModule.modules[key]) {
+      throwError(
+        `The path "${pathArray.join(
+          '.'
+        )}" is invalid, can not find module. Does the path "${pathArray
+          .splice(0, path.length - 1)
+          .join('.')}" exist?`
+      )
+    }
+    return currentModule.modules[key]
+  }, modules)
+}
+
+export function extractModulesProp(moduleKey, module, prop, transform) {
+  const value = Object.keys(module).reduce((returnValue, key) => {
+    if (key === prop) {
+      return transform ? transform(moduleKey, module[key]) : module[key]
+    }
+
+    return returnValue
+  }, {})
+
+  if (module.modules) {
+    Object.keys(module.modules).forEach(subKey => {
+      value[subKey] = extractModulesProp(
+        subKey,
+        module.modules[subKey],
+        prop,
+        transform
+      )
+    })
+  }
+
+  return value
+}


### PR DESCRIPTION
- `BaseController` handles modules, signals and providers
- `Controller` is now only related to default Cerebral model, dependency tracking and flushing
- Moved `StateProvider` as property to the Model itself, so each model can have its own state provider
- Added `cerebral-mobx` package, which just exports the Mobx (Mobx State Tree) controller and handles `model` property in modules

Check README.md on how it works in practice. 

This is of course rather experimental and should be tested more before any new release. But I really want to explore this as it simplifies Cerebral code and at the same time "empowers" the model layer with typing etc. It does of course not support a bunch of view layers, like default Cerebral model, so this could be just a choice for the developer.