### PR TITLE
@observer has to be after @inject

### DIFF
--- a/packages/node_modules/@cerebral/mobx-state-tree/README.md
+++ b/packages/node_modules/@cerebral/mobx-state-tree/README.md
@@ -107,8 +107,8 @@ render((
 import React from 'react'
 import {observer, inject} from 'mobx-react'
 
-@observer
 @inject('store', 'signals')
+@observer
 class App extends React.Component {
   renderBoxes () {
     const {store, signals} = this.props


### PR DESCRIPTION
TypeScript complains if the order of these decorators is different.

```index.module.js:858 Mobx observer: You are trying to use 'observer' on a component that already has 'inject'. Please apply 'observer' before applying 'inject```