### PR TITLE
Add missing UniversalController typing

### DIFF
--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -1,5 +1,5 @@
 import { DevTools } from './devtools'
-import { Context, FunctionTree, Payload, Provider, Resolve, ResolveValue, FunctionTreeExecutable} from 'function-tree'
+import { Context, FunctionTree, Payload, Provider, Resolve, ResolveValue, FunctionTreeExecutable, Primitive} from 'function-tree'
 
 export interface StateModel {
   concat(path: string, arr: any[]): void

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -93,6 +93,16 @@ export interface ControllerClass extends FunctionTree {
 
 export function Controller(rootModule: ModuleClass, config?: ControllerOptions): ControllerClass
 
+type ControllerSequence = string | Primitive | Array<Function | Primitive>
+export interface UniversalControllerClass extends ControllerClass {
+  setState(path: string, value: any): void
+  getChanges(): {[path: string]: any}
+  getScript(): string
+  runSequence(sequence: ControllerSequence, payload: any): Promise<any>
+}
+
+export function UniversalController(rootModule: ModuleClass, config?: ControllerOptions): UniversalControllerClass
+
 export type ValueResolver = <T=any>(tag: ResolveValue<T>) => T
 
 export class Computed<T=any> implements FunctionTreeExecutable {

--- a/packages/node_modules/cerebral/test/typescript/definitions.test.js
+++ b/packages/node_modules/cerebral/test/typescript/definitions.test.js
@@ -1,0 +1,7 @@
+/* eslint-env mocha */
+import { compileDirectory } from './helper'
+
+describe('TypeScript definitions for cerebral', function() {
+  this.timeout(15000)
+  it('should compile against index.d.ts', compileDirectory)
+})

--- a/packages/node_modules/cerebral/test/typescript/helper.js
+++ b/packages/node_modules/cerebral/test/typescript/helper.js
@@ -1,0 +1,13 @@
+import * as tt from 'typescript-definition-tester'
+import * as ts from 'typescript'
+
+export function compileDirectory(done) {
+  const filter = fileName => fileName.match(/\.ts$/)
+  const options = {
+    experimentalDecorators: true,
+    noImplicitAny: true,
+    target: ts.ScriptTarget.ES2016,
+  }
+
+  tt.compileDirectory(__dirname, filter, options, done)
+}

--- a/packages/node_modules/cerebral/test/typescript/index.test.ts
+++ b/packages/node_modules/cerebral/test/typescript/index.test.ts
@@ -1,0 +1,57 @@
+/**
+ * UniversalController type definiton test
+ */
+import { UniversalController, Module } from 'cerebral'
+
+const appModule = Module({
+  state: {
+    foo: 0,
+    isAwesome: false,
+  },
+  signals: {
+    aSignal: [],
+  },
+});
+
+const controller = UniversalController(appModule)
+
+// runSequence
+controller.runSequence([
+  function myAction ({ state, props }) {
+    state.set('app.isAwesome', props.isAwesome)
+  }
+], {
+  isAwesome: true
+})
+  .then(() => {
+    // I am done running
+  })
+
+controller
+  .runSequence('app.aSignal', {isAwesome: true})
+  .then(() => {
+    // I am done running
+  })
+
+// setState
+controller.setState('app.foo', 123)
+
+// getChanges
+controller
+  .runSequence('app.aSignal', {isAwesome: true})
+  .then(() => {
+    controller.getChanges() // {"app.isAwesome": true}
+  })
+
+// getScript
+
+controller.run([
+  function myAction ({ state, props }) {
+    state.set('app.isAwesome', props.isAwesome)
+  }
+], {
+  isAwesome: true
+})
+  .then(() => {
+    controller.getScript()
+  })


### PR DESCRIPTION
Related issue #1167 

For `runSequence()`, I was looking through how `function-tree` is typed, and find out it is using:
```
createStaticTree(tree: Primitive | Array<Function | Primitive>): Array<Primitive>
```
I wonder for `controller` usage, we might want more specific `SequenceFunction<TStateAndProps>() => any` than `Function` since I see that's used for in example:
```
controller.runSequence([
  function myAction ({ state, props }) {
    state.set('app.isAwesome', props.isAwesome)
  }
], {
  isAwesome: true
})
  .then(() => {
    // I am done running
  })
```