### PR TITLE
fix(function-tree): use indexOf instead of startsWith available only in ES6

### DIFF
--- a/packages/node_modules/function-tree/src/staticTree.js
+++ b/packages/node_modules/function-tree/src/staticTree.js
@@ -7,8 +7,8 @@ function getFunctionName(fn) {
   let ret = fn.toString()
 
   let startNameMatch
-  if (ret.startsWith('async function')) startNameMatch = 'async function '
-  else if (ret.startsWith('function')) startNameMatch = 'function '
+  if (ret.indexOf('async function') === 0) startNameMatch = 'async function '
+  else if (ret.indexOf('function') === 0) startNameMatch = 'function '
 
   ret = ret.substr(startNameMatch ? startNameMatch.length : 0)
   ret = ret.substr(0, ret.indexOf('('))


### PR DESCRIPTION
fixes #1140 