### PR TITLE
fix(types): runSignal types were wrong.

### DIFF
--- a/packages/node_modules/cerebral/test.d.ts
+++ b/packages/node_modules/cerebral/test.d.ts
@@ -1,29 +1,65 @@
 import { Action, Computed, ControllerClass, SignalChain } from './'
 
-export interface RunSignalResult<P, T> {
+export interface RunActionResult<P, T> {
   controller: ControllerClass
   props: P
   state: any
   output: T
 }
 
-export function runAction<P=any, T=any>(
-  action: Action<P,Promise<T>>,
-  fixtures?: { props: P & any } & any
-): Promise<RunSignalResult<P, T>>
+interface RunSignalResult0<P, T0> {
+  '0': RunActionResult<P, T0>
+}
+
+interface RunSignalResult1<P, T0, T1> {
+  '0': RunActionResult<P, T0>
+  '1': RunActionResult<P, T1>
+}
+
+interface RunSignalResult2<P, T0, T1, T2> {
+  '0': RunActionResult<P, T0>
+  '1': RunActionResult<P, T1>
+  '2': RunActionResult<P, T2>
+}
 
 export function runAction<P=any, T=any>(
-  action: Action<P,T>,
+  action: Action<P,Promise<T> | T>,
   fixtures?: { props: P & any } & any
-): Promise<RunSignalResult<P, T>>
+): Promise<RunActionResult<P, T>>
 
 export function runCompute<T>(computed: Computed<T>, fixtures?: any): T
 
-export function runSignal<P=any, T=any>(
-  signal: SignalChain,
+export function runSignal<P, T0>(
+  signal: [Action<P, Promise<T0> | T0>],
   fixtures?: { props: P & any } & any,
   options?: any
-): Promise<RunSignalResult<P, T>>
+): Promise<RunSignalResult0<P, T0>>
+
+export function runSignal<P, T0, T1>(
+  signal: [
+    Action<P, Promise<T0> | T0>,
+    Action<any, Promise<T1> | T1>
+  ],
+  fixtures?: { props: P & any } & any,
+  options?: any
+): Promise<RunSignalResult1<P, T0, T1>>
+
+export function runSignal<P, T0, T1, T2>(
+  signal: [
+    Action<P, Promise<T0> | T0>,
+    Action<any, Promise<T1> | T1>,
+    Action<any, Promise<T2> | T2>
+  ],
+  fixtures?: { props: P & any } & any,
+  options?: any
+): Promise<RunSignalResult2<P, T0, T1, T2>>
+
+export function runSignal(
+  signal: SignalChain,
+  fixtures?: any,
+  options?: any
+): Promise<any>
+
 
 interface CerebralTestType {
   runSignal<T=any>(signal: SignalChain, props: any): Promise<T>

--- a/packages/node_modules/cerebral/test/typescript/test.ts
+++ b/packages/node_modules/cerebral/test/typescript/test.ts
@@ -22,6 +22,11 @@ const asyncAction: Action<Props, Promise<Output>> = ({ props: { foo, bar } }) =>
   return Promise.resolve({ baz: 'hop' })
 }
 
+const asyncAction2: Action<Props, Promise<{ foo2: string }>> = ({ props: { foo, bar } }) => {
+  const x = foo.length + bar
+  return Promise.resolve({ foo2: 'hop' })
+}
+
 runAction(someAction, { props: { foo: 'f', bar: 1 } }).then( result => {
   const a = result.props.foo.length
   const b = result.props.bar + 5
@@ -34,10 +39,11 @@ runAction(asyncAction, { props: { foo: 'f', bar: 1 } }).then( result => {
   const c = result.output.baz
 })
 
-runSignal<Props, Output>([asyncAction], { props: { foo: 'f', bar: 1 } }).then( result => {
-  const a = result.props.foo.length
-  const b = result.props.bar + 5
-  const c = result.output.baz
+runSignal([asyncAction, asyncAction2], { props: { foo: 'f', bar: 1 } }).then( result => {
+  const a = result['0'].props.foo.length
+  const b = result['0'].props.bar + 5
+  const c = result['0'].output.baz
+  const d = result['1'].output.foo2
 })
 
 const test = runCompute(computed).substr(0,5)


### PR DESCRIPTION
We now support up to 3 typed actions in `runSignal` tester.