### PR TITLE
fix(cerebral): add state and computed tags as dependencies to computeds

### DIFF
--- a/packages/node_modules/cerebral/src/Controller.js
+++ b/packages/node_modules/cerebral/src/Controller.js
@@ -154,7 +154,8 @@ class Controller extends BaseController {
               const value = tag.getValue(getters)
 
               if (isComputedValue(value)) {
-                return updatedCurrentDepsMap
+                const tags = value.stateTags.concat(value.computedTags)
+                return this.createDependencyMap(tags, props, modulePath)
               }
 
               const path = tag.getPath(getters)


### PR DESCRIPTION
Looked into my problem - looks like computed values aren't being added to the dependency map inside a computed function. Not entirely sure if this code is the way things should be done, but my app still works - and it fixes my problem. :)

Resolves https://github.com/cerebral/cerebral/issues/1382