### PR TITLE
Update AngularJS view

### DIFF
--- a/packages/node_modules/@cerebral/angularjs/README.md
+++ b/packages/node_modules/@cerebral/angularjs/README.md
@@ -10,24 +10,26 @@
 ```js
 import angular from 'angular'
 import {addModule, connect} from '@cerebral/angularjs'
+import {Controller} from 'cerebral'
 import {state, signal} from 'cerebral/tags'
 
 addModule(angular)
 
+const rootModule = Module({
+  state: {
+    foo: 'bar'
+  },
+  signals: {
+    clicked: []
+  },
+  services: ['MyAngularService']  // Root module only. Added as providers with same name
+})
+
+const controller = Controller()
+
 angular.module('app', ['cerebral'])
   .config(function (cerebralProvider) {
-    cerebralProvider.configure({
-      state: {
-        foo: 'bar'
-      },
-      signals: {
-        clicked: []
-      },
-
-      // Special controller property to expose core
-      // angular services to your signals
-      services: ['$http', '$timeout']
-    })
+    cerebralProvider.configure(controller)
   })
   ...
 ```

--- a/packages/node_modules/@cerebral/angularjs/src/module.js
+++ b/packages/node_modules/@cerebral/angularjs/src/module.js
@@ -1,9 +1,10 @@
-import { Controller, provide, View } from 'cerebral'
+import { Controller, View } from 'cerebral'
 
 class CerebralScope {
   constructor(ctrl, scope, dependencies, controller, displayName) {
     this.ctrl = ctrl
     this.scope = scope
+    this.props = {} // Holds non-changed props from $onChanges
     this.onUpdate = this.onUpdate.bind(this)
     this.ctrl.$onInit = () => {
       this.props = Object.assign({}, this.ctrl)
@@ -21,6 +22,7 @@ class CerebralScope {
         this.view.unMount()
         delete this.ctrl
         delete this.scope
+        delete this.props
       }
       this.ctrl.$onChanges = changesObj => {
         const { oldProps, nextProps } = Object.keys(changesObj).reduce(
@@ -30,14 +32,15 @@ class CerebralScope {
 
             return updates
           },
-          { oldProps: {}, nextProps: {} }
+          {
+            oldProps: Object.assign({}, this.props),
+            nextProps: Object.assign({}, this.props),
+          }
         )
-        const hasUpdate = this.view.onPropsUpdate(oldProps, nextProps)
-
-        if (hasUpdate) {
-          Object.assign(this.ctrl, this.view.getProps(nextProps, false))
-          this.scope.safeApply()
-        }
+        this.view.onPropsUpdate(oldProps, nextProps)
+        Object.assign(this.props, nextProps)
+        Object.assign(this.ctrl, this.view.getProps(nextProps, false))
+        this.scope.safeApply()
       }
       this.scope.safeApply = function(fn) {
         var phase = this.$root.$$phase
@@ -61,21 +64,26 @@ class CerebralScope {
 
 export default angular => {
   angular.module('cerebral', []).provider('cerebral', function() {
+    let root = null
     let config = null
 
-    this.configure = function(controllerConfig) {
+    this.configure = function(rootModule, controllerConfig) {
+      root = rootModule
       config = controllerConfig
     }
 
     this.$get = [
       '$injector',
       function($injector) {
-        config.providers = (config.providers || []).concat(
-          (config.services || []).map(service => {
-            return provide(service, $injector.get(service))
-          })
-        )
-        const controller = new Controller(config)
+        if (root.moduleDescription.hasOwnProperty('services')) {
+          root.moduleDescription.providers =
+            root.moduleDescription.providers || {}
+          for (let service of root.moduleDescription.services) {
+            root.moduleDescription.providers[service] = $injector.get(service)
+          }
+        }
+
+        const controller = new Controller(root, config)
 
         return {
           connect(ctrl, scope, dependencies, displayName) {


### PR DESCRIPTION
Updates the AngularJS view to work with Cerebral 4.x.

Services are not wrapped with Provider due to many AngularJS services having properties, preventing them from working with Provider.

Also fixes an important bug where props that were not part of update in current cycle, would be removed from controller.