### PR TITLE
fix(router): change mapped state on url change

### DIFF
--- a/packages/node_modules/@cerebral/router/src/router.js
+++ b/packages/node_modules/@cerebral/router/src/router.js
@@ -108,7 +108,7 @@ export default class Router {
         ({ state, resolve }) => {
           if (stateMapping) {
             stateMapping.forEach(key => {
-              const value = state.get(resolve.path(map[key])) || values[key]
+              const value = values[key] || state.get(resolve.path(map[key]))
               state.set(
                 resolve.path(map[key]),
                 value === undefined ? null : value

--- a/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
+++ b/packages/node_modules/@cerebral/router/src/router.urlMapping.test.js
@@ -28,8 +28,27 @@ describe('urlMapping', () => {
         test: [],
       }
     )
-    triggerUrlChange('/foo')
+    triggerUrlChange('/foo?hello=bar')
     assert.equal(controller.getState('page'), 'foo')
+    assert.equal(controller.getState('hello'), 'bar')
+  })
+
+  it('should use default state', () => {
+    const controller = makeTest(
+      Router({
+        preventAutostart: true,
+        routes: [
+          {
+            path: '/:page',
+            map: { page: state`page`, hello: state`hello` },
+          },
+        ],
+      }),
+      {
+        test: [],
+      }
+    )
+    triggerUrlChange('/foo')
     assert.equal(controller.getState('hello'), 'world')
   })
 


### PR DESCRIPTION
fixed implementation #1253.

with the previous solution, it was not possible to change the mapped state via url, if the state was already set. see tests for an example.