### PR TITLE
fix(router): preserving the default state value

### DIFF
--- a/packages/node_modules/@cerebral/router/src/router.js
+++ b/packages/node_modules/@cerebral/router/src/router.js
@@ -106,7 +106,7 @@ export default class Router {
         ({ state, resolve }) => {
           if (stateMapping) {
             stateMapping.forEach(key => {
-              const value = values[key]
+              const value = state.get(resolve.path(map[key])) || values[key]
               state.set(
                 resolve.path(map[key]),
                 value === undefined ? null : value

--- a/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
+++ b/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
@@ -20,7 +20,7 @@ describe('urlMapping', () => {
         routes: [
           {
             path: '/:page',
-            map: { page: state`page` },
+            map: { page: state`page`, hello: state`hello` },
           },
         ],
       }),
@@ -30,6 +30,7 @@ describe('urlMapping', () => {
     )
     triggerUrlChange('/foo')
     assert.equal(controller.getState('page'), 'foo')
+    assert.equal(controller.getState('hello'), 'world')
   })
 
   it('should map query to state', () => {

--- a/packages/node_modules/@cerebral/router/test/helper.js
+++ b/packages/node_modules/@cerebral/router/test/helper.js
@@ -13,6 +13,9 @@ const devtools = {
 function makeTest(router, signals) {
   return Controller(
     Module({
+      state: {
+        hello: 'world',
+      },
       modules: {
         router,
       },


### PR DESCRIPTION
Fix the problem reported at #1244. The original code always set the default state value to null.

Moved from #1245 and cleaned up.