### PR TITLE
feat(firebase): add getDownloadURL to firebase provider for storage

### DIFF
--- a/packages/node_modules/@cerebral/firebase/README.md
+++ b/packages/node_modules/@cerebral/firebase/README.md
@@ -200,6 +200,37 @@ import {FirebaseProviderAuthenticationError} from '@cerebral/firebase'
 }
 ```
 
+## getDownloadURL
+Will get the download url of a given file in firebase storage.
+
+### action
+```js
+function someAction({ firebase, props }) {
+  return firebase.getDownloadURL('images', `${props.path}.jpg`)
+    .then((response) => {
+      /*
+        response: https://foo.com/myImage.jpg
+      */
+    })
+}
+```
+
+### operator
+```javascript
+import { getDownloadURL } from '@cerebral/firebase/operators'
+
+export default [
+  getDownloadURL('images', string`${props`path`}.jpg`), {
+    success: [
+      /* PROPS: { response: https://foo.com/myImage.jpg } */
+    ],
+    error: [
+      /* PROPS: { error: { ... } } */
+    ]
+  }
+]
+```
+
 ## getUser
 Will resolve to `{user: {}}` if user exists. If user was redirected from Facebook/Google etc. as part of first sign in, this method will handle the confirmed registration of the user.
 

--- a/packages/node_modules/@cerebral/firebase/operators.d.ts
+++ b/packages/node_modules/@cerebral/firebase/operators.d.ts
@@ -34,6 +34,7 @@ export function cancelOnDisconnect(): Action
 export function createUserWithEmailAndPassword(email: TagOr<string>, password: TagOr<string>): Action
 export function deleteFile(path: TagOr<string>, filename: TagOr<string>): Action
 export function deleteUser(password: TagOr<string>): Action
+export function getDownloadURL(path: TagOr<string>, file: any): Action
 export function getUser(): Action
 export function linkWithFacebook(options: { redirect?: TagOr<boolean>, scopes: TagOr<string[]> } & any): Action
 export function linkWithGithub(options: { redirect?: TagOr<boolean> } & any): Action

--- a/packages/node_modules/@cerebral/firebase/src/getDownloadURL.js
+++ b/packages/node_modules/@cerebral/firebase/src/getDownloadURL.js
@@ -1,0 +1,7 @@
+import { createStorageRef } from './helpers'
+
+export default function getDownloadURL(path, file) {
+  const ref = createStorageRef(path).child(file)
+
+  return ref.getDownloadURL()
+}

--- a/packages/node_modules/@cerebral/firebase/src/index.js
+++ b/packages/node_modules/@cerebral/firebase/src/index.js
@@ -13,6 +13,7 @@ import push from './push'
 import set from './set'
 import update from './update'
 import put from './put'
+import getDownloadURL from './getDownloadURL'
 import deleteFile from './delete'
 import remove from './remove'
 import transaction from './transaction'
@@ -43,6 +44,7 @@ export default function FirebaseProviderFactory(options = { payload: {} }) {
       delete: deleteFile,
       deleteFile,
       deleteUser,
+      getDownloadURL,
       getUser: getUserService,
       linkWithFacebook,
       linkWithGithub,

--- a/packages/node_modules/@cerebral/firebase/src/operators/getDownloadURL.js
+++ b/packages/node_modules/@cerebral/firebase/src/operators/getDownloadURL.js
@@ -1,0 +1,14 @@
+import { createReturnPromise } from '../helpers'
+
+function getDownloadURLFactory(filepath, file) {
+  function getDownloadURL({ firebase, props, path, resolve }) {
+    return createReturnPromise(
+      firebase.getDownloadURL(resolve.value(filepath), resolve.value(file)),
+      path
+    )
+  }
+
+  return getDownloadURL
+}
+
+export default getDownloadURLFactory

--- a/packages/node_modules/@cerebral/firebase/src/operators/index.js
+++ b/packages/node_modules/@cerebral/firebase/src/operators/index.js
@@ -6,6 +6,7 @@ export {
 export { default as delete } from './delete'
 export { default as deleteFile } from './delete'
 export { default as deleteUser } from './deleteUser'
+export { default as getDownloadURL } from './getDownloadURL'
 export { default as getUser } from './getUser'
 export { default as linkWithFacebook } from './linkWithFacebook'
 export { default as linkWithGithub } from './linkWithGithub'


### PR DESCRIPTION
Adds getDownloadURL to the firebase provider. This allows for generating file-urls based on path and filename. Typically used for generating image-urls to put in img-tags based on filename and path in firebase storage.