### PR TITLE
feat(cerebral): add path getter on 'get' with 'get.path' in views

### DIFF
--- a/packages/node_modules/@cerebral/react/index.d.ts
+++ b/packages/node_modules/@cerebral/react/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 /* eslint-disable-next-line no-unused-vars */
 import { ResolveValue, IResolve } from 'function-tree'
-import { BaseControllerClass } from 'cerebral';
+import { BaseControllerClass, Get } from 'cerebral'
 
 export type IReactComponent<P = any> =
     | React.StatelessComponent<P>
@@ -16,8 +16,6 @@ export const Container: React.ComponentClass<{
   app: BaseControllerClass
   children?: React.ReactNode
 }>
-
-type Get = <T>(typePath: T) => T
 
 type Reaction = <T>(name: string, deps: T, cb: (deps: T & { get: Get }) => void) => void
 

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -59,9 +59,14 @@ export interface Store {
   unshift<T>(path: Array<T>, value: T): void
 }
 
+export interface Get {
+  <T>(tag: T): T
+  path<T>(tag: T): string
+}
+
 export interface IContext<TProps> extends IFunctionTreeContext<TProps> {
   store: Store
-  get: <T>(tag: T) => T
+  get: Get
 }
 
 /*

--- a/packages/node_modules/cerebral/package.json
+++ b/packages/node_modules/cerebral/package.json
@@ -7,7 +7,9 @@
     "jsnext:main": "./es/index.js",
     "typings": "./index.d.ts",
     "author": "Christian Alfoni <christianalfoni@gmail.com>",
-    "contributors": [ "Aleksey Guryanov <gurianov@gmail.com>" ],
+    "contributors": [
+        "Aleksey Guryanov <gurianov@gmail.com>"
+    ],
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -31,6 +33,12 @@
         "prepublish": "npm run build"
     },
     "nyc": {
-        "exclude": [ "node_modules", "lib", "__test__", "**/*.test.js", "**/testHelper.js" ]
+        "exclude": [
+            "node_modules",
+            "lib",
+            "__test__",
+            "**/*.test.js",
+            "**/testHelper.js"
+        ]
     }
 }

--- a/packages/node_modules/cerebral/src/View.js
+++ b/packages/node_modules/cerebral/src/View.js
@@ -1,13 +1,14 @@
-import { Tag } from 'function-tree'
 import {
   getChangedProps,
-  throwError,
   getStateTreeProp,
-  noop,
   isComputedValue,
+  noop,
+  throwError,
 } from './utils'
-import Watch from './Watch'
+
 import Reaction from './Reaction'
+import { Tag } from 'function-tree'
+import Watch from './Watch'
 
 class View extends Watch {
   constructor({
@@ -184,31 +185,38 @@ class View extends Watch {
     this.dynamicDependencies = []
     this.dynamicComputed.forEach((unsubscribe) => unsubscribe())
     this.dynamicComputed = []
-    return (tag) => {
-      const value = tag.getValue(getters)
+    return Object.assign(
+      (tag) => {
+        const value = tag.getValue(getters)
 
-      if (isComputedValue(value)) {
-        const computedInstance = tag.getValue(getters)
-        const attachedComputed = computedInstance.propsTags.length
-          ? computedInstance.clone()
-          : computedInstance
-        const unsubscribe = attachedComputed.subscribe(
-          this,
-          this.updateComponent
-        )
-        this.dynamicComputed.push(
-          computedInstance.propsTags.length
-            ? () => attachedComputed.destroy()
-            : unsubscribe
-        )
+        if (isComputedValue(value)) {
+          const computedInstance = tag.getValue(getters)
+          const attachedComputed = computedInstance.propsTags.length
+            ? computedInstance.clone()
+            : computedInstance
+          const unsubscribe = attachedComputed.subscribe(
+            this,
+            this.updateComponent
+          )
+          this.dynamicComputed.push(
+            computedInstance.propsTags.length
+              ? () => attachedComputed.destroy()
+              : unsubscribe
+          )
 
-        return attachedComputed.getValue(props)
+          return attachedComputed.getValue(props)
+        }
+
+        this.dynamicDependencies.push(tag)
+
+        return value
+      },
+      {
+        path: (tag) => {
+          return tag.getPath(getters)
+        },
       }
-
-      this.dynamicDependencies.push(tag)
-
-      return value
-    }
+    )
   }
   /*
     Creates a reaction

--- a/packages/node_modules/cerebral/src/View.test.js
+++ b/packages/node_modules/cerebral/src/View.test.js
@@ -1,11 +1,12 @@
+import { Controller, Module } from './'
+import { moduleState, props, sequences, state } from './tags'
+
 /* eslint-env mocha */
 /* eslint-disable no-global-assign */
 /* eslint-disable no-new */
 import View from './View'
-import { Controller, Module } from './'
-import { state, props, moduleState, sequences } from './tags'
-import { set } from './factories'
 import assert from 'assert'
+import { set } from './factories'
 
 describe('View', () => {
   it('should throw an error if dependency is a function', () => {
@@ -705,6 +706,22 @@ describe('View', () => {
     view.update()
     controller.getSequence('methodCalled')()
     assert.equal(renderCount, 1)
+  })
+  it('should register dependencies with "get.path"', () => {
+    const paths = []
+
+    const view = new View({
+      controller: Controller({ state: { selected: 'bong' } }),
+      props: { baz: 'man' },
+    })
+    view.mount()
+    view.render({ baz: 'man' }, ({ get }) => {
+      paths.push(get.path(state`foo`))
+      paths.push(get.path(props`poo.par`))
+      paths.push(get.path(state`foo.bar.${props`baz`}`))
+      paths.push(get.path(state`foo.${state`selected`}`))
+    })
+    assert.deepEqual(paths, ['foo', 'poo.par', 'foo.bar.man', 'foo.bong'])
   })
   it('should register computed dependencies with "get"', () => {
     let renderCount = 0


### PR DESCRIPTION
Inside views we can now do:

```js
connect(
  {},
  function SomeView({ get, tagProp }) {
    const path = get.path(tagProp)
    const value = get(tagProp)
  }
)
```

Real practical example. In this example, the `input` name is extracted with `get.path` on the state
prop (which also serves to get value).

```html
  <Field state={state.login.username} icon />
```