### PR TITLE
fix(storage): Setting key value to undefined should unset key

### DIFF
--- a/packages/node_modules/@cerebral/storage/src/StorageProvider.js
+++ b/packages/node_modules/@cerebral/storage/src/StorageProvider.js
@@ -17,10 +17,12 @@ function StorageProvider(name, options = {}) {
             if (change.path.join('.').indexOf(options.sync[syncKey]) === 0) {
               const value = context.controller.getState(options.sync[syncKey])
 
-              target.setItem(
-                options.prefix + syncKey,
-                options.json ? JSON.stringify(value) : value
-              )
+              value === undefined
+                ? target.removeItem(options.prefix + syncKey)
+                : target.setItem(
+                    options.prefix + syncKey,
+                    options.json ? JSON.stringify(value) : value
+                  )
             }
           })
         })
@@ -48,10 +50,13 @@ function StorageProvider(name, options = {}) {
         return resolveValue(value)
       },
       set(key, value) {
-        const maybePromise = target.setItem(
-          options.prefix + key,
-          options.json ? JSON.stringify(value) : value
-        )
+        const maybePromise =
+          value === undefined
+            ? target.removeItem(options.prefix + key)
+            : target.setItem(
+                options.prefix + key,
+                options.json ? JSON.stringify(value) : value
+              )
 
         if (maybePromise instanceof Promise) {
           return maybePromise.catch(error => {


### PR DESCRIPTION
When setting a value to undefined it gets serialised to 'undefined' string, then when parsing the storage value back to json later it fails since 'undefined' is truthy.

Instead it should not be possible to set undefined, setting undefined now removes the key.

This also fixes sync with unset state values.