### PR TITLE
fix(Views): fix angularjs ctrl prop override bug

### DIFF
--- a/packages/node_modules/cerebral/src/views/View.js
+++ b/packages/node_modules/cerebral/src/views/View.js
@@ -27,6 +27,7 @@ class View {
     this._hasWarnedBigComponent = false
     this.isUnmounted = false
     this.updateComponent = onUpdate
+    this.propKeys = Object.keys(props)
 
     if (this.controller.devtools && this.controller.devtools.warnStateProps) {
       this.verifyProps(props)
@@ -293,7 +294,7 @@ class View {
     Runs whenever the component has an update and renders.
     Extracts the actual values from dependency trackers and/or tags
   */
-  getProps(props = {}) {
+  getProps(props = {}, includeProps = true) {
     const dependenciesProps = Object.keys(
       this.dependencies
     ).reduce((currentProps, key) => {
@@ -355,7 +356,7 @@ class View {
       )
     }
 
-    return Object.assign({}, props, dependenciesProps)
+    return Object.assign({}, includeProps ? props : {}, dependenciesProps)
   }
 }
 

--- a/packages/node_modules/cerebral/src/views/angularjs/module.js
+++ b/packages/node_modules/cerebral/src/views/angularjs/module.js
@@ -36,7 +36,7 @@ class CerebralScope {
         const hasUpdate = this.view.onPropsUpdate(oldProps, nextProps)
 
         if (hasUpdate) {
-          Object.assign(this.ctrl, this.view.getProps(nextProps))
+          Object.assign(this.ctrl, this.view.getProps(nextProps, false))
           this.scope.safeApply()
         }
       }
@@ -50,12 +50,12 @@ class CerebralScope {
           this.$apply(fn)
         }
       }
-      Object.assign(this.ctrl, this.view.getProps(this.props))
+      Object.assign(this.ctrl, this.view.getProps(this.props, false))
     }
   }
   onUpdate(stateChanges, force) {
     this.view.updateFromState(stateChanges, this.props, force)
-    Object.assign(this.ctrl, this.view.getProps(this.props))
+    Object.assign(this.ctrl, this.view.getProps(this.props, false))
     this.scope.safeApply()
   }
 }


### PR DESCRIPTION
Added a new feature to the `View` factory. Now you can choose to drag out all props, or just state props. This is necessary for view solutions where props are not being passed down, like in angularjs.