### PR TITLE
Add proxy namespace support

### DIFF
--- a/packages/node_modules/babel-plugin-cerebral/__tests__/__snapshots__/compile.js.snap
+++ b/packages/node_modules/babel-plugin-cerebral/__tests__/__snapshots__/compile.js.snap
@@ -84,3 +84,19 @@ exports[`Transform imports containing "cerebral.proxy" should rewrite tags but n
 import { state } from 'app.cerebral.proxy.ts';
 state\`world\`;"
 `;
+
+exports[`Transform namespaced imports should complain about wront tag names 1`] = `"unknown: \\"foo\\" is not a valid tag"`;
+
+exports[`Transform namespaced imports should keep track of bound variables 1`] = `
+"
+import * as proxies from 'cerebral/tags';
+const bar = proxies;
+proxies => proxies.state.hello.world;
+proxies => bar.state\`hello.world\`;"
+`;
+
+exports[`Transform namespaced imports should transform simple state dot syntax 1`] = `
+"
+import * as proxies from 'cerebral/tags';
+proxies.state\`hello.world\`;"
+`;

--- a/packages/node_modules/babel-plugin-cerebral/__tests__/compile.js
+++ b/packages/node_modules/babel-plugin-cerebral/__tests__/compile.js
@@ -148,3 +148,35 @@ describe('Transform imports containing "cerebral.proxy"', () => {
     expect(result).toMatchSnapshot()
   })
 })
