### PR TITLE
fix(cerebral): fix when tag to work with Compute in state tree

### DIFF
--- a/packages/node_modules/cerebral/src/factories/when.js
+++ b/packages/node_modules/cerebral/src/factories/when.js
@@ -1,11 +1,12 @@
 import { Tag } from '../tags'
+import { isComputedValue } from '../utils'
 
 const HELP_URL = 'http://cerebraljs.com/docs/api/factories.html#when'
 
 function whenFactory(...args) {
   const whenFunc = args.length > 1 ? args[args.length - 1] : null
   const valueTemplates = args.length > 1 ? args.slice(0, -1) : args
-  function when({ path, resolve }) {
+  function when({ path, props, resolve }) {
     if (valueTemplates.length > 0 && !(valueTemplates[0] instanceof Tag)) {
       throw new Error(
         `Cerebral factory.when: You have to use the STATE, MODULESTATE or PROPS tag as values, see: ${HELP_URL}`
@@ -16,7 +17,14 @@ function whenFactory(...args) {
         'Cerebral factory.when: true/false paths need to be provided, see: http://cerebraljs.com/docs/api/factories.html#when'
       )
     }
-    const values = valueTemplates.map((value) => resolve.value(value))
+    const values = valueTemplates.map((tag) => {
+      const value = resolve.value(tag)
+      if (isComputedValue(value)) {
+        return value.getValue(props)
+      } else {
+        return value
+      }
+    })
     const isTrue = Boolean(whenFunc ? whenFunc(...values) : values[0])
 
     return isTrue ? path.true() : path.false()

--- a/packages/node_modules/cerebral/src/factories/when.test.js
+++ b/packages/node_modules/cerebral/src/factories/when.test.js
@@ -1,8 +1,9 @@
 /* eslint-env mocha */
-import { Controller, Module } from '../'
+import { Compute, Controller, Module } from '../'
+import { props, state } from '../tags'
+
 import assert from 'assert'
 import { when } from './'
-import { props, state } from '../tags'
 
 describe('factory.when', () => {
   it('should check truthy value of props', () => {
@@ -31,6 +32,30 @@ describe('factory.when', () => {
     const rootModule = Module({
       state: {
         foo: false,
+      },
+      sequences: {
+        test: [
+          when(state`foo`),
+          {
+            true: [],
+            false: [
+              () => {
+                count++
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const controller = Controller(rootModule)
+    controller.getSequence('test')()
+    assert.equal(count, 1)
+  })
+  it('should check truthy value of computed in state', () => {
+    let count = 0
+    const rootModule = Module({
+      state: {
+        foo: Compute(() => false),
       },
       sequences: {
         test: [


### PR DESCRIPTION
If we have a compute on the path, it does not resolve the compute value and always returns `true` (the compute object).

```js
when(state.some.compute) // <=== should get compute value, not return true every time
```