### PR TITLE
fix(test): prevent double throwing of errors in tests with new option

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -9,6 +9,8 @@ const app = App(main, {
   devtools: null,
   // Also logs error handling to console.
   throwToConsole: true,
+  // Prevent rethrow of errors (useful if you already use an on('error') handler)
+  noRethrow: false,
   // A map of state changes to run before instantiation,
   // where the key is the path and value is the state value
   stateChanges: {},

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -1,20 +1,20 @@
-import { DevTools } from './devtools';
+import { DevTools } from './devtools'
 import {
-	IContext as IFunctionTreeContext,
-	FunctionTree,
-	Provider as FunctionTreeProvider,
-	ResolveValue,
-	TFunctionTreeExecutable,
-	Primitive
-} from 'function-tree';
+  IContext as IFunctionTreeContext,
+  FunctionTree,
+  Provider as FunctionTreeProvider,
+  ResolveValue,
+  TFunctionTreeExecutable,
+  Primitive,
+} from 'function-tree'
 
-export { sequence, parallel } from 'function-tree';
-export type Sequence = TFunctionTreeExecutable;
+export { sequence, parallel } from 'function-tree'
+export type Sequence = TFunctionTreeExecutable
 export {
-	IBranchContext,
-	SequenceFactory as ChainSequenceFactory,
-	SequenceWithPropsFactory as ChainSequenceWithPropsFactory
-} from 'function-tree/fluent';
+  IBranchContext,
+  SequenceFactory as ChainSequenceFactory,
+  SequenceWithPropsFactory as ChainSequenceWithPropsFactory,
+} from 'function-tree/fluent'
 
 /*
   Tags
@@ -27,183 +27,207 @@ export const sequences: any
 export const moduleState: any
 export const moduleSequences: any
 
-
 /*
   State
 */
 export interface StateModel {
-	concat(path: any, arr: any[]): void;
-	increment(path: any, amount?: number): void;
-	get<T = any>(any?: any): T | undefined;
-	merge(path: any, {}): void;
-	pop(path: any): void;
-	push(path: any, value: any): void;
-	set(path: any, value: any): void;
-	shift(path: any): void;
-	splice(path: any, ...args: number[]): void;
-	toggle(path: any): void;
-	unset(path: any): void;
-	unshift(path: any, value: any): void;
+  concat(path: any, arr: any[]): void
+  increment(path: any, amount?: number): void
+  get<T = any>(any?: any): T | undefined
+  merge(path: any, {}): void
+  pop(path: any): void
+  push(path: any, value: any): void
+  set(path: any, value: any): void
+  shift(path: any): void
+  splice(path: any, ...args: number[]): void
+  toggle(path: any): void
+  unset(path: any): void
+  unshift(path: any, value: any): void
 }
 
 export interface Store {
-	concat<T>(path: T, arr: T): void;
-	increment(path: number, amount?: number): void;
-	merge<T>(path: T, obj: Partial<T>): void;
-	pop(path: any[]): void;
-	push<T>(path: Array<T>, value: T): void;
-	set<T>(path: T, value: T): void;
-	shift(path: any[]): void;
-	splice(path: any[], ...args: number[]): void;
-	toggle(path: boolean): void;
-	unset(path: any): void;
-	unshift<T>(path: Array<T>, value: T): void;
+  concat<T>(path: T, arr: T): void
+  increment(path: number, amount?: number): void
+  merge<T>(path: T, obj: Partial<T>): void
+  pop(path: any[]): void
+  push<T>(path: Array<T>, value: T): void
+  set<T>(path: T, value: T): void
+  shift(path: any[]): void
+  splice(path: any[], ...args: number[]): void
+  toggle(path: boolean): void
+  unset(path: any): void
+  unshift<T>(path: Array<T>, value: T): void
 }
 
 export interface IContext<TProps> extends IFunctionTreeContext<TProps> {
-	store: Store;
-	get: <T>(tag: T) => T;
+  store: Store
+  get: <T>(tag: T) => T
 }
 
 /*
   Module
 */
 interface ErrorClass {
-	new (...args: any[]): any;
+  new (...args: any[]): any
 }
 
 export type SequencesMap = {
-	[sequenceName: string]: Sequence;
-};
+  [sequenceName: string]: Sequence
+}
 
 export interface ModuleObjectDefinition<State, Sequences, Compute> {
-	state?: State;
-	sequences?: Sequences;
-	computed?: Compute;
-	reactions?: {
-		[submodule: string]: void;
-	};
-	modules?: {
-		[submodule: string]: ModuleClass;
-	};
-	catch?: Function[][];
-	providers?: {
-		[providerName: string]: any;
-	};
+  state?: State
+  sequences?: Sequences
+  computed?: Compute
+  reactions?: {
+    [submodule: string]: void
+  }
+  modules?: {
+    [submodule: string]: ModuleClass
+  }
+  catch?: Function[][]
+  providers?: {
+    [providerName: string]: any
+  }
 }
 
 export interface InstantiatedModuleObjectDefinition {
-	state?: any;
-	sequences?: any;
-	reactions?: {
-		[submodule: string]: void;
-	};
-	modules?: {
-		[submodule: string]: InstantiatedModuleObjectDefinition;
-	};
-	computed?: {
-		[computed: string]: any;
-	};
-	catch?: Function[][];
-	providers?: {
-		[providerName: string]: any;
-	};
+  state?: any
+  sequences?: any
+  reactions?: {
+    [submodule: string]: void
+  }
+  modules?: {
+    [submodule: string]: InstantiatedModuleObjectDefinition
+  }
+  computed?: {
+    [computed: string]: any
+  }
+  catch?: Function[][]
+  providers?: {
+    [providerName: string]: any
+  }
 }
 
 export type ModuleFunction<State = {}, Sequences = {}, Compute = {}> = (
-	module: { name: string; path: string; app: ControllerClass }
-) => ModuleObjectDefinition<State, Sequences, Compute>;
+  module: { name: string; path: string; app: ControllerClass }
+) => ModuleObjectDefinition<State, Sequences, Compute>
 
 export type ModuleDefinition<State = {}, Sequences = {}, Compute = {}> =
