### PR TITLE
Comment: Module state overrides fixture state

### DIFF
--- a/docs/introduction/test.md
+++ b/docs/introduction/test.md
@@ -127,7 +127,20 @@ cerebral.runSignal(signal, props).then((result) => {})
 const value = cerebral.getState(path)
 ```
 
-The `fixture` argument will be passed to the cerebral controller so can contain the same properties (state, signals, modules, etc...).
+The `fixture` argument will be passed to the cerebral controller so can contain the same properties (state, signals, modules, etc...). Note that state initialized in a module takes precedence over the state property of a fixture. Example:
+
+```js
+const fixture = {
+  state: {
+    app: {    
+      showNavigation: true    
+    }
+  },
+  modules: {
+    app // if app initializes showNavigation as false, this will override the previous setting
+  }
+}
+```
 
 The optional `options` argument contain the the following options:
 


### PR DESCRIPTION
Added a comment: Users otherwise may not notice that a module they include in a fixture overrides the state they are explicitly declaring on the fixture.