### PR TITLE
No public api should depend on Module

### DIFF
--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -147,7 +147,7 @@ export interface ControllerOptions {
   throwToConsole?: boolean
   noRethrow?: boolean
   stateChanges?: any
-  returnSequencePromise: boolean
+  returnSequencePromise?: boolean
   Model?: any
 }
 

--- a/packages/node_modules/cerebral/index.d.ts
+++ b/packages/node_modules/cerebral/index.d.ts
@@ -157,7 +157,7 @@ export interface BaseControllerClass extends FunctionTree {
   get<T>(value: T): T
   runSequence(name: string, signal: Sequence, payload?: any): void
   getSequence<T = any>(path: string): RunableSequence<T>
-  addModule(path: string, module: ModuleClass): void
+  addModule(path: string, module: ModuleClass | ModuleDefinition): void
   removeModule(path: string): void
 }
 
@@ -165,7 +165,7 @@ export class BaseControllerClass {
   model: any
   module: InstantiatedModuleObjectDefinition
   constructor(
-    rootModule: ModuleClass,
+    rootModule: ModuleClass | ModuleDefinition,
     options: ControllerOptions,
     functionTreeOptions: any
   )
@@ -196,12 +196,12 @@ export interface UniversalControllerClass extends ControllerClass {
 }
 
 export function UniversalController(
-  rootModule: ModuleClass,
+  rootModule: ModuleClass | ModuleDefinition,
   config?: ControllerOptions
 ): UniversalControllerClass
 
 export function UniversalApp(
-  rootModule: ModuleClass,
+  rootModule: ModuleClass | ModuleDefinition,
   config?: ControllerOptions
 ): UniversalControllerClass
 

--- a/packages/node_modules/cerebral/src/BaseController.js
+++ b/packages/node_modules/cerebral/src/BaseController.js
@@ -297,7 +297,10 @@ class BaseController extends FunctionTree {
     const pathArray = ensurePath(path)
     const moduleKey = pathArray.pop()
     const parentModule = getModule(pathArray, this.module)
-    const newModule = module.create(this, ensurePath(path))
+    const newModule =
+      module instanceof Module
+        ? module.create(this, ensurePath(path))
+        : new Module(module).create(this, ensurePath(path))
     parentModule.modules[moduleKey] = newModule
 
     if (newModule.providers) {


### PR DESCRIPTION
Fixed `addModule` to receive both ModuleClass and ModuleDefinition so that users can adapt to deprecation warning.
Fixed other types.