### PR TITLE
fix(Module): expose ModuleClass so that we can test for instanceof.

### DIFF
--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -1,4 +1,4 @@
-import { DevTools } from "./devtools"
+import { DevTools } from './devtools'
 import { Context, FunctionTree, Payload, Provider, Resolve, ResolveValue, FunctionTreeExecutable} from 'function-tree'
 
 export interface StateModel {
@@ -62,7 +62,7 @@ type ModuleFunction = (module: {name: string, path: string, controller: Controll
 
 export type ModuleDefinition = ModuleObject | ModuleFunction
 
-export interface ModuleClass {
+export class ModuleClass {
   // not public API
   create(controller: ControllerClass, path: string): void
 }

--- a/packages/node_modules/cerebral/src/Module.test.js
+++ b/packages/node_modules/cerebral/src/Module.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import { sequence, Controller, Module } from './'
+import { sequence, Controller, Module, ModuleClass } from './'
 import assert from 'assert'
 
 describe('Module', () => {
@@ -12,6 +12,7 @@ describe('Module', () => {
     const controller = new Controller(rootModule)
 
     assert.deepEqual(controller.getState(), { foo: 'bar' })
+    assert.ok(rootModule instanceof ModuleClass)
   })
   it('should instantiate with signals', () => {
     const rootModule = Module({

--- a/packages/node_modules/cerebral/src/index.js
+++ b/packages/node_modules/cerebral/src/index.js
@@ -2,6 +2,8 @@ import BaseControllerClass from './BaseController'
 import ControllerClass from './Controller'
 import UniversalControllerClass from './UniversalController'
 import ModuleClass from './Module'
+// Needed to test for instanceof.
+export { default as ModuleClass } from './Module'
 
 export function BaseController(rootModule, options) {
   return new BaseControllerClass(rootModule, options)


### PR DESCRIPTION
This is needed to detect if an exported module is a Module or not.

In 'blocks', I use functions to define signals and therefore need to pass module definitions to 'boot' without wrapping them. Wrap with Module should only be done if it hasn't been done yet (like with router), hence the instanceof thing.

As a general question, I am wondering why we expose `Module` publicly at all. It would make the API much simpler without it, letting the controller do the wrapping.
