### PR TITLE
fix(shortcuts): override default browser behaviour

### DIFF
--- a/packages/node_modules/@cerebral/shortcuts/src/index.js
+++ b/packages/node_modules/@cerebral/shortcuts/src/index.js
@@ -5,10 +5,11 @@ export default function(shortcuts) {
   return Module((module) => {
     module.controller.on('initialized', () => {
       Object.keys(shortcuts).forEach((shortcut) => {
-        const registeredShortcut = shortway(shortcut, () => {
+        const registeredShortcut = shortway(shortcut, (event) => {
+          event.preventDefault()
           module.controller.getSignal(shortcuts[shortcut])({})
         })
-        document.addEventListener('keyup', registeredShortcut)
+        document.addEventListener('keydown', registeredShortcut)
       })
     })
 

--- a/packages/node_modules/@cerebral/shortcuts/src/index.test.js
+++ b/packages/node_modules/@cerebral/shortcuts/src/index.test.js
@@ -26,7 +26,7 @@ describe('Shortcuts module', () => {
     })
     Controller(rootModule)
     document.dispatchEvent(
-      new window.KeyboardEvent('keyup', { key: 'z', char: 'z', keyCode: 90 })
+      new window.KeyboardEvent('keydown', { key: 'z', char: 'z', keyCode: 90 })
     )
   })
 })


### PR DESCRIPTION
Shortcuts like CMD-S trigger a save dialog by the browser but not the requested Cerebral signal. In
such a case, event.preventDefault is necessary to run the requested Cerebral signal.