### PR TITLE
feat(http): content-type header can be set by browser

### DIFF
--- a/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
+++ b/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
@@ -21,6 +21,10 @@ export default {
       options.body = JSON.stringify(options.body)
     }
 
+    if (options.headers['Content-Type'] === 'undefined') {
+      delete options.headers['Content-Type']
+    }
+
     xhr.withCredentials = Boolean(options.withCredentials)
 
     Object.keys(options.headers).forEach(key => {


### PR DESCRIPTION
When transferring files over forms with a content-type header of "multipart/form-data", the browser
needs to be able to additionally set a boundary value. This is only possible if the content-type
header is not explicitly set by the user. With this commit, one is able to set the content-type header to "undefined" which forces the browser to use "multipart/form-data" with its own boundary value for the transferred files.

I'm more than open for better / cleaner / less explicit implementations or different solutions.

The idea is that there is a way to tell Cerebral's http provider not to set a Content-Type header at all, but instead let the browser decide which header to take.

It's needed when uploading files to graph.cool / GraphQL with an action like that:

```
function submitFile ({ props, http }) {
  let data = new FormData()
  data.append('data', props.file)
  return http
    .post('https://api.graph.cool/file/v1/----API----', data, {
      headers: {
        'Content-Type': 'undefined'
      }
    })
    .then((response) => {
      return {response}
    })
    .catch((error) => {
      return {error}
    })
}
```

If the approach is correct, it probably needs also documentation. Let me know what you think. Thanks.