### PR TITLE
feat(View): allow props to be a function that gets run executed with ext props

### DIFF
--- a/packages/node_modules/cerebral/src/View.js
+++ b/packages/node_modules/cerebral/src/View.js
@@ -19,9 +19,7 @@ class View {
     onUpdate,
   }) {
     if (typeof dependencies === 'function') {
-      throwError(
-        'You can not use a function to define dependencies. Use tags or a function on the specific property you want to dynamically create'
-      )
+      dependencies = dependencies(props);
     }
 
     if (!dependencies) {


### PR DESCRIPTION
This is just a proposal PR that allows dependencies to be passed as a function like we used to.

Allows:

```js
connect(extProps => ({
   name: state`name`,
   location: state`locations.${extProps.locNumber}`
}), Component);
```

Extremely useful for my fully typed implementation that is very close.