+
+describe('Transform namespaced imports', () => {
+  it('should transform simple state dot syntax', () => {
+    const code = `
+      import * as proxies from 'cerebral/proxy';
+      proxies.state.hello.world;
+    `
+    const { code: result } = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should complain about wront tag names', () => {
+    const code = `
+      import * as proxies from 'cerebral/proxy';
+      proxies.foo.bar;
+    `
+    expect(() => {
+      transform(code, pluginOptions)
+    }).toThrowErrorMatchingSnapshot()
+  })
+
+  it('should keep track of bound variables', () => {
+    const code = `
+      import * as proxies from 'cerebral/proxy';
+      const bar = proxies;
+      (proxies) => proxies.state.hello.world;
+      (proxies) => bar.state.hello.world;
+    `
+    const { code: result } = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/packages/node_modules/babel-plugin-cerebral/index.js
+++ b/packages/node_modules/babel-plugin-cerebral/index.js
@@ -33,17 +33,13 @@ export default function({ types: t }) {
   // or if it's a binding to a valid one.
   // Will return the name of the used variabel or null
   // if nothing was found
-  function getUsedVariable(scope, name, importedVariable) {
+  function getUsedVariable(scope, name) {
     const binding = scope.getBinding(name)
     if (!binding) return null
     if (t.isVariableDeclarator(binding.path.node) && binding.path.node.init) {
-      return getUsedVariable(
-        binding.path.scope,
-        binding.path.node.init.name,
-        importedVariable
-      )
+      return getUsedVariable(binding.path.scope, binding.path.node.init.name)
     }
-    return importedVariable.has(name) && binding.kind === 'module' ? name : null
+    return binding.kind === 'module' ? name : null
   }
 
   return {
@@ -51,6 +47,7 @@ export default function({ types: t }) {
       // Used to track renaming imports in local file
       // eg. import { state as s } from 'cerebral/proxies';
       this.importedVariable = new Set()
+      this.namespace = null
     },
     visitor: {
       ImportDeclaration(path) {
@@ -71,32 +68,37 @@ export default function({ types: t }) {
 
         const directImport = isDirectImport(importLocation) // 1)
         const indirectImport = isIndirectImport(importLocation) // 2)
+        const { specifiers } = path.node
 
         if (directImport || indirectImport) {
           // 1,2) a. Trigger conversion to tags
 
           // Complain about default import
-          if (
-            path.node.specifiers.some((item) =>
-              t.isImportDefaultSpecifier(item)
-            )
-          ) {
+          if (specifiers.some((item) => t.isImportDefaultSpecifier(item))) {
             throw path.buildCodeFrameError(`Default import is not allowed`)
           }
 
-          // Verify that all imports are allowed and track the localName
-          for (const {
-            imported: { name: importName },
-            local: { name: localName },
-          } of path.node.specifiers) {
-            if (isAllowedImport(importName)) {
-              this.importedVariable.add(localName)
-            } else if (directImport) {
-              // Only complain about unkown imports
-              // if it is a directImport
-              throw path.buildCodeFrameError(
-                `"${importName}" is not a valid import`
-              )
+          if (
+            specifiers.length === 1 &&
+            t.isImportNamespaceSpecifier(specifiers[0])
+          ) {
+            this.importedVariable = new Set(allowedImportVariables)
+            this.namespace = specifiers[0].local.name
+          } else {
+            // Verify that all imports are allowed and track the localName
+            for (const {
+              imported: { name: importName },
+              local: { name: localName },
+            } of path.node.specifiers) {
+              if (isAllowedImport(importName)) {
+                this.importedVariable.add(localName)
+              } else if (directImport) {
+                // Only complain about unkown imports
+                // if it is a directImport
+                throw path.buildCodeFrameError(
+                  `"${importName}" is not a valid import`
+                )
+              }
             }
           }
 
@@ -106,10 +108,11 @@ export default function({ types: t }) {
             path.node.source.value = 'cerebral/tags'
 
             // Remove "path" from imports
-            path.node.specifiers = path.node.specifiers.filter(
+            path.node.specifiers = specifiers.filter(
               (item) =>
-                item.imported.name !== 'statePath' &&
-                item.imported.name !== 'computedPath'
+                t.isImportNamespaceSpecifier(item) ||
+                (item.imported.name !== 'statePath' &&
+                  item.imported.name !== 'computedPath')
             )
 
             // remove if there aren't any specifiers left
@@ -122,18 +125,43 @@ export default function({ types: t }) {
       },
       MemberExpression(path) {
         // Always use the innermost MemberExpression
-        if (!t.isIdentifier(path.node.object)) {
+        // and don't process taggedTemplateExpressions
+        if (
+          !t.isIdentifier(path.node.object) ||
+          t.isTaggedTemplateExpression(path.parent)
+        ) {
           return
         }
 
-        const tagName = getUsedVariable(
-          path.scope,
-          path.node.object.name,
-          this.importedVariable
-        )
+        // Contains the target of the taggedTemplate
+        // either e.g. `state` or proxies.state
+        let targetExpression
 
-        if (!tagName) {
-          return
+        const objectName = path.node.object.name
+        const tagRoot = getUsedVariable(path.scope, objectName)
+
+        // Is tagRoot a reference to the namespace e.g. proxies.state
+        if (this.namespace && tagRoot === this.namespace) {
+          const tagName = path.node.property.name
+
+          // Show compile time warning for
+          // unkown properties
+          if (!this.importedVariable.has(tagName)) {
+            throw path
+              .get('property')
+              .buildCodeFrameError(`"${tagName}" is not a valid tag`)
+          }
+
+          targetExpression = t.memberExpression(
+            t.identifier(objectName),
+            t.identifier(tagName)
+          )
+          path = path.parentPath
+        } else {
+          if (!this.importedVariable.has(tagRoot)) {
+            return
+          }
+          targetExpression = t.identifier(tagRoot)
         }
 
         let quasi = []
@@ -174,10 +202,10 @@ export default function({ types: t }) {
         }
 
         // Rewrite with a tagged template like
-        // state`foo.bar`
+        // state`foo.bar` or proxies.state`foo.bar`
         rootMemberExpression.replaceWith(
           t.taggedTemplateExpression(
-            t.identifier(tagName),
+            targetExpression,
             t.templateLiteral(
               quasis.map((v) => {
                 const str = v.join('')


### PR DESCRIPTION
Just as request on discord. The babel plugin now supports namespaced imports like this:

```js
import * as proxies from 'cerebral/proxy' 
proxies.state.foo.bar
```

will be transformed to 

```js
import * as proxies from 'cerebral/tags' 
proxies.state`foo.bar`
```