### PR TITLE
Update README.md

### DIFF
--- a/packages/node_modules/@cerebral/vue/README.md
+++ b/packages/node_modules/@cerebral/vue/README.md
@@ -28,6 +28,12 @@ new Vue({
 }).$mount("#app");
 ```
 
+For `import Vue from 'vue'` you have to add a runtime. E.g for project created with `vue-cli`
+```
+// vue.config.js file:
+module.exports = { runtimeCompiler: true }
+```
+
 ## connect
 
 _MyComponent.js_


### PR DESCRIPTION
Add info about a runtime required for Vue imported directly from 'vue' package.