### PR TITLE
Change inferno render hook to avoid TypeError on SSR

### DIFF
--- a/packages/node_modules/@cerebral/inferno/src/Hoc.js
+++ b/packages/node_modules/@cerebral/inferno/src/Hoc.js
@@ -26,7 +26,7 @@ class BaseComponent extends Component {
     Register the component to the dependency store with its
     state tracker and tags state dependencies
   */
-  componentWillMount() {
+  componentDidMount() {
     this.view.mount()
   }
   /*


### PR DESCRIPTION
Registering inferno components within componentDidMount triggers a "TypeError: Cannot read property 'dom' of null" on server side.

According to https://daveceddia.com/where-fetch-data-componentwillmount-vs-componentdidmount/ it might be better to use componentDidMount instead of componentWillMount. Tested without issue on local project.

Review and discussion welcome.

Probably related to this issue: https://github.com/infernojs/inferno/issues/1215