### PR TITLE
chore(release): add next release script and remove forced major

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build:demos": "node ./scripts/run.js prepublish demos",
     "checkdeps": "node ./scripts/check.dependencies.js --auto-fix",
-    "release": "babel-node ./scripts/release/index.js",
+    "release:master": "babel-node ./scripts/release/master.js",
+    "release:next": "babel-node ./scripts/release/next.js",
     "commit": "git-cz",
     "commitmsg": "node ./node_modules/cz-customizable-ghooks/lib/index.js .git/COMMIT_EDITMSG",
     "coverage": "node ./scripts/run.js coverage",

--- a/scripts/release/master.js
+++ b/scripts/release/master.js
@@ -13,21 +13,13 @@ cooker.run('publish', [
   cook.parseCommits,
   cook.groupCommitsByPackage,
   cook.evaluateSemverByPackage,
-  ({ config }) => ({
-    semverByPackage: Object.assign(
-      {},
-      ...Object.keys(config.packagesPaths).map(name => ({
-        [name]: 'major',
-      }))
-    ),
-  }),
   cook.relatedPackagesByPackage,
   cook.getCurrentVersionByPackage,
   cook.evaluateNewVersionByPackage,
   cook.writeVersionsToPackages,
   cook.runNpmScript('prepublish'),
   cook.publishUnderTemporaryNpmTag,
-  cook.mapTemporaryNpmTagToLatest,
+  cook.mapTemporaryNpmTagTo('latest'),
   cook.resetRepository,
   cook.tagCurrentCommit,
   cook.pushTagToRemote,

--- a/scripts/release/next.js
+++ b/scripts/release/next.js
@@ -1,0 +1,30 @@
+// import {sequence, parallel} from 'function-tree'
+// import {} from 'repo-cooker'
+
+// tree to run with `repo-cooker publish`. extra arguments could be parsed and putted in props
+import { cooker } from './cooker'
+import * as cook from 'repo-cooker/actions'
+
+cooker.run('publish', [
+  cook.getLatestReleaseHash,
+  cook.getHistoryFromHash,
+  cook.getRawCommitsFromHistory,
+  cook.parseCommits,
+  cook.groupCommitsByPackage,
+  cook.evaluateSemverByPackage,
+  cook.relatedPackagesByPackage,
+  cook.getCurrentVersionByPackage,
+  cook.evaluateNewVersionByPackage,
+  cook.remap(
+    'newVersionByPackage',
+    (version, props) => `${version}-${props.hash.slice(0, 6)}`
+  ),
+  cook.writeVersionsToPackages,
+  cook.runNpmScript('prepublish'),
+  cook.publishUnderTemporaryNpmTag,
+  cook.mapTemporaryNpmTagTo('next'),
+  cook.resetRepository,
+  cook.tagCurrentCommit,
+  cook.pushTagToRemote,
+  cook.fireworks,
+])


### PR DESCRIPTION
Okay, now we run releases with:

`npm run release:master`

`npm run release:next`

To actually run release, add `-- --publish` after the command