### PR TITLE
chore(fluent): add type properties on ModuleClass type

### DIFF
--- a/packages/node_modules/@cerebral/fluent/src/index.test.ts
+++ b/packages/node_modules/@cerebral/fluent/src/index.test.ts
@@ -1,3 +1,6 @@
+import * as assert from 'assert'
+import View from './View'
+import { autorun } from 'mobx'
 /* eslint-env mocha */
 import {
   Controller,
@@ -8,9 +11,6 @@ import {
   ComputedValue,
   Computed,
 } from './'
-import View from './View'
-import { autorun } from 'mobx'
-import * as assert from 'assert'
 
 describe('Fluent', () => {
   it('should instantiate with initial state', () => {
@@ -37,7 +37,7 @@ describe('Fluent', () => {
     type Signals = {
       test: () => void
     }
-    const rootModule = Module<State>({
+    const rootModule = Module<State, Signals>({
       state: {
         foo: 'bar',
         bool: true,

--- a/packages/node_modules/@cerebral/fluent/src/index.ts
+++ b/packages/node_modules/@cerebral/fluent/src/index.ts
@@ -1,3 +1,8 @@
+import Model from './Model'
+import { BaseControllerClass, ControllerOptions, ModuleClass } from 'cerebral'
+import { CreateModuleProvider } from './providers'
+import { extractModuleProp, getModule, throwError } from 'cerebral/internal'
+import { updateIn } from './utils'
 import {
   observable,
   untracked,
@@ -6,11 +11,6 @@ import {
   ObservableMap as MobxObservableMap,
   useStrict,
 } from 'mobx'
-import { CreateModuleProvider } from './providers'
-import { BaseControllerClass, ModuleClass, ControllerOptions } from 'cerebral'
-import { extractModuleProp, getModule, throwError } from 'cerebral/internal'
-import { updateIn } from './utils'
-import Model from './Model'
 
 export { ConnectFactory, ModuleConnectFactory } from './connect'
 export { pathFor } from './paths'
@@ -53,14 +53,15 @@ export type TLegacyState = {
 
 export class FluentController<
   State = {},
-  Signals = {}
+  Signals = {},
+  Providers extends { [providerName: string]: any } = {}
 > extends BaseControllerClass {
   state: State
   signals: Signals
   devtools: any
   contextProviders: any
   constructor(
-    rootModule: ModuleClass,
+    rootModule: ModuleClass<State, Signals, Providers>,
     options: ControllerOptions & {
       useStrict?: boolean
       useLegacyStateApi?: boolean
@@ -100,7 +101,7 @@ export class FluentController<
       options.useLegacyStateApi || false
     )
   }
-  addModule(path: string, module: ModuleClass) {
+  addModule(path: string, module: ModuleClass<{}, {}, {}>) {
     const pathArray = path.split('.')
     const moduleKey = pathArray.pop()
     if (!moduleKey) {
@@ -185,8 +186,12 @@ export class FluentController<
   }
 }
 
-export function Controller<State = {}, Signals = {}>(
-  rootModule: ModuleClass,
+export function Controller<
+  State = {},
+  Signals = {},
+  Providers extends { [providerName: string]: any } = {}
+>(
+  rootModule: ModuleClass<State, Signals, Providers>,
   options: ControllerOptions & {
     useStrict?: boolean
     useLegacyStateApi?: boolean

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -50,16 +50,17 @@ export type SignalsMap = {
   [signalName: string]: Sequence
 }
 
-export interface ModuleObjectDefinition<State, Signals> {
+export interface ModuleObjectDefinition<
+  State,
+  Signals,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> },
+  Providers extends { [providerName: string]: any }
+> {
   state?: State
-  signals?: Signals
-  modules?: {
-    [submodule: string]: ModuleClass
-  }
-  catch?: [ErrorClass, Sequence][]
-  providers?: {
-    [providerName: string]: any
-  }
+  signals?: { [K in keyof Signals]: Sequence }
+  modules?: Modules
+  providers?: Providers
+  catch?: Array<[ErrorClass, Sequence]>
 }
 
 export interface InstantiatedModuleObjectDefinition {
@@ -74,15 +75,28 @@ export interface InstantiatedModuleObjectDefinition {
   }
 }
 
-type ModuleFunction<State, Signals> = (
+type ModuleFunction<
+  State,
+  Signals,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> },
+  Providers extends { [providerName: string]: any }
+> = (
   module: { name: string; path: string; controller: ControllerClass }
-) => ModuleObjectDefinition<State, Signals>
+) => ModuleObjectDefinition<State, Signals, Modules, Providers>
 
-export type ModuleDefinition<State, Signals> =
-  | ModuleObjectDefinition<State, Signals>
-  | ModuleFunction<State, Signals>
+export type ModuleDefinition<
+  State,
+  Signals,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> },
+  Providers extends { [providerName: string]: any }
+> =
+  | ModuleObjectDefinition<State, Signals, Modules, Providers>
+  | ModuleFunction<State, Signals, Modules, Providers>
 
-export class ModuleClass {
+export class ModuleClass<State, Signals, Providers = {}> {
+  __state: State
+  __signals: Signals
+  __providers: Providers
   // not public API
   create(
     controller: BaseControllerClass,
@@ -90,9 +104,40 @@ export class ModuleClass {
   ): InstantiatedModuleObjectDefinition
 }
 
-export function Module<State = {}, Signals = {}>(
-  moduleDefinition: ModuleDefinition<State, Signals>
-): ModuleClass
+export type ModuleType<
+  State,
+  Signals,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> },
+  Providers extends { [providerName: string]: any }
+> = ModuleClass<
+  ModuleState<State, Modules>,
+  ModuleSignals<Signals, Modules>,
+  ModuleProviders<State, Modules, Providers>
+>
+
+export type ModuleState<
+  State,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> }
+> = State & { [K in keyof Modules]: Modules[K]['__state'] }
+export type ModuleSignals<
+  Signals,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> }
+> = Signals & { [K in keyof Modules]: Modules[K]['__signals'] }
+export type ModuleProviders<
+  State,
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> },
+  Providers extends { [providerName: string]: any }
+> = { state: ModuleState<State, Modules> } & Providers &
+  Modules[keyof Modules]['__providers']
+
+export function Module<
+  State,
+  Signals = {},
+  Modules extends { [key: string]: ModuleClass<{}, {}, {}> } = {},
+  Providers extends { [providerName: string]: any } = {}
+>(
+  moduleDefinition: ModuleDefinition<State, Signals, Modules, Providers>
+): ModuleType<State, Signals, Modules, Providers>
 
 /*
   Connect
@@ -113,7 +158,7 @@ export interface BaseControllerClass extends FunctionTree {
   getState(path?: string): any
   runSignal(name: string, signal: Sequence, payload: any): void
   getSignal<T = any>(path: string): Signal<T>
-  addModule(path: string, module: ModuleClass): void
+  addModule(path: string, module: ModuleClass<{}, {}, {}>): void
   removeModule(path: string): void
 }
 
@@ -121,7 +166,7 @@ export class BaseControllerClass {
   model: any
   module: InstantiatedModuleObjectDefinition
   constructor(
-    rootModule: ModuleClass,
+    rootModule: ModuleClass<{}, {}, {}>,
     options: ControllerOptions,
     functionTreeOptions: any
   )
@@ -134,7 +179,7 @@ interface ControllerClass extends BaseControllerClass {
 }
 
 export function Controller(
-  rootModule: ModuleClass,
+  rootModule: ModuleClass<{}, {}, {}>,
   config?: ControllerOptions
 ): ControllerClass
 
@@ -147,7 +192,7 @@ export interface UniversalControllerClass extends ControllerClass {
 }
 
 export function UniversalController(
-  rootModule: ModuleClass,
+  rootModule: ModuleClass<{}, {}, {}>,
   config?: ControllerOptions
 ): UniversalControllerClass
 


### PR DESCRIPTION
Adding type properties in ModuleClass type allow TypeScript to infer
them and merge state and signals from modules.