### PR TITLE
add context callback version of provide API

### DIFF
--- a/docs/introduction/providers.md
+++ b/docs/introduction/providers.md
@@ -40,7 +40,6 @@ const controller = Controller({
 
 Note that some tools has a very complex API that is difficult for Cerebral to analyze. With these kinds of tools it is a better idea to create your own provider, exposing APIs that you actually use from the original tool.
 
-## Creating a provider
 You can use providers for pretty much anything, though typically it is to handle some kind of side effect. Examples of providers is [@cerebral/storage](https://github.com/cerebral/cerebral/tree/master/packages/storage), [@cerebral/firebase](https://github.com/cerebral/cerebral/tree/master/packages/firebase) and [@cerebral/http](https://github.com/cerebral/cerebral/tree/master/packages/http).
 
 To use a provider with Cerebral you put it in the providers array:
@@ -54,6 +53,8 @@ const controller = Controller({
   ]
 })
 ```
+
+## Creating a provider
 
 The **provide** factory helps you add your own providers in a simple way:
 

--- a/packages/node_modules/cerebral/src/Provide.js
+++ b/packages/node_modules/cerebral/src/Provide.js
@@ -1,6 +1,8 @@
 export default function Provide(name, provider) {
+  let cachedProvider = typeof provider === 'function' ? null : provider
+
   return function(context) {
-    context[name] = provider
+    context[name] = cachedProvider = cachedProvider || provider(context)
 
     if (context.debugger) {
       context.debugger.wrapProvider(name)

--- a/packages/node_modules/cerebral/src/Provide.test.js
+++ b/packages/node_modules/cerebral/src/Provide.test.js
@@ -18,4 +18,20 @@ describe('Provide', () => {
     })
     controller.getSignal('test')()
   })
+  it('should allow function passed the context', done => {
+    const controller = new Controller({
+      providers: [
+        provide('test', context => ({ controller: context.controller })),
+      ],
+      signals: {
+        test: [
+          ({ test, controller }) => {
+            assert.equal(test.controller, controller)
+            done()
+          },
+        ],
+      },
+    })
+    controller.getSignal('test')()
+  })
 })


### PR DESCRIPTION
This heavily simplifies creating providers.

```js
provide('foo', {})
```

Is current API, but now added

```js
provide('foo', (context) => ({}))
```

Basically the low level version is no longer needed, only for internal crazy stuff. So have highlighted these two simple approaches and explicitly stated the manual one as "low level". All packages can really start using the `provide` with a function now. Caching and debugger wrapping for free :)

Thanks @Guria for inspiration!