### PR TITLE
Fix export

### DIFF
--- a/packages/node_modules/cerebral/src/index.js
+++ b/packages/node_modules/cerebral/src/index.js
@@ -1,8 +1,9 @@
-import ControllerClass from './Controller'
-import UniversalControllerClass from './UniversalController'
-import ModuleClass from './Module'
-import { DEPRECATE } from './utils'
 import * as tags from './tags'
+
+import ControllerClass from './Controller'
+import { DEPRECATE } from './utils'
+import ModuleClass from './Module'
+import UniversalControllerClass from './UniversalController'
 
 let tagsVar = tags
 
@@ -40,6 +41,8 @@ export {
   SequenceFactory as ChainSequenceFactory,
   SequenceWithPropsFactory as ChainSequenceWithPropsFactory,
 } from 'function-tree/fluent'
+
+export { sequence, parallel } from 'function-tree'
 
 export function Controller(rootModule, options) {
   DEPRECATE('Controller', 'Use App default import instead')

--- a/packages/node_modules/cerebral/src/test/index.js
+++ b/packages/node_modules/cerebral/src/test/index.js
@@ -95,7 +95,14 @@ export function runSequence(sequence, fixtures = {}, options = {}) {
     controller.on('functionEnd', actionEnd)
     controller.on('error', error)
     controller.on('end', sequenceEnd)
-    controller.getSequence(isSequence ? 'sequence' : sequence)(fixtures.props)
+    const seq = controller.getSequence(isSequence ? 'sequence' : sequence)
+    if (typeof seq === 'function') {
+      seq(fixtures.props)
+    } else {
+      throw new Error(
+        `'${isSequence ? 'sequence' : sequence}' is not a function.`
+      )
+    }
   })
 }
 


### PR DESCRIPTION
* Docs and types mention sequence and parallel exports from 'cerebral' but they were not exported.

```js
// Now this works
import { sequence } from 'cerebral'
import * as actions from '../actions'

export const mySequence = sequence([actions.someAction])
```

* Improved test failure on missing sequence