### PR TITLE
fix(cerebral): prevent hard crash when missing dep

### DIFF
--- a/packages/node_modules/cerebral/src/DependencyStore.js
+++ b/packages/node_modules/cerebral/src/DependencyStore.js
@@ -40,6 +40,9 @@ class DependencyStore {
       const path = depsMapKey.split('.')
       path.reduce((currentMapLevel, key, index) => {
         if (index === path.length - 1) {
+          if (!currentMapLevel[key] || !currentMapLevel[key].entities) {
+            return currentMapLevel
+          }
           currentMapLevel[key].entities.splice(
             currentMapLevel[key].entities.indexOf(entity),
             1

--- a/packages/node_modules/cerebral/src/DependencyStore.test.js
+++ b/packages/node_modules/cerebral/src/DependencyStore.test.js
@@ -29,6 +29,13 @@ describe('DependencyStore', () => {
     depsStore.removeEntity(component, { foo: true })
     assert.deepStrictEqual(depsStore.map, { foo: {} })
   })
+  it('should not throw an error if a component is not found', () => {
+    const depsStore = new DependencyStore()
+    const component = {}
+    depsStore.addEntity(component, {})
+    const removeFn = () => depsStore.removeEntity(component, { foo: true })
+    assert.doesNotThrow(removeFn)
+  })
   it('should update components', () => {
     const depsStore = new DependencyStore()
     const component = {}


### PR DESCRIPTION
I've had an issue in a particular version of nwjs (v0.44.1) which comes bundled with chromium 80.0.3987.87.
Some stars seem to align in this version only, and it's seemingly possible for dependencies to have the children it expects.

See below for the output: It seems to only have "**".

![image](https://user-images.githubusercontent.com/1562807/97510798-a44c6600-19d9-11eb-8293-52da13846b4f.png)

At any rate, this MR adds a guard to prevent a hard crash when this occurs. In normal circumstances this will never be needed, but error guards are never a bad thing.
