### PR TITLE
fix(http): open xhr request prior to setting properties to fix IE11 InvalidStateError

### DIFF
--- a/packages/node_modules/@cerebral/http/src/request.js
+++ b/packages/node_modules/@cerebral/http/src/request.js
@@ -16,9 +16,11 @@ export default function request(options = {}, cb) {
 
     cb(ev)
   }
-  xhr.timeout = options.timeout || 0
 
   xhr.open(options.method, options.baseUrl + options.url)
+
+  xhr.timeout = options.timeout || 0
+
   options.onRequest(xhr, options)
 
   return xhr


### PR DESCRIPTION
Turns out setting properties on the `xhr` like `timeout` prior to calling `open` raises an `InvalidStateError` in IE11. Calling open prior to setting all of the properties resolves this exception. 

I tested the change in IE11, Chrome, Firefox and MS Edge to ensure it has no unintended side effects. 