### PR TITLE
chore(release): change dependency on cerebral from normal to peer

### DIFF
--- a/packages/node_modules/@cerebral/baobab/package.json
+++ b/packages/node_modules/@cerebral/baobab/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "http://cerebral.github.io/cerebral-website",
   "dependencies": {
-    "cerebral": "next",
-    "baobab": "^2.4.3"
+    "baobab": "^2.4.3",
+    "cerebral": "next"
   },
   "scripts": {
     "test": "mocha --compilers js:babel-register \"src/**/*.test.js\"",

--- a/packages/node_modules/@cerebral/forms/package.json
+++ b/packages/node_modules/@cerebral/forms/package.json
@@ -26,10 +26,7 @@
   },
   "homepage":
     "https://github.com/cerebral/cerebral/tree/master/packages/forms#readme",
-  "peerDependencies": {
-    "cerebral": "next"
-  },
-  "devDependencies": {
+  "dependencies": {
     "cerebral": "next"
   },
   "nyc": {

--- a/packages/node_modules/@cerebral/http/package.json
+++ b/packages/node_modules/@cerebral/http/package.json
@@ -23,14 +23,11 @@
     "url": "https://github.com/cerebral/cerebral/issues"
   },
   "homepage": "https://github.com/cerebral/cerebral/tree/master/packages/http#readme",
-  "dependencies": {
-    "function-tree": "^1.0.0-beta.3"
-  },
   "peerDependencies": {
-    "cerebral": "^2.0.0-beta.3"
+    "cerebral": "next"
   },
   "devDependencies": {
-    "cerebral": "^2.0.0-beta.3",
+    "cerebral": "next",
     "xhr-mock": "^1.9.0"
   }
 }

--- a/packages/node_modules/@cerebral/inferno/package.json
+++ b/packages/node_modules/@cerebral/inferno/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/cerebral/cerebral/issues"
   },
   "homepage": "http://cerebral.github.io/cerebral-website",
+  "devDependencies": {
+    "babel-plugin-inferno": "^3.2.0"
+  },
   "dependencies": {
     "cerebral": "next"
   },
@@ -31,8 +34,5 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
-  },
-  "devDependencies": {
-    "babel-plugin-inferno": "^3.2.0"
   }
 }

--- a/packages/node_modules/@cerebral/mobx-state-tree/package.json
+++ b/packages/node_modules/@cerebral/mobx-state-tree/package.json
@@ -16,10 +16,15 @@
     "url": "https://github.com/cerebral/cerebral/issues"
   },
   "homepage": "http://cerebral.github.io/cerebral-website",
-  "peerDependencies": {
+  "devDependencies": {
+    "prop-types": "^15.5.10"
+  },
+  "dependencies": {
     "cerebral": "next",
-    "mobx": "^3.2.0",
     "mobx-state-tree": "^0.9.1"
+  },
+  "peerDependencies": {
+    "mobx": "^3.2.0"
   },
   "scripts": {
     "build": "cross-env BABEL_ENV=production babel src/ --out-dir=lib/ -s",
@@ -34,8 +39,5 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
-  },
-  "devDependencies": {
-    "prop-types": "^15.5.10"
   }
 }

--- a/packages/node_modules/@cerebral/preact/package.json
+++ b/packages/node_modules/@cerebral/preact/package.json
@@ -16,6 +16,9 @@
   "dependencies": {
     "cerebral": "next"
   },
+  "devDependencies": {
+    "babel-preset-preact": "^1.1.0"
+  },
   "scripts": {
     "build": "cross-env BABEL_ENV=production babel src/ --out-dir=lib/ -s",
     "coverage": "nyc --reporter=lcov --reporter=json npm run test",
@@ -31,8 +34,5 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
-  },
-  "devDependencies": {
-    "babel-preset-preact": "^1.1.0"
   }
 }

--- a/packages/node_modules/@cerebral/react/package.json
+++ b/packages/node_modules/@cerebral/react/package.json
@@ -16,6 +16,12 @@
     "url": "https://github.com/cerebral/cerebral/issues"
   },
   "homepage": "http://cerebral.github.io/cerebral-website",
+  "devDependencies": {
+    "@types/react": "^15.0.27",
+    "@types/react-dom": "^15.5.0",
+    "jest": "^18.1.0",
+    "prop-types": "^15.5.10"
+  },
   "dependencies": {
     "cerebral": "next"
   },
