### PR TITLE
feat(http): add support for timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "vue": "2.3.3",
     "webpack": "2.5.1",
     "webpack-dev-server": "2.4.5",
-    "xhr-mock": "1.9.0",
+    "xhr-mock": "2.1.0",
     "yargs": "6.6.0",
     "zone.js": "0.8.17"
   }

--- a/packages/node_modules/@cerebral/http/README.md
+++ b/packages/node_modules/@cerebral/http/README.md
@@ -206,6 +206,9 @@ export default [
     abort: [
       /* PROPS: {error: {...}} */
     ],
+    timeout: [
+      /* PROPS: {error: {...}} */
+    ],
 
     // Optionally any status code, ex. 404: []
     '${STATUS_CODE}': [
@@ -264,6 +267,9 @@ export default [
     abort: [
       /* PROPS: {error: {...}} */
     ],
+    timeout: [
+      /* PROPS: {error: {...}} */
+    ],
 
     // Optionally any status code, ex. 404: []
     '${STATUS_CODE}': [
@@ -320,6 +326,9 @@ export default [
       /* PROPS: {error: {...}} */
     ],
     abort: [
+      /* PROPS: {error: {...}} */
+    ],
+    timeout: [
       /* PROPS: {error: {...}} */
     ],
 
@@ -386,6 +395,9 @@ export default [
     abort: [
       /* PROPS: {error: {...}} */
     ],
+    timeout: [
+      /* PROPS: {error: {...}} */
+    ],
 
     // Optionally any status code, ex. 404: []
     '${STATUS_CODE}': [
@@ -444,6 +456,9 @@ export default [
       /* PROPS: {error: {...}} */
     ],
     abort: [
+      /* PROPS: {error: {...}} */
+    ],
+    timeout: [
       /* PROPS: {error: {...}} */
     ],
 

--- a/packages/node_modules/@cerebral/http/README.md
+++ b/packages/node_modules/@cerebral/http/README.md
@@ -62,7 +62,7 @@ function updateDefaultHttpOptions({http}) {
 ```
 
 ## abort
-You can abort any running request, causing the request to resolve as status code **0** and set an **isAborted** property on the response object.
+You can abort any running request, causing the request to resolve as status code **0** and sets the type to **abort** on the error object.
 
 ```js
 function searchItems({input, state, path, http}) {
@@ -70,7 +70,7 @@ function searchItems({input, state, path, http}) {
   return http.get(`/items?query=${input.query}`)
     .then(path.success)
     .catch((error) => {
-      if (error.isAborted) {
+      if (error.type === 'abort') {
         return path.abort()
       }
 
@@ -108,12 +108,12 @@ import {HttpProviderError} from '@cerebral/http'
 // Error structure
 {
   name: 'HttpProviderError',
+  type: 'http | abort | timeout',
   message: 'Some error message or responseText',
   response: {
     result: {}, // Parsed responseText
     headers: {},
-    status: 200,
-    isAborted: false
+    status: 200
   },
   stack: '...'
 }
@@ -463,8 +463,7 @@ There are two types of responses from the HTTP provider. A **response** and an *
 {
   result: 'the response body',
   headers: {...},
-  status: 200,
-  isAborted: false
+  status: 200
 }
 ```
 
@@ -472,10 +471,10 @@ There are two types of responses from the HTTP provider. A **response** and an *
 ```js
 {
   name: 'HttpProviderError',
+  type: 'http | abort | timeout',
   message: 'Some potential error message',
   result: 'Message or response body',
   status: 500,
-  isAborted: false,
   headers: {},
   stack: '...'
 }

--- a/packages/node_modules/@cerebral/http/README.md
+++ b/packages/node_modules/@cerebral/http/README.md
@@ -41,7 +41,13 @@ const http = HttpProvider({
 
   // When talking to cross origin (cors), pass cookies
   // if set to true
-  withCredentials: false
+  withCredentials: false,
+
+  // Provide a global request timeout for all calls
+  // which can be overwriten for request by providing
+  // a different timeout when doing a request
+  // in actions or operators
+  timeout: 5000
 })
 
 const app = Module({

--- a/packages/node_modules/@cerebral/http/README.md
+++ b/packages/node_modules/@cerebral/http/README.md
@@ -44,7 +44,7 @@ const http = HttpProvider({
   withCredentials: false,
 
   // Provide a global request timeout for all calls
-  // which can be overwriten for request by providing
+  // which can be overwritten for request by providing
   // a different timeout when doing a request
   // in actions or operators
   timeout: 5000

--- a/packages/node_modules/@cerebral/http/index.d.ts
+++ b/packages/node_modules/@cerebral/http/index.d.ts
@@ -1,9 +1,9 @@
 import { Provider } from "function-tree"
 
-export enum HttpProviderErrorTypes {None, Abort = 'abort', Timeout = 'timeout'}
+export enum HttpProviderErrorTypes {None = 'generic', Abort = 'abort', Timeout = 'timeout'}
 
 export class HttpProviderError extends Error {
-  constructor (status: number, headers: any, body: any, message?: string, isAborted?: boolean)
+  constructor (type: HttpProviderErrorTypes, status: number, headers: any, body: any, message?: string, isAborted?: boolean)
   type: HttpProviderErrorTypes
   response: {
     status: number,

--- a/packages/node_modules/@cerebral/http/index.d.ts
+++ b/packages/node_modules/@cerebral/http/index.d.ts
@@ -1,7 +1,10 @@
 import { Provider } from "function-tree"
 
+export enum HttpProviderErrorTypes {None, Abort = 'abort', Timeout = 'timeout'}
+
 export class HttpProviderError extends Error {
   constructor (status: number, headers: any, body: any, message?: string, isAborted?: boolean)
+  type: HttpProviderErrorTypes
   response: {
     status: number,
     headers: any,

--- a/packages/node_modules/@cerebral/http/package.json
+++ b/packages/node_modules/@cerebral/http/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "cerebral": "next",
-    "xhr-mock": "^1.9.0"
+    "xhr-mock": "^2.1.0"
   }
 }

--- a/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
+++ b/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
@@ -47,12 +47,11 @@ export default {
         status: xhr.status,
         headers: responseHeaders,
         result: result,
-        isAborted: false,
       })
     } else {
       reject(
         new HttpProviderError(
-          'error',
+          undefined,
           xhr.status,
           responseHeaders,
           result,

--- a/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
+++ b/packages/node_modules/@cerebral/http/src/DEFAULT_OPTIONS.js
@@ -52,6 +52,7 @@ export default {
     } else {
       reject(
         new HttpProviderError(
+          'error',
           xhr.status,
           responseHeaders,
           result,

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.d.ts
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.d.ts
@@ -1,8 +1,6 @@
-import { Provider } from "function-tree"
-
 export enum HttpProviderErrorTypes {Http = 'http', Abort = 'abort', Timeout = 'timeout'}
 
-export class HttpProviderError extends Error {
+export default class HttpProviderError extends Error {
   constructor (type: HttpProviderErrorTypes, status: number, headers: any, body: any, message?: string, isAborted?: boolean)
   type: HttpProviderErrorTypes
   response: {
@@ -13,5 +11,3 @@ export class HttpProviderError extends Error {
   }
   toJSON (): any
 }
-
-export default function HttpProvider(options: any): Provider 

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.js
@@ -1,3 +1,5 @@
+let _warnAboutDeprecatedIsAborted = false
+
 export default class HttpProviderError extends Error {
   constructor(
     type,
@@ -19,7 +21,10 @@ export default class HttpProviderError extends Error {
 
     Object.defineProperty(this.response, 'isAborted', {
       get() {
-        console.warn('DEPRECATED - Please use error.type === "abort" instead')
+        if (!_warnAboutDeprecatedIsAborted) {
+          console.warn('DEPRECATED - Please use error.type === "abort" instead')
+          _warnAboutDeprecatedIsAborted = true
+        }
         return isAborted
       },
     })

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.js
@@ -1,17 +1,18 @@
 export default class HttpProviderError extends Error {
-  constructor(status, headers, result, message = null, isAborted = false) {
+  constructor(type, status, headers, result, message = null) {
     super()
     this.name = 'HttpProviderError'
     this.message = message
+    this.type = type || 'generic'
     this.response = {
       status,
       headers,
       result,
-      isAborted,
     }
   }
   toJSON() {
     return {
+      type: this.type,
       name: this.name,
       message: this.message,
       response: this.response,

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.js
@@ -1,5 +1,3 @@
-import { HttpProviderErrorTypes } from '../'
-
 export default class HttpProviderError extends Error {
   constructor(
     type,
@@ -12,7 +10,7 @@ export default class HttpProviderError extends Error {
     super()
     this.name = 'HttpProviderError'
     this.message = message
-    this.type = type || HttpProviderErrorTypes.None
+    this.type = type || 'http'
     this.response = {
       status,
       headers,

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.js
@@ -1,3 +1,5 @@
+import { HttpProviderErrorTypes } from '../'
+
 export default class HttpProviderError extends Error {
   constructor(
     type,
@@ -10,7 +12,7 @@ export default class HttpProviderError extends Error {
     super()
     this.name = 'HttpProviderError'
     this.message = message
-    this.type = type || 'generic'
+    this.type = type || HttpProviderErrorTypes.None
     this.response = {
       status,
       headers,

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.js
@@ -1,5 +1,12 @@
 export default class HttpProviderError extends Error {
-  constructor(type, status, headers, result, message = null) {
+  constructor(
+    type,
+    status,
+    headers,
+    result,
+    message = null,
+    isAborted = false
+  ) {
     super()
     this.name = 'HttpProviderError'
     this.message = message
@@ -9,6 +16,13 @@ export default class HttpProviderError extends Error {
       headers,
       result,
     }
+
+    Object.defineProperty(this.response, 'isAborted', {
+      get() {
+        console.warn('DEPRECATED - Please use error.type === "abort" instead')
+        return isAborted
+      },
+    })
   }
   toJSON() {
     return {

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
-import { HttpProviderError } from './'
+import { HttpProviderError } from '../'
 import assert from 'assert'
 
 describe('errors', () => {
   it('should have base error', () => {
     const error = new HttpProviderError(
-      'error',
+      undefined,
       200,
       { foo: 'bar' },
       'foo',
@@ -15,7 +15,7 @@ describe('errors', () => {
     assert.ok(error instanceof Error)
     assert.ok(error.stack)
     assert.equal(error.toJSON().name, 'HttpProviderError')
-    assert.equal(error.toJSON().type, 'error')
+    assert.equal(error.toJSON().type, 'generic')
     assert.equal(error.toJSON().response.status, 200)
     assert.deepEqual(error.toJSON().response.headers, { foo: 'bar' })
     assert.equal(error.toJSON().response.result, 'foo')

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
@@ -4,15 +4,21 @@ import assert from 'assert'
 
 describe('errors', () => {
   it('should have base error', () => {
-    const error = new HttpProviderError(200, { foo: 'bar' }, 'foo', 'msg')
+    const error = new HttpProviderError(
+      'error',
+      200,
+      { foo: 'bar' },
+      'foo',
+      'msg'
+    )
 
     assert.ok(error instanceof Error)
     assert.ok(error.stack)
     assert.equal(error.toJSON().name, 'HttpProviderError')
+    assert.equal(error.toJSON().type, 'error')
     assert.equal(error.toJSON().response.status, 200)
     assert.deepEqual(error.toJSON().response.headers, { foo: 'bar' })
     assert.equal(error.toJSON().response.result, 'foo')
     assert.equal(error.toJSON().message, 'msg')
-    assert.equal(error.toJSON().response.isAborted, false)
   })
 })

--- a/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
+++ b/packages/node_modules/@cerebral/http/src/HttpProviderError.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import { HttpProviderError } from '../'
+import HttpProviderError from './HttpProviderError'
 import assert from 'assert'
 
 describe('errors', () => {
@@ -15,7 +15,7 @@ describe('errors', () => {
     assert.ok(error instanceof Error)
     assert.ok(error.stack)
     assert.equal(error.toJSON().name, 'HttpProviderError')
-    assert.equal(error.toJSON().type, 'generic')
+    assert.equal(error.toJSON().type, 'http')
     assert.equal(error.toJSON().response.status, 200)
     assert.deepEqual(error.toJSON().response.headers, { foo: 'bar' })
     assert.equal(error.toJSON().response.result, 'foo')

--- a/packages/node_modules/@cerebral/http/src/http.test.js
+++ b/packages/node_modules/@cerebral/http/src/http.test.js
@@ -246,7 +246,7 @@ describe('Http Provider', () => {
           test: [
             ({ http, path }) => {
               return http.get(url).catch(error => {
-                assert.ok(error.response.isAborted)
+                assert.ok(error.type === 'abort')
                 return path.aborted()
               })
             },
@@ -423,7 +423,7 @@ describe('Http Provider', () => {
           test: [
             ({ http, path }) => {
               return http.get('/items').catch(error => {
-                assert.ok(error.response.isAborted)
+                assert.ok(error.type === 'abort')
                 return path.aborted()
               })
             },

--- a/packages/node_modules/@cerebral/http/src/http.test.js
+++ b/packages/node_modules/@cerebral/http/src/http.test.js
@@ -42,7 +42,6 @@ describe('Http Provider', () => {
                 ({ props }) => {
                   assert.deepEqual(props, {
                     result: { foo: 'bar' },
-                    isAborted: false,
                     status: 200,
                     headers: { 'content-type': 'application/json' },
                   })

--- a/packages/node_modules/@cerebral/http/src/http.test.js
+++ b/packages/node_modules/@cerebral/http/src/http.test.js
@@ -57,11 +57,11 @@ describe('Http Provider', () => {
     controller.getSignal('test')()
   })
   it('should create GET requests with queries', done => {
-    const url = createUrl('?foo=bar')
+    const url = createUrl()
     const query = '?foo=bar'
     mock.get(url + query, (req, res) => {
       assert.equal(req.url(), url + query)
-      return res.status(200).header('Content-Type', 'application/json')
+      return res.header('Content-Type', 'application/json').status(200)
     })
     const controller = Controller(
       Module({
@@ -193,6 +193,37 @@ describe('Http Provider', () => {
               error: [
                 ({ props }) => {
                   assert.equal(props.error.response.status, 500)
+                  done()
+                },
+              ],
+            },
+          ],
+        },
+      })
+    )
+    controller.getSignal('test')()
+  })
+  it('should handle timeout as an option', done => {
+    const url = createUrl()
+    mock.get(url, (req, res) => {
+      return new Promise(() => {})
+    })
+    const controller = Controller(
+      Module({
+        providers: { http: HttpProvider() },
+        signals: {
+          test: [
+            ({ http, path }) => {
+              return http
+                .get(url, null, { timeout: 10 })
+                .then(path.success)
+                .catch(error => path.error({ error }))
+            },
+            {
+              success: [],
+              error: [
+                ({ props }) => {
+                  assert.equal(props.error.message, 'request timeout')
                   done()
                 },
               ],

--- a/packages/node_modules/@cerebral/http/src/request.js
+++ b/packages/node_modules/@cerebral/http/src/request.js
@@ -8,7 +8,14 @@ export default function request(options = {}, cb) {
   xhr.addEventListener('error', cb)
   xhr.addEventListener('abort', cb)
 
-  xhr.ontimeout = cb.bind(null, { type: 'timeout', currentTarget: xhr })
+  xhr.ontimeout = function() {
+    const ev = {
+      type: 'timeout',
+      currentTarget: xhr,
+    }
+
+    cb(ev)
+  }
   xhr.timeout = options.timeout || 0
 
   xhr.open(options.method, options.baseUrl + options.url)

--- a/packages/node_modules/@cerebral/http/src/request.js
+++ b/packages/node_modules/@cerebral/http/src/request.js
@@ -1,11 +1,16 @@
 /* eslint-env browser */
 
-export default function request(options, cb) {
+export default function request(options = {}, cb) {
   const xhr = new XMLHttpRequest()
+
   xhr.addEventListener('progress', cb)
   xhr.addEventListener('load', cb)
   xhr.addEventListener('error', cb)
   xhr.addEventListener('abort', cb)
+
+  xhr.ontimeout = cb.bind(null, { type: 'timeout', currentTarget: xhr })
+  xhr.timeout = options.timeout || 0
+
   xhr.open(options.method, options.baseUrl + options.url)
   options.onRequest(xhr, options)
 

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -15,6 +15,7 @@ export function createResponse(options, resolve, reject) {
       case 'error':
         reject(
           new HttpProviderError(
+            event.type,
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             event.currentTarget.responseText,
@@ -25,22 +26,22 @@ export function createResponse(options, resolve, reject) {
       case 'abort':
         reject(
           new HttpProviderError(
+            event.type,
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             null,
-            'request abort',
-            true
+            'request abort'
           )
         )
         break
       case 'timeout':
         reject(
           new HttpProviderError(
+            event.type,
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             null,
-            'request timeout',
-            false
+            'request timeout'
           )
         )
         break

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -1,4 +1,4 @@
-import HttpProviderError from './HttpProviderError'
+import { HttpProviderError } from '../'
 
 export function createResponse(options, resolve, reject) {
   return event => {
@@ -15,7 +15,7 @@ export function createResponse(options, resolve, reject) {
       case 'error':
         reject(
           new HttpProviderError(
-            null,
+            undefined,
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             event.currentTarget.responseText,

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -117,8 +117,12 @@ export function processResponse(httpAction, path) {
           throw error
         }
 
-        if (error.isAborted && path.abort) {
+        if (error.type === 'abort' && path.abort) {
           return path.abort({ error: error.toJSON() })
+        }
+
+        if (error.type === 'timeout' && path.timeout) {
+          return path.timeout({ error: error.toJSON() })
         }
 
         if (path[error.response.status]) {

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -1,4 +1,4 @@
-import { HttpProviderError } from '../'
+import HttpProviderError from './HttpProviderError'
 
 export function createResponse(options, resolve, reject) {
   return event => {

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -15,7 +15,7 @@ export function createResponse(options, resolve, reject) {
       case 'error':
         reject(
           new HttpProviderError(
-            event.type,
+            null,
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             event.currentTarget.responseText,
@@ -30,7 +30,8 @@ export function createResponse(options, resolve, reject) {
             event.currentTarget.status,
             getAllResponseHeaders(event.currentTarget),
             null,
-            'request abort'
+            'request abort',
+            true
           )
         )
         break

--- a/packages/node_modules/@cerebral/http/src/utils.js
+++ b/packages/node_modules/@cerebral/http/src/utils.js
@@ -33,6 +33,17 @@ export function createResponse(options, resolve, reject) {
           )
         )
         break
+      case 'timeout':
+        reject(
+          new HttpProviderError(
+            event.currentTarget.status,
+            getAllResponseHeaders(event.currentTarget),
+            null,
+            'request timeout',
+            false
+          )
+        )
+        break
     }
   }
 }


### PR DESCRIPTION
Added `timeout` option
Added `ontimeout` callback to throw as an error

Upgraded xhr-mock to be able to add tests for timeout

TODO: 
- [x] update docs

ISSUES CLOSED: #774