### PR TITLE
feat(cerebral): expose the controller in CerebralTest response

### DIFF
--- a/docs/introduction/test.md
+++ b/docs/introduction/test.md
@@ -118,13 +118,18 @@ it('should increment numbers in state', () => {
 
 ## Signals
 
-The `CerebralTest` factory returns runSignal, setState and getState functions.
+The `CerebralTest` factory returns runSignal, setState and getState functions as well as the controller.
 
 ```js
 const cerebral = CerebralTest(fixture, options)
 cerebral.setState(path, value)
 cerebral.runSignal(signal, props).then((result) => {})
 const value = cerebral.getState(path)
+const wrapper = mount(
+  <Container controller={cerebral.controller}>
+    <Login />
+  </Container>
+)
 ```
 
 The `fixture` argument will be passed to the cerebral controller so can contain the same properties (state, signals, modules, etc...). Note that state initialized in a module takes precedence over the state property of a fixture. Example:

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -1,11 +1,11 @@
-import { DevTools } from "./devtools"
-import { FunctionTree, Payload, Provider, FunctionTreeExecutable} from 'function-tree'
+import { DevTools } from './devtools'
+import { FunctionTree, Payload, Provider, FunctionTreeExecutable } from 'function-tree'
 import { Tag } from './tags'
 
 export interface StateModel {
   concat(path: string, arr: any[]): void
   increment(path: string, amount?: number): void
-  get<T=any>(path?: string): T | undefined
+  get<T = any>(path?: string): T | undefined
   merge(path: string, {}): void
   pop(path: string): void
   push(path: string, value: any): void
@@ -29,7 +29,7 @@ export interface Resolve {
 }
 
 export interface ActionContextBase {
-  [providerName: string]: any  
+  [providerName: string]: any
   controller: ControllerClass
   debugger: any
   execution: any
@@ -40,11 +40,11 @@ export interface ActionContextBase {
 
 export type ActionContext<C = {}> = ActionContextBase & C
 
-export interface Action<C=any,T=void> extends FunctionTreeExecutable {
+export interface Action<C = any, T = void> extends FunctionTreeExecutable {
   (context: ActionContext<C>): T
 }
 
-export type ActionFactory<T={}> = (...args: any[]) => Action<T>
+export type ActionFactory<T = {}> = (...args: any[]) => Action<T>
 
 interface Paths extends FunctionTreeExecutable {
   [path: string]: Chain
@@ -54,28 +54,28 @@ export type Chain = FunctionTreeExecutable | FunctionTreeExecutable
 export type SignalChain = Chain
 export type ActionChain = Chain
 
-type SignalsMap = { 
+type SignalsMap = {
   [signalName: string]: SignalChain
 }
 
 interface ModuleObject {
-  state?: any,
-  signals?: SignalsMap,
-  modules?: any,
+  state?: any
+  signals?: SignalsMap
+  modules?: any
   provider?(context: any, functionDetails: any, payload: any): void
 }
 
-type ModuleFunction = (module: {name: string, path: string, controller: ControllerClass}) => ModuleObject
+type ModuleFunction = (module: { name: string; path: string; controller: ControllerClass }) => ModuleObject
 
 export type Module = ModuleObject | ModuleFunction
 
-type ModulesMap = { 
+type ModulesMap = {
   [moduleName: string]: Module
 }
 
-export type Signal<T=any> = (props?: T) => void
+export type Signal<T = any> = (props?: T) => void
 
-interface ControllerOptions {
+export interface ControllerOptions {
   state?: any
   signals?: SignalsMap
   providers?: Provider[]
@@ -98,38 +98,35 @@ export interface ControllerClass extends FunctionTree {
 
 export function Controller(config?: ControllerOptions): ControllerClass
 
-export type ValueResolver = <T=any>(tag: Tag<T>) => T
+export type ValueResolver = <T = any>(tag: Tag<T>) => T
 
-export class Computed<T=any> implements FunctionTreeExecutable {
-  constructor(...args: (any|ValueResolver)[])
+export class Computed<T = any> implements FunctionTreeExecutable {
+  constructor(...args: (any | ValueResolver)[])
   getValue(getters: any): T
 }
 
 type TagOrComputed<T> = Tag<T> | Computed<T> | T
 
-export function compute<A,T>(
-  arg1: TagOrComputed<A>,
-  fn: (arg1: A, get: ValueResolver) => T
-): Computed<T>
-export function compute<A,B,T>(
+export function compute<A, T>(arg1: TagOrComputed<A>, fn: (arg1: A, get: ValueResolver) => T): Computed<T>
+export function compute<A, B, T>(
   arg1: TagOrComputed<A>,
   arg2: TagOrComputed<B>,
   fn: (arg1: A, arg2: B, get: ValueResolver) => T
 ): Computed<T>
-export function compute<A,B,C,T>(
+export function compute<A, B, C, T>(
   arg1: TagOrComputed<A>,
   arg2: TagOrComputed<B>,
   arg3: TagOrComputed<C>,
   fn: (arg1: A, arg2: B, arg3: C, get: ValueResolver) => T
 ): Computed<T>
 
-export function compute<A,B,T>(value1: Tag<A> | A, value2: Tag<B> | B, fn: ( value1: A, value2: B ) => T ): Computed<T>
-export function compute<A,T>(value1: Tag<A> | A, fn: ( value1: A ) => T ): Computed<T>
-export function compute<T=any>(...args: any[]): Computed<T>
+export function compute<A, B, T>(value1: Tag<A> | A, value2: Tag<B> | B, fn: (value1: A, value2: B) => T): Computed<T>
+export function compute<A, T>(value1: Tag<A> | A, fn: (value1: A) => T): Computed<T>
+export function compute<T = any>(...args: any[]): Computed<T>
 export function provide(name: string, provider: any): Provider
 
 export { sequence, parallel } from 'function-tree'
 
 export class View {
-    constructor(config:any)
+  constructor(config: any)
 }

--- a/packages/node_modules/cerebral/src/test/index.js
+++ b/packages/node_modules/cerebral/src/test/index.js
@@ -21,10 +21,10 @@ export function runCompute(compute, fixtures = {}) {
 
 export function runSignal(signal, fixtures = {}, options = {}) {
   return new Promise((resolve, reject) => {
-    const recordActions = options.recordActions &&
-      options.recordActions === 'byName'
-      ? 'name'
-      : 'functionIndex'
+    const recordActions =
+      options.recordActions && options.recordActions === 'byName'
+        ? 'name'
+        : 'functionIndex'
     const isSignal = Array.isArray(signal) || signal instanceof Primitive
     const controller =
       options.controller ||
@@ -95,6 +95,7 @@ export function CerebralTest(fixtures = {}, options = {}) {
   const controller = Controller(Object.assign({}, fixtures))
   const model = controller.getModel()
   return {
+    controller,
     runSignal(signal, props) {
       return runSignal(
         signal,

--- a/packages/node_modules/cerebral/test.d.ts
+++ b/packages/node_modules/cerebral/test.d.ts
@@ -1,4 +1,4 @@
-import { Action, Computed, ControllerClass, SignalChain } from './'
+import { Action, Computed, ControllerClass, SignalChain, ControllerOptions } from './'
 
 export interface RunActionResult<P, T> {
   controller: ControllerClass
@@ -22,8 +22,8 @@ interface RunSignalResult2<P, T0, T1, T2> {
   '2': RunActionResult<P, T2>
 }
 
-export function runAction<P=any, T=any>(
-  action: Action<P,Promise<T> | T>,
+export function runAction<P = any, T = any>(
+  action: Action<P, Promise<T> | T>,
   fixtures?: { props: P & any } & any
 ): Promise<RunActionResult<P, T>>
 
@@ -36,35 +36,24 @@ export function runSignal<P, T0>(
 ): Promise<RunSignalResult0<P, T0>>
 
 export function runSignal<P, T0, T1>(
-  signal: [
-    Action<P, Promise<T0> | T0>,
-    Action<any, Promise<T1> | T1>
-  ],
+  signal: [Action<P, Promise<T0> | T0>, Action<any, Promise<T1> | T1>],
   fixtures?: { props: P & any } & any,
   options?: any
 ): Promise<RunSignalResult1<P, T0, T1>>
 
 export function runSignal<P, T0, T1, T2>(
-  signal: [
-    Action<P, Promise<T0> | T0>,
-    Action<any, Promise<T1> | T1>,
-    Action<any, Promise<T2> | T2>
-  ],
+  signal: [Action<P, Promise<T0> | T0>, Action<any, Promise<T1> | T1>, Action<any, Promise<T2> | T2>],
   fixtures?: { props: P & any } & any,
   options?: any
 ): Promise<RunSignalResult2<P, T0, T1, T2>>
 
-export function runSignal(
-  signal: SignalChain,
-  fixtures?: any,
-  options?: any
-): Promise<any>
-
+export function runSignal(signal: SignalChain, fixtures?: any, options?: any): Promise<any>
 
 interface CerebralTestType {
-  runSignal<T=any>(signal: SignalChain, props: any): Promise<T>
+  controller: ControllerClass
+  runSignal<T = any>(signal: SignalChain, props: any): Promise<T>
   setState(path: string, value: any): void
   getState(path: string): any
 }
 
-export function CerebralTest(fixtures: any, options: any): CerebralTestType
+export function CerebralTest(fixtures: ControllerOptions, options?: any): CerebralTestType

--- a/packages/node_modules/function-tree/index.d.ts
+++ b/packages/node_modules/function-tree/index.d.ts
@@ -21,9 +21,16 @@ export class Abort {
   constructor(payload: Payload)
 }
 
-export function createStaticTree(tree: Sequence | Parallel | FunctionTreePrimitive | Array<Function | Sequence | Parallel>): Array<FunctionTreePrimitive>
+export function createStaticTree(
+  tree: Sequence | Parallel | FunctionTreePrimitive | Array<Function | Sequence | Parallel>
+): Array<FunctionTreePrimitive>
 
-type RunFunctionResolve = (funcDetails: FunctionTreePrimitive, payload: Payload, prevPayload: Payload, next: any) => void
+type RunFunctionResolve = (
+  funcDetails: FunctionTreePrimitive,
+  payload: Payload,
+  prevPayload: Payload,
+  next: any
+) => void
 type BranchStartCallback = (funcDetails: FunctionTreePrimitive, path: string, payload: Payload) => void
 type BranchEndCallback = (payload: Payload) => void
 type ParallelStartEndCallback = (payload: Payload, itemLength: number) => void
@@ -43,21 +50,20 @@ export function executeTree(
 
 export interface FunctionTreePrimitive {
   name?: string
-  "function": Function
+  function: Function
   functionIndex: number
   items: Array<FunctionTreePrimitive>
-  type: "parallel" | "sequence"
+  type: 'parallel' | 'sequence'
   _functionTreePrimitive: boolean
   outputs?: { [name: string]: FunctionTreePrimitive }
 }
 
-export interface FunctionTreeExecutable {
-}
+export interface FunctionTreeExecutable {}
 
 export class Sequence implements FunctionTreeExecutable {
-  constructor(items: Array<FunctionTreePrimitive>)  
-  constructor(name: string, items: Array<FunctionTreePrimitive>)  
-  
+  constructor(items: Array<FunctionTreePrimitive>)
+  constructor(name: string, items: Array<FunctionTreePrimitive>)
+
   toJSON(): FunctionTreePrimitive
 }
 
@@ -80,7 +86,6 @@ export interface RunTreeFunction {
   once(event: string | symbol, listener: Function): this
   off(event: string | symbol, listener: Function): this
 }
-
 
 export interface DebounceFunction extends FunctionTreeExecutable {
   displayName: string
@@ -107,11 +112,15 @@ export class Devtools {
   sendMessage(message: string): void
   watchExecution(tree: FunctionTree): void
   sendInitial(): void
-  createExecutionMessage(debuggingData: any, context: any, functionDetails: FunctionTreePrimitive, payload: Payload): string
+  createExecutionMessage(
+    debuggingData: any,
+    context: any,
+    functionDetails: FunctionTreePrimitive,
+    payload: Payload
+  ): string
   sendExecutionData(debuggingData: any, context: any, functionDetails: FunctionTreePrimitive, payload: Payload): void
   Provider(): (context: any, functionDetails: FunctionTreePrimitive, payload: Payload) => any
 }
-
 
 export class FunctionTreeError extends Error {
   constructor(error: any)


### PR DESCRIPTION
Having direct access to the controller allows you to use it in render tests

```js
    const cerebral = CerebralTest({ modules: { login: LoginModule() } });
    const wrapper = mount(
      <Container controller={cerebral.controller}>
        <Login />
      </Container>
    );
    expect(wrapper.find('.submit-button')).toHaveProp('disabled', false);
```