### PR TITLE
fix(angular): missing ngOnChanges

### DIFF
--- a/packages/node_modules/@cerebral/angular/src/CerebralComponent.ts
+++ b/packages/node_modules/@cerebral/angular/src/CerebralComponent.ts
@@ -20,4 +20,5 @@ export class CerebralComponent {
   ngOnDestroy() {}
   ngOnInit() {}
   ngAfterViewInit() {}
+  ngOnChanges() {}
 }


### PR DESCRIPTION
when feeding child component props and the props changes the ngOnChanges binding code does not run with out this, if child have compute the compute value get stale in the child component