### PR TITLE
fix(cerebral): prevent checkForComputed from throwing when the path does not exist in state

### DIFF
--- a/packages/node_modules/cerebral/src/Model.js
+++ b/packages/node_modules/cerebral/src/Model.js
@@ -65,7 +65,7 @@ class Model extends BaseModel {
 
   checkForComputed(path) {
     const valueToReplace = path.reduce(
-      (currentState, key) => currentState[key],
+      (currentState, key) => key in currentState ? currentState[key]: {},
       this.state
     )
 

--- a/packages/node_modules/cerebral/src/Model.test.js
+++ b/packages/node_modules/cerebral/src/Model.test.js
@@ -417,5 +417,17 @@ describe('Model', () => {
         model.set(['foo'], new Date())
       })
     })
+    it('should NOT throw error if setting a value to a path not in state while devtools are open', () => {
+      const rootModule = {
+        state: {},
+      }
+      const model = new BaseController(rootModule, {
+        Model,
+        devtools: { init() {} },
+      }).model
+      assert.doesNotThrow(() => {
+        model.set(['bar', 'baz'], 1)
+      })
+    })
   })
 })


### PR DESCRIPTION
When the devtools are open, checkForComputed will try to access the current data that will be overwritten. When this data does not exist, it throws an error trying to access something on undefined

ISSUES CLOSED: #1412