### PR TITLE
maxLength: check isExisty before checking length

### DIFF
--- a/packages/node_modules/@cerebral/forms/src/rules.js
+++ b/packages/node_modules/@cerebral/forms/src/rules.js
@@ -80,7 +80,9 @@ const rules = {
     return value === get(state`${field}.value`)
   },
   maxLength(value, length) {
-    return value.length <= length
+    return (
+      !rules.isExisty(value) || value.length <= length
+    )
   },
   minLength(value, length) {
     return (


### PR DESCRIPTION
maxLength checks on null or undefined lead to an exception. Note that contrary to minLength, we don't need to check isEmpty since the length is defined for an empty string and its length 0 works fine with maxLength.