### PR TITLE
ts(inferno): use InfernoChildren type instead of undefined JSX type

### DIFF
--- a/packages/node_modules/@cerebral/inferno/index.d.ts
+++ b/packages/node_modules/@cerebral/inferno/index.d.ts
@@ -1,9 +1,10 @@
+import { InfernoChildren } from 'inferno';
 
 export function StateContainer(opts: any): any
 
 export interface ContainerInterface {
     getChildContext(): any
-    render(): JSX.Element | null
+    render(): InfernoChildren
 }
 export function Container(opts: any): any
 


### PR DESCRIPTION
related issue: #1141 

TODO:

- [ ] Fix other `Inferno` missing/any type

- [ ] Add tests for `@cerebral/inferno` type definition file to cover basic usage