-	| ModuleObjectDefinition<State, Sequences, Compute>
-	| ModuleFunction<State, Sequences, Compute>;
+  | ModuleObjectDefinition<State, Sequences, Compute>
+  | ModuleFunction<State, Sequences, Compute>
 
 export class ModuleClass {
-	// not public API
-	create(controller: BaseControllerClass, path: string[]): InstantiatedModuleObjectDefinition;
+  // not public API
+  create(
+    controller: BaseControllerClass,
+    path: string[]
+  ): InstantiatedModuleObjectDefinition
 }
 
 export function Module<State = {}, Sequences = {}, Compute = {}>(
-	moduleDefinition: ModuleDefinition<State, Sequences, Compute>
-): ModuleClass;
+  moduleDefinition: ModuleDefinition<State, Sequences, Compute>
+): ModuleClass
 
 /*
   Connect
 */
-export type RunableSequence<T = any> = (props?: T) => void;
+export type RunableSequence<T = any> = (props?: T) => void
 
 /*
   Controller
 */
 export interface ControllerOptions {
-	devtools?: DevTools;
-	throwToConsole?: boolean;
-	Model?: any;
+  devtools?: DevTools
+  throwToConsole?: boolean
+  noRethrow?: boolean
+  stateChanges?: any
+  returnSequencePromise: boolean
+  Model?: any
 }
 
 export interface BaseControllerClass extends FunctionTree {
-	getModel(): StateModel;
-  getState(path?: string): any;
+  getModel(): StateModel
+  getState(path?: string): any
   get<T>(value: T): T
-	runSequence(name: string, signal: Sequence, payload?: any): void;
-	getSequence<T = any>(path: string): RunableSequence<T>;
-	addModule(path: string, module: ModuleClass): void;
-	removeModule(path: string): void;
+  runSequence(name: string, signal: Sequence, payload?: any): void
+  getSequence<T = any>(path: string): RunableSequence<T>
+  addModule(path: string, module: ModuleClass): void
+  removeModule(path: string): void
 }
 
 export class BaseControllerClass {
-	model: any;
-	module: InstantiatedModuleObjectDefinition;
-	constructor(rootModule: ModuleClass, options: ControllerOptions, functionTreeOptions: any);
+  model: any
+  module: InstantiatedModuleObjectDefinition
+  constructor(
+    rootModule: ModuleClass,
+    options: ControllerOptions,
+    functionTreeOptions: any
+  )
 }
 
 interface ControllerClass extends BaseControllerClass {
-	constructor(config?: ControllerOptions): void;
-	flush(force: boolean): void;
-	updateComponents(changes: any[], force: boolean): void;
+  constructor(config?: ControllerOptions): void
+  flush(force: boolean): void
+  updateComponents(changes: any[], force: boolean): void
 }
 
-export function Controller(rootModule: ModuleClass | ModuleDefinition, config?: ControllerOptions): ControllerClass;
+export function Controller(
+  rootModule: ModuleClass | ModuleDefinition,
+  config?: ControllerOptions
+): ControllerClass
 
