### PR TITLE
Update signal.md

### DIFF
--- a/docs/api/signal.md
+++ b/docs/api/signal.md
@@ -79,7 +79,7 @@ import * as actions from '../actions'
 
 export const myOtherSequence = [actions.doThis]
 
-export const mySequence = [actions.someAction, myOtherSequence]
+export const mySequence = [someAction, myOtherSequence]
 ```
 
 ## Parallel


### PR DESCRIPTION
line 82: someAction imported from '../actions/someAction' is referenced incorrectly as actions.someAction; should be referenced as just someAction with out the actions. prefix