### PR TITLE
feat(http): pass through options from operators

### DIFF
--- a/packages/node_modules/@cerebral/http/README.md
+++ b/packages/node_modules/@cerebral/http/README.md
@@ -175,7 +175,7 @@ function someDeleteAction ({http}) {
 
 ### operator
 ```js
-import {httpPost} from '@cerebral/http/operators'
+import {httpDelete} from '@cerebral/http/operators'
 import {state} from 'cerebral/tags'
 
 export default [
@@ -190,7 +190,7 @@ export default [
 
 ### operator with paths
 ```js
-import {httpPost} from '@cerebral/http/operators'
+import {httpDelete} from '@cerebral/http/operators'
 import {state} from 'cerebral/tags'
 
 export default [
@@ -413,7 +413,7 @@ function somePutAction ({http}) {
 
 ### operator
 ```js
-import {httpPost} from '@cerebral/http/operators'
+import {httpPut} from '@cerebral/http/operators'
 
 export default [
   httpPut('/items', {
@@ -429,7 +429,7 @@ export default [
 
 ### operator with paths
 ```js
-import {httpPost} from '@cerebral/http/operators'
+import {httpPut} from '@cerebral/http/operators'
 
 export default [
   httpPut('/items', {

--- a/packages/node_modules/@cerebral/http/index.d.ts
+++ b/packages/node_modules/@cerebral/http/index.d.ts
@@ -1,7 +1,14 @@
 import { Provider } from "function-tree"
 
 export class HttpProviderError extends Error {
-  constructor (status: Number, headers: any, body: any, message?: string, isAborted?: boolean)
-  toJSON () : any
+  constructor (status: number, headers: any, body: any, message?: string, isAborted?: boolean)
+  response: {
+    status: number,
+    headers: any,
+    result: any,
+    isAborted: boolean,
+  }
+  toJSON (): any
 }
+
 export default function HttpProvider(options: any): Provider 

--- a/packages/node_modules/@cerebral/http/operators.d.ts
+++ b/packages/node_modules/@cerebral/http/operators.d.ts
@@ -1,6 +1,10 @@
-export function httpDelete(url: string, query: any): Function
-export function httpGet(url: string, query: any): Function
-export function httpPatch(url: string, body: any): Function
-export function httpPost(url: string, body: any): Function
-export function httpPut(url: string, body: any): Function
-export function httpUploadFile(urlValue: string, filesValue: string[], optionsValue: any[]): Function
+import { Tag } from 'cerebral/tags'
+import { Action } from 'cerebral'
+
+export function httpAbort(regexp: string | Tag): Action
+export function httpDelete(url: string | Tag, query?: any, options?: any): Action
+export function httpGet(url: string | Tag, query?: any, options?: any): Action
+export function httpPatch(url: string | Tag, body?: any, options?: any): Action
+export function httpPost(url: string | Tag, body?: any, options?: any): Action
+export function httpPut(url: string | Tag, body?: any, options?: any): Action
+export function httpUploadFile(urlValue: string | Tag, filesValue: string[], optionsValue: any[]): Action

--- a/packages/node_modules/@cerebral/http/src/operators/httpDelete.js
+++ b/packages/node_modules/@cerebral/http/src/operators/httpDelete.js
@@ -1,12 +1,13 @@
 import { processResponse } from '../utils'
 import { convertObjectWithTemplates } from 'cerebral/tags'
 
-function httpDeleteFactory(url, query = {}) {
+function httpDeleteFactory(url, query = {}, options) {
   function httpDelete({ http, path, resolve }) {
     return processResponse(
       http.delete(
         resolve.value(url),
-        convertObjectWithTemplates(query, resolve, 'http.httpDelete')
+        convertObjectWithTemplates(query, resolve, 'http.httpDelete'),
+        options
       ),
       path
     )

--- a/packages/node_modules/@cerebral/http/src/operators/httpGet.js
+++ b/packages/node_modules/@cerebral/http/src/operators/httpGet.js
@@ -1,12 +1,13 @@
 import { processResponse } from '../utils'
 import { convertObjectWithTemplates } from 'cerebral/tags'
 
-function httpGetFactory(url, query = {}) {
+function httpGetFactory(url, query = {}, options) {
   function httpGet({ http, path, resolve }) {
     return processResponse(
       http.get(
         resolve.value(url),
-        convertObjectWithTemplates(query, resolve, 'http.httpGet')
+        convertObjectWithTemplates(query, resolve, 'http.httpGet'),
+        options
       ),
       path
     )

--- a/packages/node_modules/@cerebral/http/src/operators/httpPatch.js
+++ b/packages/node_modules/@cerebral/http/src/operators/httpPatch.js
@@ -1,12 +1,13 @@
 import { processResponse } from '../utils'
 import { convertObjectWithTemplates } from 'cerebral/tags'
 
-function httpPatchFactory(url, body = {}) {
+function httpPatchFactory(url, body = {}, options) {
   function httpPatch({ http, path, resolve }) {
     return processResponse(
       http.patch(
         resolve.value(url),
-        convertObjectWithTemplates(body, resolve, 'http.httpPatch')
+        convertObjectWithTemplates(body, resolve, 'http.httpPatch'),
+        options
       ),
       path
     )

--- a/packages/node_modules/@cerebral/http/src/operators/httpPost.js
+++ b/packages/node_modules/@cerebral/http/src/operators/httpPost.js
@@ -1,12 +1,13 @@
 import { processResponse } from '../utils'
 import { convertObjectWithTemplates } from 'cerebral/tags'
 
-function httpPostFactory(url, body = {}) {
+function httpPostFactory(url, body = {}, options) {
   function httpPost({ http, path, resolve }) {
     return processResponse(
       http.post(
         resolve.value(url),
-        convertObjectWithTemplates(body, resolve, 'http.httpPost')
+        convertObjectWithTemplates(body, resolve, 'http.httpPost'),
+        options
       ),
       path
     )

--- a/packages/node_modules/@cerebral/http/src/operators/httpPut.js
+++ b/packages/node_modules/@cerebral/http/src/operators/httpPut.js
@@ -1,12 +1,13 @@
 import { processResponse } from '../utils'
 import { convertObjectWithTemplates } from 'cerebral/tags'
 
-function httpPutFactory(url, body = {}) {
+function httpPutFactory(url, body = {}, options) {
   function httpPut({ http, path, resolve }) {
     return processResponse(
       http.put(
         resolve.value(url),
-        convertObjectWithTemplates(body, resolve, 'http.httpPut')
+        convertObjectWithTemplates(body, resolve, 'http.httpPut'),
+        options
       ),
       path
     )


### PR DESCRIPTION
`@cerebral/http` operators now accept and pass through options.