### PR TITLE
docs(website): Fix markdown link to introduction

### DIFF
--- a/docs/introduction/tutorial.md
+++ b/docs/introduction/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-If you are interested in the concepts of Cerebral you can read [an an introduction to the architecture(/docs/introduction/the_architecture) or [dig into the details](/docs/advanced/index)
+If you are interested in the concepts of Cerebral you can read [an introduction to the architecture](/docs/introduction/the_architecture) or [dig into the details](/docs/advanced/index)
 
 As you read through the introductory chapters it can be a good idea to follow along in your local environment. Follow the [get started](/docs/introduction) guide and download the debugger as well. When you see section like this:
 


### PR DESCRIPTION
There was a `]` missing, and I removed an `an` too many.