### PR TITLE
Include addRoutes method on router module

### DIFF
--- a/packages/node_modules/@cerebral/router/README.md
+++ b/packages/node_modules/@cerebral/router/README.md
@@ -340,3 +340,40 @@ const controller = Controller({
   }
 })
 ```
+
+#### Dynamically add routes
+
+Apps that use code splitting for security reasons may not want to define all routes until after the user has been verified.
+
+The `addRoutes()` method allows routes to be added after the app has been initialized.
+
+Define your initial set of routes as normal:
+```js
+import Router from '@cerebral/router';
+
+export default Router({
+  routes: [
+    { path: '/', signal: 'homeRouted' },
+    { path: '/login', signal: 'loginRouted' }
+  ]
+});
+```
+
+Then later you can call `addRoutes`:
+```js
+import router from './router';
+
+router.addRoutes([
+  { path: '/now-you-see-me', signal: 'hiddenModule.hiddenRouted' }
+]);
+```
+
+When used together with code splitting and `controller.addModule()` you can dynamically add functionality to a running cerebral application.
+
+The only gotcha is that you might need to refresh the current route when reloading the app. Due to the order of evens, the router may fire before the routes have loaded, This can be handled with an action that should be called after the `addRoutes` method has been called:
+```js
+export default function reloadRoute({ router }) {
+  const path = document.location.pathname;
+  router.redirect(path);
+}
+```

--- a/packages/node_modules/@cerebral/router/src/base.js
+++ b/packages/node_modules/@cerebral/router/src/base.js
@@ -36,5 +36,9 @@ export default function(options = {}) {
     )
   }
 
+  routerModule.addRoutes = function addRoutes(routes) {
+    return router.addRoutes(routes)
+  }
+
   return routerModule
 }

--- a/packages/node_modules/@cerebral/router/src/router.js
+++ b/packages/node_modules/@cerebral/router/src/router.js
@@ -48,6 +48,12 @@ export default class Router {
     })
   }
 
+  addRoutes(routes) {
+    this.options.routes = [...routes, ...this.options.routes]
+    this.routesConfig = flattenConfig(this.options.routes)
+    this.routesBySignal = getRoutesBySignal(this.routesConfig, this.controller)
+  }
+
   getRoutablePart(url) {
     let path = url.replace(this.addressbar.origin, '')
     if (path[0] !== '/') {


### PR DESCRIPTION
Adds the option to add new routes after the router module has been initialised. Useful for lazy loading app parts and for app security.

Not tested, just a concept!!!