### PR TITLE
Fix release with new repo-cooker, fixes view error message, change logo size

### DIFF
--- a/packages/node_modules/cerebral/src/views/View.js
+++ b/packages/node_modules/cerebral/src/views/View.js
@@ -271,9 +271,7 @@ class View {
       }
 
       if (!this.dependencies[propKey].getTags) {
-        throwError(
-          `Prop ${propKey} should be tags or a function on the specific property you want to dynamically create`
-        )
+        throwError(`Prop '${propKey}' should be a tag or a compute.`)
       }
 
       const getters = this.createTagGetters(props)

--- a/packages/node_modules/cerebral/src/views/View.test.js
+++ b/packages/node_modules/cerebral/src/views/View.test.js
@@ -60,7 +60,7 @@ describe('View', () => {
         if (err instanceof Error) {
           return (
             err.message ===
-            'Cerebral - Prop foo should be tags or a function on the specific property you want to dynamically create'
+            "Cerebral - Prop 'foo' should be a tag or a compute."
           )
         }
       }

--- a/packages/website/builder/pages/index/index.js
+++ b/packages/website/builder/pages/index/index.js
@@ -10,7 +10,7 @@ function Index(props) {
           backgroundSize: 'contain',
           backgroundPosition: 'center',
           width: '100%',
-          height: '50vh',
+          height: '25vh',
         }}
       />
       <h1 className="index-title">Cerebral</h1>

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -11,17 +11,6 @@ cooker.cook('publish', [
   cook.groupCommitsByPackage,
   cook.evaluateSemverByPackage,
   cook.relatedPackagesByPackage,
-  // Temporary cleanup of circular deps
-  // To be removed on [DEPRECATION] cleanup
-  ({ props: { relatedPackagesByPackage } }) => {
-    const views = ['angularjs', 'inferno', 'preact', 'react', 'vue'].map(
-      k => `@cerebral/${k}`
-    )
-    relatedPackagesByPackage['cerebral'] = relatedPackagesByPackage[
-      'cerebral'
-    ].filter(key => !views.includes(key))
-    return { relatedPackagesByPackage }
-  },
   cook.getCurrentVersionByPackage,
   cook.evaluateNewVersionByPackage,
   cook.byBranch,


### PR DESCRIPTION
The new repo-cooker now supports circular dependencies (Yeah !) so we should not filter out dependencies because this leads to invalid "@next" releases (peer dependency mess or worse multiple cerebral versions installed and breaking apps).

Made the log 25vh instead of 50vh because it is really too big now and pushes the important links way down....

Please let me pull this PR in when it is approved (need to bust cache for repo-cooker).