### PR TITLE
feat(http): content-type header can be set by browser

### DIFF
--- a/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
+++ b/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
@@ -21,6 +21,14 @@ export default {
       options.body = JSON.stringify(options.body)
     }
 
+    if (
+      typeof window !== 'undefined' &&
+      window.FormData &&
+      options.body instanceof window.FormData
+    ) {
+      delete options.headers['Content-Type']
+    }
+
     xhr.withCredentials = Boolean(options.withCredentials)
 
     Object.keys(options.headers).forEach(key => {


### PR DESCRIPTION
When transferring files over forms with a content-type header of "multipart/form-data", the browser
needs to be able to additionally set a boundary value. This is only possible if the content-type
header is not explicitly set. With this commit, one is able to set the content-type header to
"undefined" which forces the browser to use "multipart/form-data" with its own boundary value for
the transferred files.