### PR TITLE
fix(router): preserve the default state value

### DIFF
--- a/packages/node_modules/@cerebral/router/README.md
+++ b/packages/node_modules/@cerebral/router/README.md
@@ -297,22 +297,22 @@ const controller = Controller({
 
 #### computed mapping
 
-You can use a `compute` value here to run a computed in order to prepare
+You can use a `Compute` value here to run a computed in order to prepare
 the value passed to build the url.
 
 ```js
 map: {
-  urlKey: compute(/* ... */)
+  urlKey: Compute(/* ... */)
 }
 ```
 
-If you use a `compute` the router cannot map back from the url key to the
+If you use a `Compute` the router cannot map back from the url key to the
 state and you need to define a reverse map with `rmap`:
 
 ```js
 rmap: {
-  'some.state': compute(props`urlKey`, (urlKey) => /* ... */),
-  'other.state': compute(props`urlKey`, (urlKey) => /* ... */)
+  'some.state': Compute(props`urlKey`, (urlKey) => /* ... */),
+  'other.state': Compute(props`urlKey`, (urlKey) => /* ... */)
 }
 ```
 
@@ -330,7 +330,7 @@ const controller = Controller({
           // This maps a complex app state to the `opts` param in
           // url query.
           map: {
-            opts: compute(
+            opts: Compute(
               state`projectId`,
               state`user.lang`,
               (projectId, lang) => ({projectId, lang})
@@ -339,12 +339,12 @@ const controller = Controller({
           // This parses the url query `opts` into two state values.
           // It does a 'reverse map' hence the 'rmap' name.
           rmap: {
-            'projectId': compute(
+            'projectId': Compute(
               state`projectId`,
               props`opts`,
               (projectId, opts) => opts.projectId || projectId
             ),
-            'user.lang': compute(
+            'user.lang': Compute(
               state`validLangs`,
               props`opts`,
               (validLangs, opts) => (

--- a/packages/node_modules/@cerebral/router/index.d.ts
+++ b/packages/node_modules/@cerebral/router/index.d.ts
@@ -14,6 +14,9 @@ export interface RouterOptions {
   preventAutostart?: boolean
   query?: boolean
   routes: Route[]
+  
+  // EXPERIMENTAL: NOT PART OF OFFICIAL API
+  filterFalsy?: boolean
 }
 
 export default function Router(opts: RouterOptions): any

--- a/packages/node_modules/@cerebral/router/src/router.js
+++ b/packages/node_modules/@cerebral/router/src/router.js
@@ -106,7 +106,7 @@ export default class Router {
         ({ state, resolve }) => {
           if (stateMapping) {
             stateMapping.forEach(key => {
-              const value = values[key]
+              const value = state.get(resolve.path(map[key])) || values[key]
               state.set(
                 resolve.path(map[key]),
                 value === undefined ? null : value

--- a/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
+++ b/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
@@ -20,7 +20,7 @@ describe('urlMapping', () => {
         routes: [
           {
             path: '/:page',
-            map: { page: state`page` },
+            map: { page: state`page`, hello: state`hello` },
           },
         ],
       }),
@@ -30,6 +30,7 @@ describe('urlMapping', () => {
     )
     triggerUrlChange('/foo')
     assert.equal(controller.getState('page'), 'foo')
+    assert.equal(controller.getState('hello'), 'world')
   })
 
   it('should map query to state', () => {

--- a/packages/node_modules/@cerebral/router/test/helper.js
+++ b/packages/node_modules/@cerebral/router/test/helper.js
@@ -13,6 +13,9 @@ const devtools = {
 function makeTest(router, signals) {
   return Controller(
     Module({
+      state: {
+        hello: 'world',
+      },
       modules: {
         router,
       },


### PR DESCRIPTION
Fix the problem reported at https://github.com/cerebral/cerebral/issues/1244. The original code always set the default state value to null.