### PR TITLE
feat(cerebral): Add support for transform functions on set factory

### DIFF
--- a/docs/api/factories.md
+++ b/docs/api/factories.md
@@ -69,6 +69,12 @@ set(state.foo.bar, true)
 set(props.foo, true)
 ```
 
+Optionally transform the value before setting
+
+```js
+set(state.some.number, props.number, (value) => value * 2)
+```
+
 ### shift
 
 Shift a value off an array (removes first element in array).

--- a/packages/node_modules/cerebral/src/factories/set.js
+++ b/packages/node_modules/cerebral/src/factories/set.js
@@ -1,7 +1,9 @@
 import { isObject } from '../utils'
 
-export default function(target, value) {
-  function set({ store, props, resolve }) {
+export default function(target, value, transformFn) {
+  function set(context) {
+    const { store, props, resolve } = context
+
     if (!resolve.isTag(target, 'state', 'props', 'moduleState')) {
       throw new Error(
         'Cerebral factory.set: You have to use the STATE, PROPS or MODULESTATE tag as first argument'
@@ -14,6 +16,10 @@ export default function(target, value) {
       resolvedValue = Object.assign({}, resolvedValue)
     } else if (!resolve.isResolveValue(value) && Array.isArray(value)) {
       resolvedValue = resolvedValue.slice()
+    }
+
+    if (transformFn) {
+      resolvedValue = transformFn(resolvedValue, context)
     }
 
     if (target.type === 'state' || target.type === 'moduleState') {

--- a/packages/node_modules/cerebral/src/factories/set.test.js
+++ b/packages/node_modules/cerebral/src/factories/set.test.js
@@ -148,4 +148,38 @@ describe('factory.set', () => {
     })
     controller.getSequence('test')()
   })
+  it('should transform a value', () => {
+    const rootModule = Module({
+      state: {
+        foo: 'bar',
+        grabValue: 'bar2',
+      },
+      sequences: {
+        test: [set(state`foo`, state`grabValue`, (value) => value + '1')],
+      },
+    })
+    const controller = Controller(rootModule)
+    controller.getSequence('test')()
+    assert.equal(controller.getState().foo, 'bar21')
+  })
+  it('should transform a value with access to context', () => {
+    const rootModule = Module({
+      state: {
+        foo: 'bar',
+        grabValue: 'bar2',
+      },
+      sequences: {
+        test: [
+          set(
+            state`foo`,
+            state`grabValue`,
+            (value, { props }) => props.prepend + value
+          ),
+        ],
+      },
+    })
+    const controller = Controller(rootModule)
+    controller.getSequence('test')({ prepend: 'foo' })
+    assert.equal(controller.getState().foo, 'foobar2')
+  })
 })


### PR DESCRIPTION
I've been using a custom version of the `set` operator/factory for the last couple of years with support for a transformFn, so it seems that it might be of use to others too.

```js
set(state.some.number, props.number, (value) => value * 2)
```