-export default function App(rootModule: ModuleClass | ModuleDefinition, config?: ControllerOptions): ControllerClass;
+export default function App(
+  rootModule: ModuleClass | ModuleDefinition,
+  config?: ControllerOptions
+): ControllerClass
 
-type ControllerSequence = string | Primitive | Array<Function | Primitive>;
+type ControllerSequence = string | Primitive | Array<Function | Primitive>
 export interface UniversalControllerClass extends ControllerClass {
-	setState(path: string, value: any): void;
-	getChanges(): { [path: string]: any };
-	getScript(): string;
-	runSequence(sequence: ControllerSequence, payload: any): Promise<any>;
+  setState(path: string, value: any): void
+  getChanges(): { [path: string]: any }
+  getScript(): string
+  runSequence(sequence: ControllerSequence, payload: any): Promise<any>
 }
 
-export function UniversalController(rootModule: ModuleClass, config?: ControllerOptions): UniversalControllerClass;
+export function UniversalController(
+  rootModule: ModuleClass,
+  config?: ControllerOptions
+): UniversalControllerClass
 
-export function UniversalApp(rootModule: ModuleClass, config?: ControllerOptions): UniversalControllerClass;
+export function UniversalApp(
+  rootModule: ModuleClass,
+  config?: ControllerOptions
+): UniversalControllerClass
 
 /*
   Compute
 */
-export type ValueResolver = <T = any>(tag: ResolveValue<T>) => T;
+export type ValueResolver = <T = any>(tag: ResolveValue<T>) => T
 
 export class ComputedInstance<T = any> {
-	constructor(...args: (any | ValueResolver)[]);
-	getValue(getters: any): T;
+  constructor(...args: (any | ValueResolver)[])
+  getValue(getters: any): T
 }
 
-export type ComputedGetter = <T>(arg: T) => T;
+export type ComputedGetter = <T>(arg: T) => T
 
-export function Compute<K>(cb: (get: ComputedGetter) => K): K;
+export function Compute<K>(cb: (get: ComputedGetter) => K): K
 
-export function Reaction<T, K>(dependencies: T, cb: (dependencies: T & { get: ComputedGetter }) => void): void;
+export function Reaction<T, K>(
+  dependencies: T,
+  cb: (dependencies: T & { get: ComputedGetter }) => void
+): void
 
