### PR TITLE
Next.js support

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -11,7 +11,11 @@ const controller = Controller({
   signals: {},
 
   // Defines the top level modules
-  modules: {}
+  modules: {},
+
+  // A map of state changes to run before instantiation,
+  // where the key is the path and value is the state value
+  stateChanges: {}
 })
 
 export default controller

--- a/docs/api/universalcontroller.md
+++ b/docs/api/universalcontroller.md
@@ -89,6 +89,32 @@ const controller = UniversalController({
 controller.setState('app.foo', 123)
 ```
 
+### getChanges
+Returns a map of the changes made.
+
+```js
+const controller = new UniversalController({
+  modules: {
+    app: {
+      ...,
+      signals: {
+        aSignal: [
+          function myAction ({state, props}) {
+            state.set('app.isAwesome', props.isAwesome)
+          }
+        ],
+      },
+    },
+  },
+})
+
+controller
+  .runSequence('app.aSignal', {isAwesome: true})
+  .then(() => {
+    controller.getChanges() // {"app.isAwesome": true}
+  })
+```
+
 ### getScript
 When the client side application loads it will do its first render with the default state, meaning that if the server updated the state this is now out of sync. Using the **getScript** method you will get a script tag you can inject into the *HEAD* of the returned HTML. Cerebral will use this to bring your client side application state up to date with the server.
 

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -31,6 +31,7 @@ class BaseController extends FunctionTree {
       modules = {},
       devtools = null,
       options = {},
+      stateChanges = typeof window !== 'undefined' && window.CEREBRAL_STATE,
     } = config
     const getSignal = this.getSignal
 
@@ -56,9 +57,9 @@ class BaseController extends FunctionTree {
       .concat(this.model.StateProvider(this.devtools), ResolveProvider())
       .concat(providers.concat(getProviders(this.module)))
 
-    if (typeof window !== 'undefined' && window.CEREBRAL_STATE) {
-      Object.keys(window.CEREBRAL_STATE).forEach(statePath => {
-        this.model.set(ensurePath(statePath), window.CEREBRAL_STATE[statePath])
+    if (stateChanges) {
+      Object.keys(stateChanges).forEach(statePath => {
+        this.model.set(ensurePath(statePath), stateChanges[statePath])
       })
     }
 
@@ -155,9 +156,7 @@ class BaseController extends FunctionTree {
   getSignal(path) {
     const pathArray = ensurePath(path)
     const signalKey = pathArray.pop()
-    const module = pathArray.reduce((currentModule, key) => {
-      return currentModule ? currentModule.modules[key] : undefined
-    }, this.module)
+    const module = getModule(pathArray, this.module)
     const signal = module && module.signals[signalKey]
 
     return signal && signal.run

--- a/packages/node_modules/cerebral/src/UniversalController.js
+++ b/packages/node_modules/cerebral/src/UniversalController.js
@@ -1,5 +1,5 @@
 import Controller from './Controller'
-import { ensurePath, throwError } from './utils'
+import { ensurePath, throwError, getModule } from './utils'
 
 class UniversalController extends Controller {
   constructor(controllerOptions) {
@@ -13,14 +13,15 @@ class UniversalController extends Controller {
   trackChanges(changes) {
     this.changes = this.changes.concat(changes)
   }
-  getScript() {
-    const state = JSON.stringify(
-      this.changes.reduce((changes, change) => {
-        changes[change.path.join('.')] = this.getState(change.path)
+  getChanges() {
+    return this.changes.reduce((changes, change) => {
+      changes[change.path.join('.')] = this.getState(change.path)
 
-        return changes
-      }, {})
-    )
+      return changes
+    }, {})
+  }
+  getScript() {
+    const state = JSON.stringify(this.getChanges())
 
     this.hasRun = true
     return `<script>window.CEREBRAL_STATE = ${state}</script>`
@@ -31,7 +32,12 @@ class UniversalController extends Controller {
     if (Array.isArray(sequence)) {
       signalRun = this.run('UniversalController.run', sequence, payload)
     } else if (typeof sequence === 'string') {
-      signalRun = this.getSignal(sequence)(payload)
+      const pathArray = ensurePath(sequence)
+      const signalKey = pathArray.pop()
+      const module = getModule(pathArray, this.module)
+      const signalDefinition = module && module.signals[signalKey]
+
+      signalRun = this.run(sequence, signalDefinition.signal, payload)
     } else {
       throwError('Sequence must be a signal-path or an array of action.')
     }

--- a/packages/node_modules/cerebral/src/UniversalController.test.js
+++ b/packages/node_modules/cerebral/src/UniversalController.test.js
@@ -19,6 +19,19 @@ describe('UniversalController', () => {
       { path: ['foo'], forceChildPathUpdates: true },
     ])
   })
+  it('should expose method to get state changes', () => {
+    const controller = new UniversalController({
+      state: {
+        foo: 'bar',
+      },
+    })
+    controller.run([
+      function stateUpdate({ state }) {
+        state.set('foo', 'bar2')
+      },
+    ])
+    assert.deepEqual(controller.getChanges(), { foo: 'bar2' })
+  })
   it('should expose method to produce script with state changes', () => {
     const controller = new UniversalController({
       state: {
@@ -87,12 +100,13 @@ describe('UniversalController', () => {
         },
       },
     })
-    controller.runSequence('app.moduleSignal', { value: 1 })
-    assert.deepEqual(controller.getState(), { app: { foo: 'bar2' } })
-    assert.deepEqual(controller.changes, [
-      { path: ['app', 'foo'], forceChildPathUpdates: true },
-      { path: ['app', 'foo'], forceChildPathUpdates: true },
-    ])
+    controller.runSequence('app.moduleSignal', { value: 1 }).then(() => {
+      assert.deepEqual(controller.getState(), { app: { foo: 'bar2' } })
+      assert.deepEqual(controller.changes, [
+        { path: ['app', 'foo'], forceChildPathUpdates: true },
+        { path: ['app', 'foo'], forceChildPathUpdates: true },
+      ])
+    })
   })
   it('should allow multiple runs', () => {
     const controller = new UniversalController({


### PR DESCRIPTION
This is basically how it looks in `next.js`:

```js
import React from 'react'
import {Controller, UniversalController} from 'cerebral'
import Devtools from 'cerebral/devtools'
import {Container} from '@cerebral/react'
import modules from '../modules'
import Page from '../components/Page'

export default class extends React.Component {
  static async getInitialProps({pathname}) {
    const controller = UniversalController({modules})

    return controller.runSequence([
      function setPage ({state}) {
        state.set('app.currentPage', 'home')
      }
    ])
      .then(() => {
        return {
          stateChanges: controller.getChanges()
        }
      })
  }
  render() {
    return (
      <Container controller={Controller({
        devtools: typeof window === 'undefined' ? null : Devtools({host: 'localhost:8787'}),
        stateChanges: this.props.stateChanges,
        modules
      })}>
        <Page />
      </Container>
    )
  }
}
```