@@ -34,11 +40,5 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
-  },
-  "devDependencies": {
-    "@types/react": "^15.0.27",
-    "@types/react-dom": "^15.5.0",
-    "jest": "^18.1.0",
-    "prop-types": "^15.5.10"
   }
 }

--- a/packages/node_modules/@cerebral/router/package.json
+++ b/packages/node_modules/@cerebral/router/package.json
@@ -18,13 +18,8 @@
   "homepage": "https://cerebral.github.io/cerebral-website/api/08_router.html",
   "dependencies": {
     "addressbar": "^1.0.3",
+    "cerebral": "next",
     "url-mapper": "^1.1.1"
-  },
-  "peerDependencies": {
-    "cerebral": "next"
-  },
-  "devDependencies": {
-    "cerebral": "next"
   },
   "scripts": {
     "test": "mocha -r test/setup  --compilers js:babel-register \"src/**/*.test.js\" \"test/**/*.test.js\"",

--- a/packages/node_modules/@cerebral/shortcuts/package.json
+++ b/packages/node_modules/@cerebral/shortcuts/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "shortway": "^0.3.0"
   },
-  "peerDependencies": {
+  "devDependencies": {
     "cerebral": "next"
   },
-  "devDependencies": {
+  "peerDependencies": {
     "cerebral": "next"
   }
 }

--- a/packages/node_modules/@cerebral/storage/package.json
+++ b/packages/node_modules/@cerebral/storage/package.json
@@ -23,10 +23,10 @@
     "url": "https://github.com/cerebral/cerebral/issues"
   },
   "homepage": "https://github.com/cerebral/cerebral/tree/master/packages/storage#readme",
-  "peerDependencies": {
+  "devDependencies": {
     "cerebral": "next"
   },
-  "devDependencies": {
-    "cerebral": "^2.0.0-beta.3"
+  "peerDependencies": {
+    "cerebral": "next"
   }
 }

--- a/packages/node_modules/@cerebral/useragent/package.json
+++ b/packages/node_modules/@cerebral/useragent/package.json
@@ -24,16 +24,11 @@
   "homepage":
     "https://github.com/cerebral/cerebral/tree/master/packages/useragent#readme",
   "dependencies": {
+    "cerebral": "next",
     "feature.js": "^1.0.0",
     "match-media": "^0.2.0",
     "offline-js": "^0.7.18",
     "raf": "^3.3.0",
     "ua-parser-js": "^0.7.10"
-  },
-  "peerDependencies": {
-    "cerebral": "next"
-  },
-  "devDependencies": {
-    "cerebral": "next"
   }
 }

--- a/packages/node_modules/cerebral/package.json
+++ b/packages/node_modules/cerebral/package.json
@@ -26,6 +26,11 @@
     "@cerebral/vue": "next",
     "@cerebral/angularjs": "next"
   },
+  "devDependencies": {
+    "@types/react": "15.0.27",
+    "@types/react-dom": "15.5.0",
+    "prop-types": "^15.5.10"
+  },
   "scripts": {
     "test": "mocha -r test/setup --compilers js:babel-register \"src/**/*.test.js\" \"test/**/*.test.js\"",
     "test:watch": "npm run test -- --watch",
@@ -41,10 +46,5 @@
       "**/*.test.js",
       "**/testHelper.js"
     ]
-  },
-  "devDependencies": {
-    "@types/react": "15.0.27",
-    "@types/react-dom": "15.5.0",
-    "prop-types": "^15.5.10"
   }
 }

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -11,6 +11,18 @@ cooker.cook('publish', [
   cook.groupCommitsByPackage,
   cook.evaluateSemverByPackage,
   cook.relatedPackagesByPackage,
+  // Temporary cleanup of circular deps
+  // To be removed on [DEPRECATION] cleanup
+  ({ props: { relatedPackagesByPackage } }) => {
+    const views = ['angularjs', 'inferno', 'preact', 'react', 'vue'].map(
+      k => `@cerebral/${k}`
+    )
+    relatedPackagesByPackage[
+      'cerebral'
+    ].dependencies = relatedPackagesByPackage['cerebral'].dependencies.filter(
+      key => !views.includes(key)
+    )
+  },
   cook.getCurrentVersionByPackage,
   cook.evaluateNewVersionByPackage,
   cook.byBranch,


### PR DESCRIPTION
We do not want to have circular depencencies because this prevents release with repo-cooker.