### PR TITLE
feat(firebase-admin): depend on latest version of firebase-admin

### DIFF
--- a/packages/node_modules/@cerebral/firebase-admin/package.json
+++ b/packages/node_modules/@cerebral/firebase-admin/package.json
@@ -10,10 +10,12 @@
   },
   "dependencies": {
     "faye-websocket": "^0.11.1",
-    "firebase": "^3.9.0",
-    "firebase-admin": "^4.0.4",
-    "firebase-queue": "^1.6.0",
     "proxyquire": "^1.7.11"
+  },
+  "peerDependencies": {
+    "firebase": "^5.4.3",
+    "firebase-admin": "^4.0.4",
+    "firebase-queue": "^1.6.0"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
BREAKING CHANGE:

Might break where firebase-admin is used directly. Be sure to depend on same version in own

package.json if any