### PR TITLE
refactor(view): don’t recreate getters

### DIFF
--- a/packages/node_modules/cerebral/src/View.js
+++ b/packages/node_modules/cerebral/src/View.js
@@ -270,7 +270,6 @@ class View extends Watch {
     }
 
     if (this.mergeProps) {
-      const getters = this.controller.createContext(props)
       return this.mergeProps(dependenciesProps, props, (tag) => {
         if (!(tag instanceof Tag)) {
           throwError('You are not passing a tag to the mergeProp get function')


### PR DESCRIPTION
@christianalfoni while browsing the code for `mergeProps` i noticed that getters are probably unnecessarily recreated (if i'm wrong please discard this PR).

Another thing that made me wonder: if i define `mergeProps` fn, then `getProps` return early without attaching `get` and `reaction` to props. Wouldn't it be more consistent if these were always available?