### PR TITLE
Allow assigning proxied tags to variables

### DIFF
--- a/packages/node_modules/babel-plugin-cerebral/__tests__/__snapshots__/compile.js.snap
+++ b/packages/node_modules/babel-plugin-cerebral/__tests__/__snapshots__/compile.js.snap
@@ -85,6 +85,12 @@ import { state } from 'app.cerebral.proxy.ts';
 state\`world\`;"
 `;
 
+exports[`Transform namespaced imports should allow assigning tags to variables 1`] = `
+"
+import * as proxies from 'cerebral/tags';
+const bar = proxies.state;"
+`;
+
 exports[`Transform namespaced imports should complain about wront tag names 1`] = `"unknown: \\"foo\\" is not a valid tag"`;
 
 exports[`Transform namespaced imports should keep track of bound variables 1`] = `
@@ -93,6 +99,13 @@ import * as proxies from 'cerebral/tags';
 const bar = proxies;
 proxies => proxies.state.hello.world;
 proxies => bar.state\`hello.world\`;"
+`;
+
+exports[`Transform namespaced imports should keept track of assigned tags 1`] = `
+"
+import * as proxies from 'cerebral/tags';
+const bar = proxies.state;
+bar\`hello.world\`;"
 `;
 
 exports[`Transform namespaced imports should transform simple state dot syntax 1`] = `

--- a/packages/node_modules/babel-plugin-cerebral/__tests__/compile.js
+++ b/packages/node_modules/babel-plugin-cerebral/__tests__/compile.js
@@ -179,4 +179,23 @@ describe('Transform namespaced imports', () => {
     const { code: result } = transform(code, pluginOptions)
     expect(result).toMatchSnapshot()
   })
+
+  it('should allow assigning tags to variables', () => {
+    const code = `
+      import * as proxies from 'cerebral/proxy';
+      const bar = proxies.state;
+    `
+    const { code: result } = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should keept track of assigned tags', () => {
+    const code = `
+      import * as proxies from 'cerebral/proxy';
+      const bar = proxies.state;
+      bar.hello.world;
+    `
+    const { code: result } = transform(code, pluginOptions)
+    expect(result).toMatchSnapshot()
+  })
 })

--- a/packages/node_modules/babel-plugin-cerebral/index.js
+++ b/packages/node_modules/babel-plugin-cerebral/index.js
@@ -1,13 +1,13 @@
 const allowedImportPath = ['cerebral/proxy']
 const allowedImportVariables = [
-  'path',
   'props',
   'state',
+  'signals',
   'sequences',
   'computed',
   'moduleState',
   'moduleComputed',
-  'moduleSequences',
+  'moduleSignals',
 ]
 
 function isDirectImport(location) {
@@ -36,11 +36,23 @@ export default function({ types: t }) {
   // if nothing was found
   function getUsedVariable(scope, name) {
     const binding = scope.getBinding(name)
-    if (!binding) return null
-    if (t.isVariableDeclarator(binding.path.node) && binding.path.node.init) {
+    if (!binding) return {}
+    if (binding.path.getData('cerebral_proxy_tagged')) {
+      return {
+        tagged: true,
+        name,
+      }
+    } else if (
+      t.isVariableDeclarator(binding.path.node) &&
+      binding.path.node.init
+    ) {
       return getUsedVariable(binding.path.scope, binding.path.node.init.name)
     }
-    return binding.kind === 'module' ? name : null
+
+    return {
+      tagged: false,
+      name: binding.kind === 'module' ? name : null,
+    }
   }
 
   return {
@@ -134,16 +146,20 @@ export default function({ types: t }) {
           return
         }
 
+        const objectName = path.node.object.name
+        const { tagged, name: tagRoot } = getUsedVariable(
+          path.scope,
+          objectName
+        )
+
         // Contains the target of the taggedTemplate
         // either e.g. `state` or proxies.state
         let targetExpression
-
-        const objectName = path.node.object.name
-        const tagRoot = getUsedVariable(path.scope, objectName)
+        let tagName = tagRoot
 
         // Is tagRoot a reference to the namespace e.g. proxies.state
         if (this.namespace && tagRoot === this.namespace) {
-          const tagName = path.node.property.name
+          tagName = path.node.property.name
 
           // Show compile time warning for
           // unkown properties
@@ -159,7 +175,9 @@ export default function({ types: t }) {
           )
           path = path.parentPath
         } else {
-          if (!this.importedVariable.has(tagRoot)) {
+          // if this variable was tagged before
+          // we don't want to bail here
+          if (!tagged && !this.importedVariable.has(tagRoot)) {
             return
           }
           targetExpression = t.identifier(tagRoot)
@@ -202,6 +220,12 @@ export default function({ types: t }) {
           currentMember = currentMember.parentPath
         }
 
+        // Bail on proxies.state usage
+        if (quasis.length === 1 && quasis[0].length === 0) {
+          // but tag the path to detect it in getUsedVariable
+          path.setData('cerebral_proxy_tagged', true)
+          return
+        }
         // Rewrite with a tagged template like
         // state`foo.bar` or proxies.state`foo.bar`
         rootMemberExpression.replaceWith(


### PR DESCRIPTION
Like asked on discord. This PR allows for using proxied tags like this:
```js
import * as proxies from 'cerebral/proxy';
const bar = proxies.state;
bar.hello.world;
```
↓↓↓↓↓

```js
import * as proxies from 'cerebral/tags';
const bar = proxies.state;
bar`hello.world`;"
```

Regarding the problem in todomvc-ts. I changed the import to `import * as tags from 'cerebral/proxy'` but I am still getting a typescript error:
```
Property 'sequences' does not exist on type 'typeof "/Users/FWeinb/GitHub/cerebral/packages/node_modules/cerebral/proxy/index"'.
```

Which sounds like a error outside of the babel-plugin. For typescript one should import 'cerebral.proxy' anyway, right?
