### PR TITLE
Turn storage provider into a module + api to re-hydrate upon refresh

### DIFF
--- a/docs/introduction/modules.md
+++ b/docs/introduction/modules.md
@@ -67,7 +67,7 @@ import {provide} from 'cerebral'
 export default {
   state: {},
   signals: {},
-  providers: provide('whatevah', {
+  provider: provide('whatevah', {
     foo() {},
     bar() {}
   })

--- a/packages/node_modules/@cerebral/angular/README.md
+++ b/packages/node_modules/@cerebral/angular/README.md
@@ -30,7 +30,7 @@ export function configureController(someAngularService : SomeAngularService) {
       provide('someAngularService', someAngularService)
     ]
   })
-})
+}
 
 @NgModule({
   imports:      [ BrowserModule ],

--- a/packages/node_modules/@cerebral/storage/README.md
+++ b/packages/node_modules/@cerebral/storage/README.md
@@ -16,19 +16,22 @@ import {Controller} from 'cerebral'
 import StorageProvider from '@cerebral/storage'
 
 const controller = Controller({
-  providers: [StorageProvider({
-    // instance of storage, can be window.localStorage / localStorage
-    // or window.sessionStorage / sessionStorage
-    target: localStorage
-    // Serializes and parses to JSON by default
-    json: true,
-    // Synchronize state when it changes
-    sync: {
-      'someStorageKey': 'some.state.path'
-    },
-    // Set prefix for storagekey "somePrefix.someStorageKey"
-    prefix: 'somePrefix'
-  })]
+  modules: {
+    // storage key is now a reserved key in the state tree (module namespacing)
+    storage: StorageProvider({
+      // instance of storage, can be window.localStorage / localStorage
+      // or window.sessionStorage / sessionStorage
+      target: localStorage,
+      // Serializes and parses to JSON by default
+      json: true,
+      // Synchronize state when it changes
+      sync: {
+        'someStorageKey': 'some.state.path'
+      },
+      // Set prefix for storagekey "somePrefix.someStorageKey"
+      prefix: 'somePrefix'
+    })
+  }
 })
 ```
 

--- a/packages/node_modules/@cerebral/storage/src/index.js
+++ b/packages/node_modules/@cerebral/storage/src/index.js
@@ -58,5 +58,21 @@ function StorageProvider(options = {}) {
 }
 
 export default (options = {}) => {
-  return { provider: StorageProvider(options) }
+  return ({ controller }) => {
+    controller.once('initialized:model', () => {
+      const targetStorage = options.target || localStorage
+
+      Object.keys(options.sync || {}).forEach(syncKey => {
+        const value = targetStorage.getItem(options.prefix + syncKey)
+
+        if (!value) {
+          return
+        }
+
+        const path = options.sync[syncKey].split('.')
+        controller.model.set(path, options.json ? JSON.parse(value) : value)
+      })
+    })
+    return { provider: StorageProvider(options) }
+  }
 }

--- a/packages/node_modules/@cerebral/storage/src/index.js
+++ b/packages/node_modules/@cerebral/storage/src/index.js
@@ -57,4 +57,6 @@ function StorageProvider(options = {}) {
   }
 }
 
-export default StorageProvider
+export default (options = {}) => {
+  return { provider: StorageProvider(options) }
+}

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -50,6 +50,8 @@ class BaseController extends FunctionTree {
     })
     this.model = new config.Model(this)
 
+    this.emit('initialized:model')
+
     this.contextProviders = [ControllerProvider(this)]
       .concat(this.devtools ? [DebuggerProvider()] : [])
       .concat(isDeveloping() ? [VerifyPropsProvider] : [])


### PR DESCRIPTION
An improvement to avoid getter setter ```localStorage``` boilercodes in the controller options. 

Referencing #1064 