-export function Provider(provider: any, options?: any): FunctionTreeProvider;
+export function Provider(provider: any, options?: any): FunctionTreeProvider
 
 export class View {
-	constructor(config: any);
+  constructor(config: any)
 }
 
 export class CerebralError {
-	constructor(message: string, details?: any);
-	name: string;
-	details: any;
-	toJSON: () => any;
+  constructor(message: string, details?: any)
+  name: string
+  details: any
+  toJSON: () => any
 }

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -83,7 +83,7 @@ export interface ModuleObjectDefinition<State, Sequences, Compute> {
     [submodule: string]: void
   }
   modules?: {
-    [submodule: string]: ModuleClass
+    [submodule: string]: ModuleDefinition | ModuleClass
   }
   catch?: Function[][]
   providers?: {

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -1,19 +1,20 @@
-import FunctionTree from 'function-tree'
-import Module from './Module'
 import {
-  ensurePath,
-  isDeveloping,
-  throwError,
-  isSerializable,
-  forceSerializable,
-  isObject,
-  getProviders,
-  getModule,
   cleanPath,
+  ensurePath,
+  forceSerializable,
+  getModule,
+  getProviders,
+  isDeveloping,
+  isObject,
+  isSerializable,
+  throwError,
 } from './utils'
+
 import DebuggerProvider from './providers/Debugger'
-import ModuleProvider from './providers/Module'
+import FunctionTree from 'function-tree'
 import GetProvider from './providers/Get'
+import Module from './Module'
+import ModuleProvider from './providers/Module'
 
 /*
   The controller is where everything is attached. The devtools
@@ -31,6 +32,7 @@ class BaseController extends FunctionTree {
       throwToConsole = true,
       preventInitialize = false,
       returnSequencePromise = false,
+      noRethrow = false,
     } = options
 
     const getSequence = this.getSequence
@@ -49,6 +51,7 @@ class BaseController extends FunctionTree {
     }
 
     this.throwToConsole = throwToConsole
+    this.noRethrow = noRethrow
     this.returnSequencePromise = returnSequencePromise
 
     this.devtools = devtools
@@ -232,12 +235,16 @@ class BaseController extends FunctionTree {
           }
         }
 
-        if (error.execution.isAsync) {
-          setTimeout(() => {
+        // If we already catch errors in controller.on('error'), we might not
+        // want errors to be thrown again.
+        if (!this.noRethrow) {
+          if (error.execution.isAsync) {
+            setTimeout(() => {
+              throw error
+            })
+          } else {
             throw error
-          })
-        } else {
-          throw error
+          }
         }
       }
     }

--- a/packages/node_modules/cerebral/src/test/index.js
+++ b/packages/node_modules/cerebral/src/test/index.js
@@ -37,7 +37,8 @@ export function runSequence(sequence, fixtures = {}, options = {}) {
       new Controller(
         new Module(
           Object.assign({}, fixtures, isSequence && { sequences: { sequence } })
-        )
+        ),
+        { noRethrow: true }
       )
     const response = { controller }
 
@@ -107,7 +108,10 @@ export function runSequence(sequence, fixtures = {}, options = {}) {
 }
 
 export function CerebralTest(rootModule, options = { throwToConsole: false }) {
-  const controller = new Controller(rootModule, options)
+  const controller = new Controller(
+    rootModule,
+    Object.assign({}, { noRethrow: true }, options)
+  )
   const model = controller.getModel()
   return {
     controller,

--- a/packages/node_modules/cerebral/test/index.d.ts
+++ b/packages/node_modules/cerebral/test/index.d.ts
@@ -14,7 +14,7 @@ export interface SnapshotTest {
   mock: (path: string, value: any) => SnapshotTest
   mockResolvedPromise: (path: string, value: any) => SnapshotTest
   mockRejectedPromise: (path: string, value: any) => SnapshotTest
-  run: (signal: string, payload: {}) => Promise<any>
+  run: (sequence: string, payload: {}) => Promise<any>
 }
 
 export function Snapshot(module: ModuleDefinition): SnapshotTest
@@ -26,16 +26,16 @@ export interface RunActionResult<P, T> {
   output: T
 }
 
-interface RunSignalResult0<P, T0> {
+interface RunSequenceResult0<P, T0> {
   '0': RunActionResult<P, T0>
 }
 
-interface RunSignalResult1<P, T0, T1> {
+interface RunSequenceResult1<P, T0, T1> {
   '0': RunActionResult<P, T0>
   '1': RunActionResult<P, T1>
 }
 
-interface RunSignalResult2<P, T0, T1, T2> {
+interface RunSequenceResult2<P, T0, T1, T2> {
   '0': RunActionResult<P, T0>
   '1': RunActionResult<P, T1>
   '2': RunActionResult<P, T2>
@@ -48,30 +48,30 @@ export function runAction<P = any, T = any>(
 
 export function runCompute<T>(computed: T, fixtures?: any): T
 
-export function runSignal<P, T0>(
-  signal: [Action<P, Promise<T0> | T0>],
+export function runSequence<P, T0>(
+  sequence: [Action<P, Promise<T0> | T0>],
   fixtures?: { props: P & any } & any,
   options?: any
-): Promise<RunSignalResult0<P, T0>>
+): Promise<RunSequenceResult0<P, T0>>
 
-export function runSignal<P, T0, T1>(
-  signal: [Action<P, Promise<T0> | T0>, Action<any, Promise<T1> | T1>],
+export function runSequence<P, T0, T1>(
+  sequence: [Action<P, Promise<T0> | T0>, Action<any, Promise<T1> | T1>],
   fixtures?: { props: P & any } & any,
   options?: any
-): Promise<RunSignalResult1<P, T0, T1>>
+): Promise<RunSequenceResult1<P, T0, T1>>
 
-export function runSignal<P, T0, T1, T2>(
-  signal: [
+export function runSequence<P, T0, T1, T2>(
+  sequence: [
     Action<P, Promise<T0> | T0>,
     Action<any, Promise<T1> | T1>,
     Action<any, Promise<T2> | T2>
   ],
   fixtures?: { props: P & any } & any,
   options?: any
-): Promise<RunSignalResult2<P, T0, T1, T2>>
+): Promise<RunSequenceResult2<P, T0, T1, T2>>
 
-export function runSignal(
-  signal: Sequence,
+export function runSequence(
+  sequence: Sequence,
   fixtures?: any,
   options?: any
 ): Promise<any>


### PR DESCRIPTION
The `noRethrow` controller option prevents throwing errors. This is used if the
user has an `on('error')` handler and does not want double errors.

The `CerebralTest` thing now has this option set `on` by default. Without this option, errors thrown in promises pop up later when a setTimeout is encountered which is very disturbing (looks like a Heisenbug).

Since snapshot testing does not handle errors, we don't need the option to be changed there.

### Types

This PR also contains some fixes to TS types used in testing and some missing options for controller.