### PR TITLE
fix(cerebral): make undefined serializable

### DIFF
--- a/packages/node_modules/cerebral/src/utils.js
+++ b/packages/node_modules/cerebral/src/utils.js
@@ -35,6 +35,9 @@ export function isComplexObject(obj) {
 }
 
 export function isSerializable(value, additionalTypes = []) {
+	if (value == null) {
+		return true
+	}
   const validType = additionalTypes.reduce((currentValid, type) => {
     if (currentValid || value instanceof type) {
       return true
@@ -43,9 +46,7 @@ export function isSerializable(value, additionalTypes = []) {
     return currentValid
   }, false)
 
-  if (
-    value !== undefined &&
-    (validType ||
+  if (validType ||
       (isObject(value) &&
         Object.prototype.toString.call(value) === '[object Object]' &&
         (value.constructor === Object ||
@@ -54,7 +55,7 @@ export function isSerializable(value, additionalTypes = []) {
       typeof value === 'string' ||
       typeof value === 'boolean' ||
       value === null ||
-      Array.isArray(value))
+      Array.isArray(value)
   ) {
     return true
   }

--- a/packages/node_modules/cerebral/src/utils.test.js
+++ b/packages/node_modules/cerebral/src/utils.test.js
@@ -4,6 +4,12 @@ import assert from 'assert'
 
 describe('utils', () => {
   describe('isSerializable', () => {
+		it('should return true on null', () => {
+      assert.ok(utils.isSerializable(null))
+		})
+		it('should return true on undefined', () => {
+      assert.ok(utils.isSerializable(undefined))
+    })
     it('should return true on strings', () => {
       assert.ok(utils.isSerializable('foo'))
     })


### PR DESCRIPTION
If dev tools are enabled, the `verifyValue` function in Model.js will check if the given value is serializable. Trying to set a value to `undefined` in a sequence, results in an error ("You are passing a non serializable value into the state tree on path...")

Setting a value to `null` seems to be OK for cerebral, but `undefined` is not. A value from props (e.g. accessing an undefined property in a map) is likely to be `undefined` so i guess that behavior is not intended.

check the browser console after clicking on toggle, in this example: https://codesandbox.io/s/null-vs-undefined-tbxjd