### PR TITLE
Add 'signals' tag to target all the signals of the specified module

### DIFF
--- a/docs/api/tags.md
+++ b/docs/api/tags.md
@@ -14,4 +14,5 @@ This allows you to express signals and component dependencies more effectively. 
 - **state** - Used in signals and connect to target state
 - **props** - Used in signals to target payload and in connect to target component props
 - **signal** - Used in signals and connect to target a signal
+- **signals** - Used in connect to target all the signals of the specified module
 - **string** - Used in signals to evaluate a composed string

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -34,10 +34,17 @@ class BaseController extends FunctionTree {
       stateChanges = typeof window !== 'undefined' && window.CEREBRAL_STATE,
     } = config
     const getSignal = this.getSignal
+    const getSignals = this.getSignals
 
     this.getSignal = () => {
       throwError(
         'You are grabbing a signal before controller has initialized, please wait for "initialized" event'
+      )
+    }
+
+    this.getSignals = () => {
+      throwError(
+        'You are grabbing a signals before controller has initialized, please wait for "initialized" event'
       )
     }
 
@@ -81,6 +88,7 @@ class BaseController extends FunctionTree {
     }
 
     this.getSignal = getSignal
+    this.getSignals = getSignals
 
     this.emit('initialized')
   }
@@ -174,6 +182,26 @@ class BaseController extends FunctionTree {
     const signal = module && module.signals[signalKey]
 
     return signal && signal.run
+  }
+  getSignals(modulePath) {
+    const pathArray = ensurePath(modulePath)
+    const module = pathArray.reduce((currentModule, key) => {
+      return currentModule ? currentModule.modules[key] : undefined
+    }, this.module)
+
+    const signals = module && module.signals
+
+    if (!signals) {
+      return undefined
+    }
+
+    const callableSignals = {}
+    for (const name in signals) {
+      const signal = signals[name].run
+      callableSignals[name] = signal
+    }
+
+    return callableSignals
   }
   addModule(path, module) {
     const pathArray = ensurePath(path)

--- a/packages/node_modules/cerebral/src/Controller.test.js
+++ b/packages/node_modules/cerebral/src/Controller.test.js
@@ -139,6 +139,7 @@ describe('Controller', () => {
     })
     assert.ok(controller.getSignal('foo'))
     assert.ok(controller.getSignal('moduleA.foo'))
+    assert.ok(controller.getSignals('moduleA'))
   })
   it('should expose method to get model', () => {
     const controller = new Controller({

--- a/packages/node_modules/cerebral/src/View.js
+++ b/packages/node_modules/cerebral/src/View.js
@@ -31,6 +31,7 @@ class View {
     }
     this.stateGetter = this.stateGetter.bind(this)
     this.signalGetter = this.signalGetter.bind(this)
+    this.signalsGetter = this.signalsGetter.bind(this)
     this.mergeProps = mergeProps
     this.controller = controller
     this._displayName = displayName
@@ -78,6 +79,12 @@ class View {
   */
   signalGetter(path) {
     return this.controller.getSignal(path)
+  }
+  /*
+    A getter for tags to grab signals of module from Cerebral
+  */
+  signalsGetter(modulePath) {
+    return this.controller.getSignals(modulePath)
   }
   /*
     A method to ensure objects and arrays from state tree are not passed as props
@@ -298,6 +305,7 @@ class View {
       state: this.stateGetter,
       props: props,
       signal: this.signalGetter,
+      signals: this.signalsGetter,
     }
   }
   /*

--- a/packages/node_modules/cerebral/src/View.test.js
+++ b/packages/node_modules/cerebral/src/View.test.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-new */
 import View from './View'
 import { Controller, compute } from './'
-import { state, props, signal } from './tags'
+import { state, props, signal, signals } from './tags'
 import assert from 'assert'
 
 describe('View', () => {
@@ -148,17 +148,26 @@ describe('View', () => {
       signals: {
         someSignal: [],
       },
+      modules: {
+        someModule: {
+          signals: {
+            moduleSignal: [],
+          },
+        },
+      },
     })
     const view = new View({
       dependencies: {
         foo: state`foo`,
         signal: signal`someSignal`,
+        moduleSignals: signals`someModule`,
       },
       controller,
     })
     const componentProps = view.getProps()
     assert.equal(componentProps.foo, 'bar')
     assert.ok(typeof componentProps.signal === 'function')
+    assert.ok(typeof componentProps.moduleSignals.moduleSignal === 'function')
   })
   it('should allow props tag', () => {
     const controller = Controller({

--- a/packages/node_modules/cerebral/src/tags/index.js
+++ b/packages/node_modules/cerebral/src/tags/index.js
@@ -20,6 +20,15 @@ export const signal = createTemplateTag('signal', (path, context) => {
   return context.controller.getSignal(path)
 })
 
+export const signals = createTemplateTag('signals', (path, context) => {
+  // View
+  if (typeof context.signal === 'function') {
+    return context.signals(path)
+  }
+
+  return context.controller.getSignals(path)
+})
+
 export const state = createTemplateTag('state', (path, context) => {
   // Computed tracking and View
   if (typeof context.state === 'function') {

--- a/packages/node_modules/cerebral/tags/index.d.ts
+++ b/packages/node_modules/cerebral/tags/index.d.ts
@@ -3,5 +3,6 @@ export { resolveObject, ResolveValue, Tag } from 'function-tree'
 
 export function props<T=any>(path: TemplateStringsArray | string[], ...values: any[]): Tag<T>
 export function signal<T=any>(path: TemplateStringsArray | string[], ...values: any[]): Tag<T>
+export function signals<T=any>(path: TemplateStringsArray | string[], ...values: any[]): Tag<T>
 export function state<T=any>(path: TemplateStringsArray | string[], ...values: any[]): Tag<T>
 export function string(path: TemplateStringsArray | string[], ...values: any[]): Tag<string>


### PR DESCRIPTION
Hello! I thought it was a good idea to allow all module signals to be pushed right into the view without needing to specify each signal separately.

Example of usage:
```
@connect({
  moduleSignals: signals`someModule`
})
...
props.moduleSignals.moduleSignal(payload)
```

What do you think about it?
This PR is the recreation of https://github.com/cerebral/cerebral/pull/1155