### PR TITLE
docs(website): add official typescript docs

### DIFF
--- a/docs/introduction/typescript.md
+++ b/docs/introduction/typescript.md
@@ -1,0 +1,1 @@
+# Typescript

--- a/docs/introduction/typescript.md
+++ b/docs/introduction/typescript.md
@@ -1,1 +1,54 @@
-# Typescript
+# TypeScript
+
+When writing applications with Cerebral and TypeScript, the simplest and most comfortable solution
+is to create a single file exporting the state, signals and context types. By using an alias in
+tsconfig, you can import this file anywhere without having to worry about relative paths.
+
+For this documentation, let's say you export these types from an 'app.ts' file, imported with 'app'.
+
+## Actions
+
+When writing actions, you can precisely type the arguments. In order for your action context to
+include your providers' types, you can wrap `ActionContext` inside your `app.ts` file:
+
+```ts
+// ====== app.ts
+import { ActionContext as BaseActionContext } from 'cerebral'
+
+interface Providers {
+  foo: FooProviderType
+  // etc
+}
+
+export type ActionContext<C = { props: any }> = BaseActionContext < C & Providers >
+```
+
+Now in your actions file, you can import your context definition and use it to type the function's
+arguments:
+
+```ts
+// ====== myAction.ts
+import { ActionContext } from 'app'
+
+export function myAction ( { props, foo, state }: ActionContext ) {
+
+}
+```
+
+If you want to be even more precise and include the props passed to the action, you can do this:
+
+```ts
+// ====== myAction.ts
+import { ActionContext } from 'app'
+
+interface Props {
+  name: string
+  id: string
+  age: number
+  // ...
+}
+
+export function myAction ( { props, foo, state }: ActionContext < Props > ) {
+  const { name, id, age } = props // all are typed here
+}
+```

--- a/packages/website/builder/config.json
+++ b/packages/website/builder/config.json
@@ -28,7 +28,8 @@
       "../../../docs/introduction/errors",
       "../../../docs/introduction/views",
       "../../../docs/introduction/compute",
-      "../../../docs/introduction/test"
+      "../../../docs/introduction/test",
+      "../../../docs/introduction/typescript"
     ],
     "api": [
       "../../../docs/api/action",


### PR DESCRIPTION
Okay, so I need help with this :)

I think we should write official typescript docs recommending how to write Cerebral with typescript. These are the things I hope we can get in there with as much type stuff and autosuggestions as possible:

- Signals
- Actions
- State
- Connect

I think the docs would be nice with a short summary on top of what Typescript helps you with and then specific subtitles of API it affects and example.

Think this would be a great start for the official Typescript story :)