### PR TITLE
Fix broken link in tutorial.md

### DIFF
--- a/docs/introduction/tutorial.md
+++ b/docs/introduction/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-If you are interested in the concepts of Cerebral you can read about [the architecture](/docs/advanced/the_architecture).
+If you are interested in the concepts of Cerebral you can read [an an introduction to the architecture(/docs/introduction/the_architecture) or [dig into the details](/docs/advanced/index)
 
 As you read through the introductory chapters it can be a good idea to follow along in your local environment. Follow the [get started](/docs/introduction) guide and download the debugger as well. When you see section like this:
 


### PR DESCRIPTION
The link currently goes to `https://cerebraljs.com/docs/advanced/the_architecture` which is a 404.

I've changed it to direct to `docs/introduction/the_architecture` and `/docs/advanced/index`